### PR TITLE
Fix glibc incompatibilty for the Soft Token

### DIFF
--- a/usr/lib/pkcs11/ep11_stdll/ep11_specific.c
+++ b/usr/lib/pkcs11/ep11_stdll/ep11_specific.c
@@ -12,7 +12,6 @@
 			  Change Log
 			  ==========
 ****************************************************************************/
-#define _DEFAULT_SOURCE
 
 #include <pthread.h>
 #include <string.h>
@@ -34,7 +33,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <endian.h>
 #include <asm/zcrypt.h>
 #include <syslog.h>
 #include <dlfcn.h>

--- a/usr/lib/pkcs11/soft_stdll/soft_specific.c
+++ b/usr/lib/pkcs11/soft_stdll/soft_specific.c
@@ -18,7 +18,11 @@
 
 
 ****************************************************************************/
+#if __GLIBC__ >= 2 && __GLIBC_MINOR__ > 19
 #define _DEFAULT_SOURCE
+#else
+#define _BSD_SOURCE
+#endif
 
 #include <pthread.h>
 #include <string.h>            // for memcmp() et al


### PR DESCRIPTION
We had moved from the deprecated _BSD_SOURCE to _DEFAULT_SOURCE, but some
distros are still running on older versions of glibc, so to avoid
incompatibility we check for the glibc and define the necessary source.
Also removed the _DEFAULT_SOURCE from EP11 code as it is not used anywhere.

Signed-off-by: Eduardo Barretto <ebarretto@linux.vnet.ibm.com>