### PR TITLE
Rework some trace strings

### DIFF
--- a/usr/lib/pkcs11/common/mech_dsa.c
+++ b/usr/lib/pkcs11/common/mech_dsa.c
@@ -180,7 +180,7 @@ ckm_dsa_key_pair_gen( TEMPLATE  * publ_tmpl,
 
    rc = token_specific.t_dsa_generate_keypair(publ_tmpl,priv_tmpl);
    if (rc != CKR_OK)
-      TRACE_DEVEL("Tpken specific dsa keypair generation failed.\n");
+      TRACE_DEVEL("Token specific dsa keypair generation failed.\n");
    return rc;
 }
 

--- a/usr/lib/pkcs11/common/obj_mgr.c
+++ b/usr/lib/pkcs11/common/obj_mgr.c
@@ -55,7 +55,7 @@ object_mgr_add( SESSION          * sess,
    if (token_specific.t_object_add != NULL) {
       rc = token_specific.t_object_add(o);
       if (rc != CKR_OK) {
-	 TRACE_DEVEL("Token Specific object add failed.\n");
+	 TRACE_DEVEL("Token specific object add failed.\n");
 	 goto done;
       }
    }

--- a/usr/lib/pkcs11/ep11_stdll/ep11_specific.c
+++ b/usr/lib/pkcs11/ep11_stdll/ep11_specific.c
@@ -796,7 +796,7 @@ static const char* ep11_get_ckm(CK_ULONG mechanism)
 	case CKM_IBM_ECDH1_DERIVE_RAW: return "CKM_IBM_ECDH1_DERIVE_RAW";
 	case CKM_IBM_RETAINKEY: return "CKM_IBM_RETAINKEY";
 	default:
-		TRACE_WARNING("%s unknown mechanism %lx\n", __func__, mechanism);
+		TRACE_WARNING("%s unknown mechanism 0x%lx\n", __func__, mechanism);
 		return "UNKNOWN";
 	}
 }

--- a/usr/lib/pkcs11/ep11_stdll/new_host.c
+++ b/usr/lib/pkcs11/ep11_stdll/new_host.c
@@ -1854,7 +1854,7 @@ CK_RV SC_DigestInit(ST_SESSION_HANDLE *sSession, CK_MECHANISM_PTR pMechanism)
 		TRACE_DEVEL("digest_mgr_init() failed.\n");
 
 done:
