### PR TITLE
Add support to systemd-tmpfiles config file.

### DIFF
--- a/misc/Makefile.am
+++ b/misc/Makefile.am
@@ -1,15 +1,51 @@
-EXTRA_DIST = pkcsslotd.in pkcsslotd.service.in
+TOKENS = swtok
+
+if ENABLE_ICATOK
+TOKENS += lite
+endif
+
+if ENABLE_EP11TOK
+TOKENS += ep11tok
+endif
+
+if ENABLE_TPMTOK
+TOKENS += tpm
+endif
+
+if ENABLE_CCATOK
+TOKENS += ccatok
+endif
+
+if ENABLE_ICSFTOK
+TOKENS += icsf
+endif
+
+EXTRA_DIST = pkcsslotd.in pkcsslotd.service.in tmpfiles.conf.in
 
 if ENABLE_DAEMON
 if ENABLE_SYSTEMD
 servicedir = $(unitdir)
-service_DATA = pkcsslotd.service
+service_DATA = pkcsslotd.service tmpfiles.conf
 
-CLEANFILES = pkcsslotd.service
+CLEANFILES = pkcsslotd.service tmpfiles.conf
 
 pkcsslotd.service: pkcsslotd.service.in
 	@SED@ -e s!\@sbindir\@!"@sbindir@"!g < $< > $@-t
 	mv $@-t $@
+
+tmpfiles.conf: tmpfiles.conf.in
+	@SED@ -e s!\@lockdir\@!$(lockdir)!g < $< > $@-t
+	$(foreach TOK,$(TOKENS),\
+		echo "D $(lockdir)/$(TOK) 0770 root pkcs11 -" >> $@-t;)
+	mv $@-t $@
+
+install-data-hook:
+	cp tmpfiles.conf $(DESTDIR)/usr/lib/tmpfiles.d/opencryptoki.conf
+	$(CHMOD) 0644 $(DESTDIR)/usr/lib/tmpfiles.d/opencryptoki.conf
+
+uninstall-hook:
+	if test -e $(DESTDIR)/usr/lib/tmpfiles.d/opencryptoki.conf; then \
+		rm -f $(DESTDIR)/usr/lib/tmpfiles.d/opencryptoki.conf; fi
 else
 initddir = $(sysconfdir)/rc.d/init.d
 initd_SCRIPTS = pkcsslotd

--- a/misc/tmpfiles.conf.in
+++ b/misc/tmpfiles.conf.in
@@ -1,0 +1,2 @@
+# path          mode    uid     gid     age
+D @lockdir@     0770    root    pkcs11  -


### PR DESCRIPTION
Add support to create configuration file for creation, deletion and cleaning
of volatile and temporary files in systemd.

The tmpfiles.d/opencryptoki.conf file will be created automatically during
compilation time based on enabled tokens in configure. The output will be
installed in default systemd-tmpfiles path structure, described here [1].

[1] https://www.freedesktop.org/software/systemd/man/tmpfiles.d.html

This patch fixes #25

Signed-off-by: Paulo Vital <pvital@linux.vnet.ibm.com>