### PR TITLE
Fix segfault on ec_test

### DIFF
--- a/usr/lib/pkcs11/icsf_stdll/icsf.c
+++ b/usr/lib/pkcs11/icsf_stdll/icsf.c
@@ -3009,6 +3009,8 @@ int icsf_hash_signverify(LDAP *ld, int *reason, struct icsf_object_record *key,
 	 */
 	if (ICSF_RC_IS_ERROR(rc) && (reason_code != 3003))
 		goto done;
+	else if ((reason_code == 8000) || (reason_code == 11000))
+		goto done;
 
 	/* Parse the response. */
 	if (ber_scanf(result, "{ooi}", &bvChain, &bvSig, &length) < 0) {

--- a/usr/lib/pkcs11/icsf_stdll/icsf_specific.c
+++ b/usr/lib/pkcs11/icsf_stdll/icsf_specific.c
@@ -3503,6 +3503,11 @@ CK_RV icsftok_sign(SESSION *session, CK_BYTE *in_data, CK_ULONG in_data_len,
 	case CKM_SHA512_RSA_PKCS:
 	case CKM_DSA_SHA1:
 	case CKM_ECDSA_SHA1:
+		if (length_only) {
+			rc = CKR_OK;
+			goto done;
+		}
+
 		rc = icsf_hash_signverify(session_state->ld, &reason,
 				&mapping->icsf_object, &ctx->mech,
 				"ONLY", in_data, in_data_len, signature,
@@ -3775,6 +3780,10 @@ CK_RV icsftok_sign_final(SESSION *session, CK_BYTE *signature,
 	case CKM_SHA512_RSA_PKCS:
 	case CKM_DSA_SHA1:
 	case CKM_ECDSA_SHA1:
+		if (length_only) {
+			rc = CKR_OK;
+			goto done;
+		}
 
 		/* see if any data left in the cache */
 		if (multi_part_ctx && multi_part_ctx->used_data_len) {


### PR DESCRIPTION
While performing ec tests on ICSF token ($ ./testcases/crypto/ec_tests
-slot 5) we're having a segmentation fault. This is related to the case
when length_only attribute is set, so the signature shouldn't be done
and just the signature length should be returned, or for the case when
the signature is invalid, CKR_SIGNATURE_INVALID should be returned.

Signed-off-by: Eduardo Barretto <ebarretto@linux.vnet.ibm.com>

Fix for issue #18 