### PR TITLE
Fix ock_test to not check if root is in group pkcs11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ before_install:
     - sudo apt-get install -y expect
 before_script:
     - sudo groupadd pkcs11
-    - sudo usermod -G pkcs11 root
     - ./bootstrap.sh
 script:
     - ./configure --enable-testcases --enable-debug && make

--- a/testcases/ock_tests.sh.in
+++ b/testcases/ock_tests.sh.in
@@ -194,16 +194,19 @@ check_env()
         exit 1
     fi
 
-    ## Check if the pkcs11 group 'exists'
-    P11GROUP=`getent group pkcs11 | cut -d ":" -f 3`
-    if [ -z $P11GROUP ]; then
-        echo "FATAL: Can't find pkcs11 group"
-        exit 1
-    fi
-    ## Check if we're part of it
-    if ! id -G | grep $P11GROUP; then
-        echo "FATAL: Must be part of the pkcs11 group"
-        exit 1
+    # if user is not root
+    if [ $EUID -ne 0 ]; then
+        ## Check if the pkcs11 group 'exists'
+        P11GROUP=`getent group pkcs11 | cut -d ":" -f 3`
+        if [ -z $P11GROUP ]; then
+            echo "FATAL: Can't find pkcs11 group"
+            exit 1
+        fi
+        ## Check if we're part of it
+        if ! id -G | grep $P11GROUP; then
+            echo "FATAL: Must be part of the pkcs11 group"
+            exit 1
+        fi
     fi
 
     ## Make sure we have the slot daemon running


### PR DESCRIPTION
Root user should be able to build and run opencryptoki without being part of
group pkcs11. Only non-root users should be in the pkcs11 group.

Signed-off-by: Eduardo Barretto <ebarretto@linux.vnet.ibm.com>