### PR TITLE
Remove duplicated fopen in save_token_data()

### DIFF
--- a/usr/lib/pkcs11/common/loadsave.c
+++ b/usr/lib/pkcs11/common/loadsave.c
@@ -474,14 +474,11 @@ CK_RV save_token_data(CK_SLOT_ID slot_id)
 	}
 
 	sprintf(fname, "%s/%s", get_pk_dir(pk_dir_buf), PK_LITE_NV);
-	fp = fopen((char *)fname, "r+");
+	fp = fopen((char *)fname, "w");
 	if (!fp) {
-		fp = fopen((char *)fname, "w");
-		if (!fp) {
-			TRACE_ERROR("fopen(%s): %s\n", fname, strerror(errno));
-			rc = CKR_FUNCTION_FAILED;
-			goto done;
-		}
+		TRACE_ERROR("fopen(%s): %s\n", fname, strerror(errno));
+		rc = CKR_FUNCTION_FAILED;
+		goto done;
 	}
 	set_perm(fileno(fp));
 


### PR DESCRIPTION
save_token_data() was trying to fopen twice: once with "r+" and the second
with "w". Since the function only writes in a specific file, removed the
"r+" try and return an error code if not possible to open the file.

This patch fixes the GitHub issue #5

Signed-off-by: Paulo Vital <pvital@linux.vnet.ibm.com>