### PR TITLE
Remove dependence of pk_config_data in ock_tests.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ script:
     - ./configure --enable-testcases --enable-debug && make
     - sudo make install
     - sudo ldconfig
-    - sudo touch /usr/local/var/lib/opencryptoki/pk_config_data
     - sudo pkcsslotd
     - sudo pkcsconf -t
     - cd testcases

--- a/doc/README-IBM_CCA_users
+++ b/doc/README-IBM_CCA_users
@@ -101,10 +101,6 @@ STEP 2:
    libxcryp.so		xcryptolinz
    libcrypto.so		openssl
 
-   When a token is detected by the startup scripts run by /etc/init.d/pkcsslotd, an
-   entry is made in the /var/lib/opencryptoki/pk_config_data file. This file will
-   contain 1 line per token.
-
 STEP 3:
 
   Initialize the CCA token.

--- a/testcases/Makefile.am
+++ b/testcases/Makefile.am
@@ -7,7 +7,7 @@ EXTRA_DIST = ock_tests.sh.in init_token.sh.in
 CLEANFILES = ock_tests.sh init_token.sh
 
 ock_tests.sh: ock_tests.sh.in
-	@SED@	-e s!\@localstatedir\@!"@localstatedir@"!g	\
+	@SED@	-e s!\@sysconfdir\@!"@sysconfdir@"!g	\
 		-e s!\@sbindir\@!"@sbindir@"!g			\
 		-e s!\@libdir\@!"@libdir@"!g < $< > $@-t
 	@CHMOD@ a+x $@-t

--- a/testcases/ock_tests.sh.in
+++ b/testcases/ock_tests.sh.in
@@ -31,7 +31,7 @@ LOGGING=0
 TESTDIR=`dirname $0`
 LOGFILE="$TESTDIR/ock-tests.log"
 ERR_SUMMARY="$TESTDIR/ock-tests.err"
-PKCONF="@localstatedir@/lib/opencryptoki/pk_config_data"
+PKCONF="@sysconfdir@/opencryptoki/opencryptoki.conf"
 PKCSCONFBIN="@sbindir@/pkcsconf"
 TESTCONF="$TESTDIR/ock-tests.config"
 TOKTYPE=""
@@ -258,7 +258,7 @@ main_script()
 
     # where to run
     if [ -z $SLOT ]; then
-        NUMSLOT=`wc -l $PKCONF | cut -d " " -f 1`
+        NUMSLOT=$(grep '^slot' $PKCONF | wc -l)
         for ((i=0; i<$NUMSLOT; i++)); do
             SLOT="$SLOT $i"
         done


### PR DESCRIPTION
Since opencryptoki-3.0 the file pk_config_data was replaced by the
opencryptoki.conf file. The ock_tests.sh script was still depending
on the pk_config_data file to read slots number to execute.

This patch fixes GitHub issue #12

Signed-off-by: Paulo Vital <pvital@linux.vnet.ibm.com>