### PR TITLE
Skip EC testcase in case a mechanism is not supported

### DIFF
--- a/testcases/crypto/ec_func.c
+++ b/testcases/crypto/ec_func.c
@@ -182,6 +182,7 @@ run_GenerateSignVerifyECC(CK_SESSION_HANDLE session, CK_MECHANISM_TYPE mechType,
 			/* no support for EC key gen? skip */
 			testcase_skip("Slot %u doesn't support %s",
 				(unsigned int) SLOT_ID, p11_get_ckm(mechType));
+			rc = CKR_OK;
 			goto testcase_cleanup;
 		}
 		else {
@@ -358,6 +359,7 @@ run_GenerateECCKeyPairSignVerify()
 			/* no support for EC key gen? skip */
 			testcase_skip("Slot %u doesn't support CKM_EC_KEY_PAIR_GEN",
 				(unsigned int) SLOT_ID);
+			rc = CKR_OK;
 			goto testcase_cleanup;
 		}
 		else {

--- a/usr/lib/pkcs11/common/mech_rsa.c
+++ b/usr/lib/pkcs11/common/mech_rsa.c
@@ -2476,9 +2476,11 @@ CK_RV emsa_pss_encode(CK_RSA_PKCS_PSS_PARAMS *pssParms, CK_BYTE *in_data,
 
 	/* pkcs1v2.2, Step 4: Generate salt */
 	salt = buf + (8 + in_data_len);
-	rc = rng_generate(salt, pssParms->sLen);
-	if (rc != CKR_OK)
-		goto done;
+	if (pssParms->sLen > 0) {
+		rc = rng_generate(salt, pssParms->sLen);
+		if (rc != CKR_OK)
+			goto done;
+	}
 
 	/* pkcs1v2.2, Step 5: set M' */
 	memcpy(buf + 8, in_data, in_data_len);


### PR DESCRIPTION
When running with a CEXxP card that does not support a newer
mechanism, such as ECDSA with SHA256, the testcase is now
skipped and does no longer fail.

The second patch is for a problem with RSA PKCS PSS testcase failing with the ICA token, since the current version of libica does not allow to request zero bytes of random when libica is built with FIPS support. 

Signed-off-by: Ingo Franzki <ifranzki@linux.vnet.ibm.com>