-	TRACE_INFO("C_DigestInit: rc = 0x%08lx, sess = %ld, mech = %lu\n",
+	TRACE_INFO("C_DigestInit: rc = 0x%08lx, sess = %ld, mech = 0x%lx\n",
 		   rc, (sess == NULL)?-1:(CK_LONG)sess->handle,
 		   pMechanism->mechanism);
 
@@ -1953,7 +1953,7 @@ CK_RV SC_DigestUpdate(ST_SESSION_HANDLE *sSession, CK_BYTE_PTR pPart,
 			TRACE_DEVEL("digest_mgr_digest_update() failed.\n");
 	}
 done:
-	TRACE_INFO("C_DigestUpdate: rc = %08lx, sess = %ld, datalen = %lu\n",
+	TRACE_INFO("C_DigestUpdate: rc = 0x%08lx, sess = %ld, datalen = %lu\n",
 		   rc, (sess == NULL)?-1:(CK_LONG)sess->handle, ulPartLen);
 
 	return rc;
@@ -1989,7 +1989,7 @@ CK_RV SC_DigestKey(ST_SESSION_HANDLE *sSession, CK_OBJECT_HANDLE hKey)
 		TRACE_DEVEL("digest_mgr_digest_key() failed.\n");
 
 done:
-	TRACE_INFO("C_DigestKey: rc = %08lx, sess = %ld, key = %lu\n",
+	TRACE_INFO("C_DigestKey: rc = 0x%08lx, sess = %ld, key = %lu\n",
 		   rc, (sess == NULL)?-1:(CK_LONG)sess->handle, hKey);
 
 	return rc;
@@ -2037,7 +2037,7 @@ CK_RV SC_DigestFinal(ST_SESSION_HANDLE *sSession, CK_BYTE_PTR pDigest,
 		TRACE_ERROR("digest_mgr_digest_final() failed.\n");
 
 done:
-	TRACE_INFO("C_DigestFinal: rc = %08lx, sess = %ld\n",
+	TRACE_INFO("C_DigestFinal: rc = 0x%08lx, sess = %ld\n",
 		   rc, (sess == NULL)?-1:(CK_LONG)sess->handle);
 
 	return rc;
@@ -2090,7 +2090,7 @@ CK_RV SC_SignInit(ST_SESSION_HANDLE *sSession, CK_MECHANISM_PTR pMechanism,
 		TRACE_DEVEL("*_sign_init() failed.\n");
 
 done:
-	TRACE_INFO("C_SignInit: rc = %08lx, sess = %ld, mech = %lx\n",
+	TRACE_INFO("C_SignInit: rc = 0x%08lx, sess = %ld, mech = 0x%lx\n",
 		   rc, (sess == NULL)?-1:(CK_LONG)sess->handle,
 		   pMechanism->mechanism);
 
@@ -2143,7 +2143,7 @@ done:
 	if (rc != CKR_BUFFER_TOO_SMALL && (rc != CKR_OK || length_only != TRUE))
 		sign_mgr_cleanup(&sess->sign_ctx);
 
-	TRACE_INFO("C_Sign: rc = %08lx, sess = %ld, datalen = %lu\n",
+	TRACE_INFO("C_Sign: rc = 0x%08lx, sess = %ld, datalen = %lu\n",
 		   rc, (sess == NULL)?-1:(CK_LONG)sess->handle, ulDataLen);
 
 	return rc;
@@ -2189,7 +2189,7 @@ done:
 	if (rc != CKR_OK)
 		sign_mgr_cleanup(&sess->sign_ctx);
 
-	TRACE_INFO("C_SignUpdate: rc = %08lx, sess = %ld, datalen = %lu\n",
+	TRACE_INFO("C_SignUpdate: rc = 0x%08lx, sess = %ld, datalen = %lu\n",
 		   rc, (sess == NULL)?-1:(CK_LONG)sess->handle, ulPartLen);
 
 	return rc;
@@ -2239,7 +2239,7 @@ done:
 	if (rc != CKR_BUFFER_TOO_SMALL && (rc != CKR_OK || length_only != TRUE))
 		sign_mgr_cleanup(&sess->sign_ctx);
 
-	TRACE_INFO("C_SignFinal: rc = %08lx, sess = %ld\n",
+	TRACE_INFO("C_SignFinal: rc = 0x%08lx, sess = %ld\n",
 		   rc, (sess == NULL)?-1:(CK_LONG)sess->handle);
 
 	return rc;
@@ -2323,7 +2323,7 @@ CK_RV SC_VerifyInit(ST_SESSION_HANDLE *sSession, CK_MECHANISM_PTR pMechanism,
 		TRACE_DEVEL("ep11tok_verify_init() failed.\n");
 
 done:
-	TRACE_INFO("C_VerifyInit: rc = %08lx, sess = %ld, mech = %lx\n",
+	TRACE_INFO("C_VerifyInit: rc = 0x%08lx, sess = %ld, mech = 0x%lx\n",
 		   rc, (sess == NULL)?-1:(CK_LONG)sess->handle,
 		   pMechanism->mechanism);
 
@@ -2370,7 +2370,7 @@ CK_RV SC_Verify(ST_SESSION_HANDLE *sSession, CK_BYTE_PTR pData,
 done:
 	verify_mgr_cleanup(&sess->verify_ctx);
 
-	TRACE_INFO("C_Verify: rc = %08lx, sess = %ld, datalen = %lu\n",
+	TRACE_INFO("C_Verify: rc = 0x%08lx, sess = %ld, datalen = %lu\n",
 		   rc, (sess == NULL)?-1:(CK_LONG)sess->handle, ulDataLen);
 
 	return rc;
@@ -2416,7 +2416,7 @@ done:
 	if (rc != CKR_OK)
 		verify_mgr_cleanup(&sess->verify_ctx);
 
-	TRACE_INFO("C_VerifyUpdate: rc = %08lx, sess = %ld, datalen = %lu\n",
+	TRACE_INFO("C_VerifyUpdate: rc = 0x%08lx, sess = %ld, datalen = %lu\n",
 		   rc, (sess == NULL)?-1:(CK_LONG)sess->handle, ulPartLen);
 
 	return rc;
@@ -2461,7 +2461,7 @@ CK_RV SC_VerifyFinal(ST_SESSION_HANDLE *sSession, CK_BYTE_PTR pSignature,
 done:
 	verify_mgr_cleanup(&sess->verify_ctx);
 
-	TRACE_INFO("C_VerifyFinal: rc = %08lx, sess = %ld\n",
+	TRACE_INFO("C_VerifyFinal: rc = 0x%08lx, sess = %ld\n",
 		   rc, (sess == NULL)?-1:(CK_LONG)sess->handle);
 
 	return rc;
@@ -2597,7 +2597,7 @@ CK_RV SC_GenerateKey(ST_SESSION_HANDLE *sSession, CK_MECHANISM_PTR pMechanism,
 		TRACE_DEVEL("ep11tok_generate_key() failed.\n");
 
 done:
-	TRACE_INFO("C_GenerateKey: rc = %08lx, sess = %ld, mech = %lx\n", rc,
+	TRACE_INFO("C_GenerateKey: rc = 0x%08lx, sess = %ld, mech = 0x%lx\n", rc,
 		    (sess == NULL) ? -1 : (CK_LONG) sess->handle,
 		    pMechanism->mechanism);
 
@@ -2608,7 +2608,7 @@ done:
 	attr = pTemplate;
 	for (i = 0; i < ulCount; i++, attr++) {
 		CK_BYTE *ptr = (CK_BYTE *) attr->pValue;
-		TRACE_DEBUG("%d: Attribute type: 0x%08lx,Value Length: %lu\n",
+		TRACE_DEBUG("%d: Attribute type: 0x%08lx, Value Length: %lu\n",
 			    i, attr->type, attr->ulValueLen);
 		if (attr->ulValueLen != ((CK_ULONG) -1) && (ptr != NULL)) {
 			TRACE_DEBUG("First 4 bytes: %02x %02x %02x %02x\n",
@@ -2674,7 +2674,7 @@ CK_RV SC_GenerateKeyPair(ST_SESSION_HANDLE *sSession,
 		TRACE_DEVEL("ep11tok_generate_key_pair() failed.\n");
 
 done:
-	TRACE_INFO("C_GenerateKeyPair: rc = %08lx, sess = %ld, mech = %lx\n",
+	TRACE_INFO("C_GenerateKeyPair: rc = 0x%08lx, sess = %ld, mech = 0x%lx\n",
 		   rc, (sess == NULL) ? -1 : ((CK_LONG) sess->handle),
 		   pMechanism->mechanism);
 
@@ -2756,7 +2756,7 @@ CK_RV SC_WrapKey(ST_SESSION_HANDLE *sSession, CK_MECHANISM_PTR pMechanism,
 		TRACE_DEVEL("ep11tok_wrap_key() failed.\n");
 
 done:
-	TRACE_INFO("C_WrapKey: rc = %08lx, sess = %ld, encrypting key = %lu, "
+	TRACE_INFO("C_WrapKey: rc = 0x%08lx, sess = %ld, encrypting key = %lu, "
 		   "wrapped key = %lu\n", rc,
 		   (sess == NULL) ? -1 : (CK_LONG) sess->handle,
 		   hWrappingKey, hKey);
@@ -2811,7 +2811,7 @@ CK_RV SC_UnwrapKey(ST_SESSION_HANDLE *sSession, CK_MECHANISM_PTR pMechanism,
 		TRACE_DEVEL("ep11tok_unwrap_key() failed.\n");
 
 done:
-	TRACE_INFO("C_UnwrapKey: rc = %08lx, sess = %ld, decrypting key = %lu,"
+	TRACE_INFO("C_UnwrapKey: rc = 0x%08lx, sess = %ld, decrypting key = %lu,"
 		   "unwrapped key = %lu\n", rc,
 		   (sess == NULL) ? -1 : (CK_LONG) sess->handle,
 		   hUnwrappingKey, *phKey);
@@ -2879,7 +2879,7 @@ CK_RV SC_DeriveKey(ST_SESSION_HANDLE *sSession, CK_MECHANISM_PTR pMechanism,
 		TRACE_DEVEL("epl11tok_derive_key() failed.\n");
 
 done:
-	TRACE_INFO("C_DeriveKey: rc = %08lx, sess = %ld, mech = %lx\n",
+	TRACE_INFO("C_DeriveKey: rc = 0x%08lx, sess = %ld, mech = 0x%lx\n",
 		   rc, (sess == NULL)?-1:(CK_LONG)sess->handle,
 		   pMechanism->mechanism);
 #ifdef DEBUG
@@ -2977,7 +2977,7 @@ CK_RV SC_GenerateRandom(ST_SESSION_HANDLE *sSession, CK_BYTE_PTR pRandomData,
 		TRACE_DEVEL("rng_generate() failed.\n");
 
 done:
-	TRACE_INFO("C_GenerateRandom:rc = %08lx, %lu bytes\n", rc, ulRandomLen);
+	TRACE_INFO("C_GenerateRandom: rc = 0x%08lx, %lu bytes\n", rc, ulRandomLen);
 	return rc;
 }
 

--- a/usr/lib/pkcs11/ica_s390_stdll/ica_specific.c
+++ b/usr/lib/pkcs11/ica_s390_stdll/ica_specific.c
@@ -2341,7 +2341,7 @@ CK_RV token_specific_aes_gcm(SESSION *sess, ENCR_DECR_CONTEXT *ctx,
 	}
 
 	if (rc != 0) {
-		TRACE_ERROR("ica_aes_gcm failed with %lx.\n", rc);
+		TRACE_ERROR("ica_aes_gcm failed with rc = 0x%lx.\n", rc);
 		(*out_data_len) = 0;
 		rc = CKR_FUNCTION_FAILED;
 	}
@@ -2425,7 +2425,7 @@ CK_RV token_specific_aes_gcm_update(SESSION *sess, ENCR_DECR_CONTEXT *ctx,
 		memcpy (buffer, context->data, context->len);
 		memcpy (buffer+context->len, in_data, out_len - context->len);
 
-		TRACE_DEVEL("Ciphertext length (%02ld bytes).\n", in_data_len);
+		TRACE_DEVEL("Ciphertext length (%ld bytes).\n", in_data_len);
 
 		rc = ica_aes_gcm_intermediate(buffer, (unsigned int)out_len,
 					      out_data, ucb, auth_data,
@@ -2476,7 +2476,7 @@ CK_RV token_specific_aes_gcm_update(SESSION *sess, ENCR_DECR_CONTEXT *ctx,
 	}
 
 	if( rc != 0) {
-		TRACE_ERROR("ica_aes_gcm_update failed with %lx.\n", rc);
+		TRACE_ERROR("ica_aes_gcm_update failed with rc = 0x%lx.\n", rc);
 		rc = CKR_FUNCTION_FAILED;
 		goto done;
 	}
@@ -2561,7 +2561,8 @@ CK_RV token_specific_aes_gcm_final(SESSION *sess, ENCR_DECR_CONTEXT *ctx,
 		} else
 			*out_data_len = tag_data_len;
 
-		TRACE_DEVEL("GCM Final: context->len=%ld, tag_data_len=%ld, out_data_len=%ld\n", context->len, tag_data_len, *out_data_len);
+		TRACE_DEVEL("GCM Final: context->len=%ld, tag_data_len=%ld, out_data_len=%ld\n",
+			    context->len, tag_data_len, *out_data_len);
 
 		rc = ica_aes_gcm_last(icb, (unsigned int)auth_data_len,
 				      (unsigned int)context->ulClen, tag_data,
@@ -2570,7 +2571,7 @@ CK_RV token_specific_aes_gcm_final(SESSION *sess, ENCR_DECR_CONTEXT *ctx,
 				      subkey, 1);
 
 		if (rc != 0) {
-			TRACE_ERROR("ica_aes_gcm_final failed with %lx.\n", rc);
+			TRACE_ERROR("ica_aes_gcm_final failed with rc = 0x%lx.\n", rc);
 			rc = CKR_FUNCTION_FAILED;
 			goto done;
 		}
@@ -2623,7 +2624,7 @@ CK_RV token_specific_aes_gcm_final(SESSION *sess, ENCR_DECR_CONTEXT *ctx,
 				      (unsigned int)attr->ulValueLen, subkey,
 				      0);
 		if (rc != 0) {
-			TRACE_ERROR("ica_aes_gcm_final failed with %lx.\n", rc);
+			TRACE_ERROR("ica_aes_gcm_final failed with rc = 0x%lx.\n", rc);
 			rc = CKR_FUNCTION_FAILED;
 		}
 	}


### PR DESCRIPTION
Test complains about different printouts for the very same info.
So for example the mechanism value is sometimes printed as %ld
sometimes %lx and sometimes 0x%lx or 0x%08lx. So here is a rework
touching just trace statements and doing only slight modifications.
The goal is to have identical printouts for the rc value (0x%08x),
mechanism (0x%lx), slot id (%ld), handles (%ld), key index (%ld).

Signed-off-by: Harald Freudenberger <freude@linux.vnet.ibm.com>