### PR TITLE
MTI additional patches

### DIFF
--- a/doc/README.ep11_stdll
+++ b/doc/README.ep11_stdll
@@ -13,6 +13,10 @@ into the kernel and the availability of EP11 library libep11.
 The token directory of the EP11 token is opencryptoki/ep11tok typically located
 in /var/lib.
 
+There is a new possibility to configure multiple EP11 tokens.
+Thus dedicated adapter/domains can be assigned to different tokens respectively
+applications. That ensures data isolation between multiple applications.
+
 Configuration
 -------------
 
@@ -22,19 +26,33 @@ configuration file that sets the stdll attribute to libpkcs11_ep11.so.
 A EP11 token specific configuration file must be set up to define the target
 adapters and target adapter domains. The name of the configuration file must be
 defined in the global openCryptoki configuration opencryptoki.conf file as part
-of the token specification using the confname attribute.
-E.g. the entry
+of the token specification using the confname attribute. In case of using
+multiple ep11 tokens a token directory name must be specified for each token
+using the tokname attribute.
+E.g.
 
 slot 4
 {
 stdll = libpkcs11_ep11.so
-confname = ep11tok.conf
+confname = ep11tok01.conf
+tokname = ep11token01
 }
 
-defines the name of the configuration file of the EP11 token to be ep11tok.conf.
-Per default this file is searched in the directory where openCryptoki searches
-its global configuration file. This default path can be overridden using the
-OCK_EP11_TOKEN_DIR environment variable.
+slot 5
+{
+stdll = libpkcs11_ep11.so
+confname = ep11tok02.conf
+tokname = ep11token02
+}
+
+The sample entry define the name of the configuration files of the EP11 token
+to be e.g. ep11tok01.conf. Per default this file is searched in the directory
+where openCryptoki searches its global configuration file. This default path
+can be overriden using the OCK_EP11_TOKEN_DIR environment variable.
+
+The tokname attribute specifies the name of the individual token directory.
+Typically it's located in /var/lib/opencryptoki/. Each token directory contain
+it's own token individual objects that are separated from other ep11 tokens.
 
 EP11 token configuration files defines a list of adapter/domain pairs to which
 the EP11 token sends its cryptographic requests. This list can be specified as a

--- a/usr/lib/pkcs11/api/apiproto.h
+++ b/usr/lib/pkcs11/api/apiproto.h
@@ -31,10 +31,10 @@ void API_UnRegister();
 int DL_Load_and_Init(API_Slot_t *, CK_SLOT_ID);
 
 
-CK_RV CreateXProcLock(char *tokname);
-CK_RV XProcLock(void);
-CK_RV XProcUnLock(void);
-CK_RV XProcClose(void);
+CK_RV CreateProcLock();
+CK_RV ProcLock(void);
+CK_RV ProcUnLock(void);
+CK_RV ProcClose(void);
 
 void _init(void);
 void get_sess_count(CK_SLOT_ID, CK_ULONG *);

--- a/usr/lib/pkcs11/common/h_extern.h
+++ b/usr/lib/pkcs11/common/h_extern.h
@@ -1844,10 +1844,11 @@ CK_RV get_keytype(STDLL_TokData_t  *tokdata, CK_OBJECT_HANDLE hkey,
 CK_RV check_user_and_group();
 
 //lock and unlock routines
-CK_RV XProcLock(void);
-CK_RV XProcUnLock(void);
-void XProcLock_Init(void);
-void CloseXProcLock(void);
+CK_RV XProcLock(STDLL_TokData_t *tokdata);
+CK_RV XProcUnLock(STDLL_TokData_t *tokdata);
+CK_RV CreateXProcLock(char *tokname, STDLL_TokData_t *tokdata);
+void XProcLock_Init(STDLL_TokData_t *tokdata);
+void CloseXProcLock(STDLL_TokData_t *tokdata);
 
 //list mechanisms
 //

--- a/usr/lib/pkcs11/common/h_extern.h
+++ b/usr/lib/pkcs11/common/h_extern.h
@@ -1835,8 +1835,8 @@ CK_RV _DestroyMutex( MUTEX *mutex );
 CK_RV _LockMutex( MUTEX *mutex );
 CK_RV _UnlockMutex( MUTEX *mutex );
 
-CK_RV attach_shm(CK_SLOT_ID slot_id, LW_SHM_TYPE **shmem);
-CK_RV detach_shm(LW_SHM_TYPE *shmem);
+CK_RV attach_shm(STDLL_TokData_t *tokdata, CK_SLOT_ID slot_id);
+CK_RV detach_shm(STDLL_TokData_t *tokdata);
 
 //get keytype
 CK_RV get_keytype(STDLL_TokData_t  *tokdata, CK_OBJECT_HANDLE hkey,

--- a/usr/lib/pkcs11/common/host_defs.h
+++ b/usr/lib/pkcs11/common/host_defs.h
@@ -293,6 +293,7 @@ typedef struct _LW_SHM_TYPE
 
 typedef struct _STDLL_TokData_t {
 	CK_SLOT_INFO    slot_info;
+	int             spinxplfd;              // token specific lock
 	char		data_store[256];	// path information of the token directory
 	CK_BBOOL        initialized;
 	CK_ULONG 	ro_session_count;

--- a/usr/lib/pkcs11/common/loadsave.c
+++ b/usr/lib/pkcs11/common/loadsave.c
@@ -395,7 +395,7 @@ load_token_data(STDLL_TokData_t *tokdata, CK_SLOT_ID slot_id)
 	TOKEN_DATA td;
 	CK_RV rc;
 
-	rc = XProcLock();
+	rc = XProcLock(tokdata);
 	if (rc != CKR_OK) {
 		TRACE_ERROR("Failed to get Process Lock.\n");
 		goto out_nolock;
@@ -409,9 +409,9 @@ load_token_data(STDLL_TokData_t *tokdata, CK_SLOT_ID slot_id)
 			/* init_token_data may call save_token_data, which
 			 * grabs the lock, so we must release it around this
 			 * call */
-			XProcUnLock();
+			XProcUnLock(tokdata);
 			init_token_data(tokdata, slot_id);
-			rc = XProcLock();
+			rc = XProcLock(tokdata);
 			if (rc != CKR_OK) {
 				TRACE_ERROR("Failed to get Process Lock.\n");
 				goto out_nolock;
@@ -452,7 +452,7 @@ load_token_data(STDLL_TokData_t *tokdata, CK_SLOT_ID slot_id)
 	rc = CKR_OK;
 
 out_unlock:
-	XProcUnLock();
+	XProcUnLock(tokdata);
 
 out_nolock:
 	if (fp)
@@ -469,7 +469,7 @@ CK_RV save_token_data(STDLL_TokData_t *tokdata, CK_SLOT_ID slot_id)
 	CK_RV rc;
 	CK_BYTE fname[PATH_MAX];
 
-	rc = XProcLock();
+	rc = XProcLock(tokdata);
 	if (rc != CKR_OK) {
 		TRACE_ERROR("Failed to get Process Lock.\n");
 		goto out_nolock;
@@ -501,7 +501,7 @@ CK_RV save_token_data(STDLL_TokData_t *tokdata, CK_SLOT_ID slot_id)
 	rc = CKR_OK;
 
 done:
-	XProcUnLock();
+	XProcUnLock(tokdata);
 
 out_nolock:
 	if (fp)

--- a/usr/lib/pkcs11/common/new_host.c
+++ b/usr/lib/pkcs11/common/new_host.c
@@ -184,7 +184,7 @@ CK_RV ST_Initialize(API_Slot_t *sltp, CK_SLOT_ID SlotNumber,
 	 */
 	if (sltp->TokData->initialized == FALSE) {
 
-		rc = attach_shm(SlotNumber, &(sltp->TokData->global_shm));
+		rc = attach_shm(sltp->TokData, SlotNumber);
 		if (rc != CKR_OK) {
 			TRACE_ERROR("Could not attach to shared memory.\n");
 			goto done;
@@ -266,7 +266,7 @@ CK_RV SC_Finalize(STDLL_TokData_t *tokdata, CK_SLOT_ID sid, SLOT_INFO *sinfp)
 
 	session_mgr_close_all_sessions();
 	object_mgr_purge_token_objects(tokdata);
-	detach_shm(tokdata->global_shm);
+	detach_shm(tokdata);
 	/* close spin lock file	*/
 	CloseXProcLock();
 	if (token_specific.t_final != NULL) {

--- a/usr/lib/pkcs11/common/new_host.c
+++ b/usr/lib/pkcs11/common/new_host.c
@@ -56,8 +56,6 @@ CK_ULONG  usage_count = 0;	/* track DLL usage */
 void Fork_Initializer(void)
 {
 
-	/* Initialize spinlock. */
-	XProcLock_Init();
 
 	/* Force logout.  This cleans out the private session and list
 	 * and cleans out the private object map
@@ -155,13 +153,6 @@ CK_RV ST_Initialize(API_Slot_t *sltp, CK_SLOT_ID SlotNumber,
 	MY_CreateMutex(&sess_list_mutex);
 	MY_CreateMutex(&login_mutex);
 
-	/* Create lockfile */
-	if (CreateXProcLock(sinfp->tokname) != CKR_OK) {
-		TRACE_ERROR("Process lock failed.\n");
-		rc = CKR_FUNCTION_FAILED;
-		goto done;
-	}
-
 	/*
 	 * Create separate memory area for each token specific data
 	 */
@@ -178,6 +169,16 @@ CK_RV ST_Initialize(API_Slot_t *sltp, CK_SLOT_ID SlotNumber,
 	}
 	else
 		init_data_store((char *)PK_DIR, sltp->TokData->data_store);
+
+	/* Initialize Lock */
+	XProcLock_Init();
+
+	/* Create lockfile */
+	if (CreateXProcLock(sinfp->tokname) != CKR_OK) {
+		TRACE_ERROR("Process lock failed.\n");
+		rc = CKR_FUNCTION_FAILED;
+		goto done;
+	}
 
 	/* Handle global initialization issues first if we have not
 	 * been initialized.

--- a/usr/lib/pkcs11/common/obj_mgr.c
+++ b/usr/lib/pkcs11/common/obj_mgr.c
@@ -133,7 +133,7 @@ object_mgr_add( STDLL_TokData_t  * tokdata,
       // we'll be modifying nv_token_data so we should protect this part with
       // the 'pkcs_mutex'
       //
-      rc = XProcLock();
+      rc = XProcLock(tokdata);
       if (rc != CKR_OK){
          TRACE_ERROR("Failed to get Process Lock.\n");
          goto done;
@@ -146,7 +146,7 @@ object_mgr_add( STDLL_TokData_t  * tokdata,
             if (tokdata->global_shm->num_priv_tok_obj >= MAX_TOK_OBJS) {
                rc = CKR_HOST_MEMORY;
                TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
-               XProcUnLock();
+               XProcUnLock(tokdata);
                goto done;
             }
          }
@@ -154,7 +154,7 @@ object_mgr_add( STDLL_TokData_t  * tokdata,
             if (tokdata->global_shm->num_publ_tok_obj >= MAX_TOK_OBJS) {
                rc = CKR_HOST_MEMORY;
                TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
-               XProcUnLock();
+               XProcUnLock(tokdata);
                goto done;
             }
          }
@@ -167,7 +167,7 @@ object_mgr_add( STDLL_TokData_t  * tokdata,
          rc = compute_next_token_obj_name( current, next );
          if (rc != CKR_OK) {
                  // TODO: handle error, check if rc is a valid per spec
-                XProcUnLock();
+                XProcUnLock(tokdata);
                  goto done;
          }
          memcpy( &tokdata->nv_token_data->next_token_object_name, next, 8 );
@@ -175,7 +175,7 @@ object_mgr_add( STDLL_TokData_t  * tokdata,
          rc = save_token_object( tokdata, o );
          if (rc != CKR_OK) {
                  // TODO: handle error, check if rc is a valid per spec
-                XProcUnLock();
+                XProcUnLock(tokdata);
                 goto done;
          }
 
@@ -188,11 +188,11 @@ object_mgr_add( STDLL_TokData_t  * tokdata,
          rc = save_token_data(tokdata, sess->session_info.slotID);
          if (rc != CKR_OK) {
                  // TODO: handle error, check if rc is a valid per spec
-                XProcUnLock();
+                XProcUnLock(tokdata);
                 goto done;
          }
 
-         XProcUnLock();
+         XProcUnLock(tokdata);
 
       }
 
@@ -234,14 +234,14 @@ object_mgr_add( STDLL_TokData_t  * tokdata,
 	    bt_node_free(&publ_token_obj_btree, obj_handle, NULL);
          }
 
-         rc = XProcLock();
+         rc = XProcLock(tokdata);
          if (rc != CKR_OK){
             TRACE_ERROR("Failed to get Process Lock.\n");
             goto done;
          }
          object_mgr_del_from_shm( o, tokdata->global_shm );
 
-         XProcUnLock();
+         XProcUnLock(tokdata);
       }
    }
 
@@ -421,7 +421,7 @@ object_mgr_copy( STDLL_TokData_t  * tokdata,
       // we'll be modifying nv_token_data so we should protect this part
       // with 'pkcs_mutex'
       //
-      rc = XProcLock();
+      rc = XProcLock(tokdata);
       if (rc != CKR_OK){
          TRACE_ERROR("Failed to get Process Lock.\n");
          goto done;
@@ -432,7 +432,7 @@ object_mgr_copy( STDLL_TokData_t  * tokdata,
          //
          if (priv_obj) {
             if (tokdata->global_shm->num_priv_tok_obj >= MAX_TOK_OBJS) {
-               XProcUnLock();
+               XProcUnLock(tokdata);
                TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
                rc = CKR_HOST_MEMORY;
                goto done;
@@ -440,7 +440,7 @@ object_mgr_copy( STDLL_TokData_t  * tokdata,
          }
          else {
             if (tokdata->global_shm->num_publ_tok_obj >= MAX_TOK_OBJS) {
-               XProcUnLock();
+               XProcUnLock(tokdata);
                TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
                rc = CKR_HOST_MEMORY;
                goto done;
@@ -460,7 +460,7 @@ object_mgr_copy( STDLL_TokData_t  * tokdata,
          //
          object_mgr_add_to_shm( new_obj, tokdata->global_shm );
 
-         XProcUnLock();
+         XProcUnLock(tokdata);
 
          save_token_data(tokdata, sess->session_info.slotID);
       }
@@ -509,14 +509,14 @@ object_mgr_copy( STDLL_TokData_t  * tokdata,
 	    bt_node_free(&publ_token_obj_btree, obj_handle, NULL);
          }
 
-         rc = XProcLock();
+         rc = XProcLock(tokdata);
          if (rc != CKR_OK){
             TRACE_ERROR("Failed to get Process Lock.\n");
             goto done;
          }
          object_mgr_del_from_shm( new_obj, tokdata->global_shm );
 
-         XProcUnLock();
+         XProcUnLock(tokdata);
       }
    }
 
@@ -646,7 +646,7 @@ object_mgr_create_final( STDLL_TokData_t  * tokdata,
       // we'll be modifying nv_token_data so we should protect this part
       // with 'pkcs_mutex'
       //
-      rc = XProcLock();
+      rc = XProcLock(tokdata);
       if (rc != CKR_OK){
          TRACE_ERROR("Failed to get Process Lock.\n");
          return rc;
@@ -657,14 +657,14 @@ object_mgr_create_final( STDLL_TokData_t  * tokdata,
          //
          if (priv_obj) {
             if (tokdata->global_shm->num_priv_tok_obj >= MAX_TOK_OBJS) {
-               XProcUnLock();
+               XProcUnLock(tokdata);
                TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
                return CKR_HOST_MEMORY;
             }
          }
          else {
             if (tokdata->global_shm->num_publ_tok_obj >= MAX_TOK_OBJS) {
-               XProcUnLock();
+               XProcUnLock(tokdata);
                TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
                return CKR_HOST_MEMORY;
             }
@@ -683,7 +683,7 @@ object_mgr_create_final( STDLL_TokData_t  * tokdata,
          //
          object_mgr_add_to_shm( obj, tokdata->global_shm );
 
-         XProcUnLock();
+         XProcUnLock(tokdata);
 
          save_token_data(tokdata, sess->session_info.slotID);
       }
@@ -730,14 +730,14 @@ object_mgr_create_final( STDLL_TokData_t  * tokdata,
 	    bt_node_free(&publ_token_obj_btree, obj_handle, NULL);
          }
 
-         rc = XProcLock();
+         rc = XProcLock(tokdata);
          if (rc != CKR_OK){
             TRACE_ERROR("Failed to get Process Lock.\n");
             return rc;
          }
          object_mgr_del_from_shm( obj, tokdata->global_shm );
 
-         XProcUnLock();
+         XProcUnLock(tokdata);
       }
    }
 
@@ -770,7 +770,7 @@ destroy_object_cb(STDLL_TokData_t  *tokdata, void *node)
 
 		/* Use the same calling convention as the old code, if XProcLock fails, don't
 		 * delete from shm and don't free the object in its other btree */
-		if (XProcLock()) {
+		if (XProcLock(tokdata)) {
 			TRACE_ERROR("Failed to get Process Lock.\n");
 			goto done;
 		}
@@ -778,7 +778,7 @@ destroy_object_cb(STDLL_TokData_t  *tokdata, void *node)
 		object_mgr_del_from_shm(o, tokdata->global_shm);
 		DUMP_SHM(tokdata->global_shm, "after");
 
-		XProcUnLock();
+		XProcUnLock(tokdata);
 
 		if (map->is_private)
 			bt_node_free(&priv_token_obj_btree, map->obj_handle, call_free);
@@ -837,14 +837,14 @@ delete_token_obj_cb(STDLL_TokData_t  *tokdata, void *node, unsigned long map_han
 		 * XProcLock fails, don't delete from shm and don't free
 		 * the object in its other btree
 		 */
-		if (XProcLock()) {
+		if (XProcLock(tokdata)) {
 			TRACE_ERROR("Failed to get Process Lock.\n");
 			goto done;
 		}
 
 		object_mgr_del_from_shm(o, tokdata->global_shm);
 
-		XProcUnLock();
+		XProcUnLock(tokdata);
 
 		if (map->is_private)
 			bt_node_free(&priv_token_obj_btree, map->obj_handle, call_free);
@@ -868,7 +868,7 @@ object_mgr_destroy_token_objects(STDLL_TokData_t *tokdata)
 
    // now we want to purge the token object list in shared memory
    //
-   rc = XProcLock();
+   rc = XProcLock(tokdata);
    if (rc == CKR_OK) {
       locked = TRUE;
 
@@ -882,7 +882,7 @@ object_mgr_destroy_token_objects(STDLL_TokData_t *tokdata)
       TRACE_ERROR("Failed to get Process Lock.\n");
 
    if (locked == TRUE) {
-	XProcUnLock();
+	XProcUnLock(tokdata);
    }
 
    return rc;
@@ -990,9 +990,9 @@ object_mgr_find_in_map1( STDLL_TokData_t  *tokdata,
     * Accounting is done in shm, so check shm to see if object still exists.
     */
    if (!object_is_session_object(obj)) {
-	XProcLock();
+	XProcLock(tokdata);
 	rc = object_mgr_check_shm( tokdata, obj );
-	XProcUnLock();
+	XProcUnLock(tokdata);
 
         if (rc != CKR_OK) {
 		TRACE_DEVEL("object_mgr_check_shm failed.\n");
@@ -1063,9 +1063,9 @@ object_mgr_find_in_map2( STDLL_TokData_t  * tokdata,
 
    *handle = fa.map_handle;
 
-   XProcLock();
+   XProcLock(tokdata);
    object_mgr_check_shm( tokdata, obj );
-   XProcUnLock();
+   XProcUnLock(tokdata);
 
    return CKR_OK;
 }
@@ -1180,9 +1180,9 @@ object_mgr_find_init( STDLL_TokData_t  *tokdata,
    sess->find_idx   = 0;
 
 //  --- need to grab the object lock here
-   XProcLock();
+   XProcLock(tokdata);
    object_mgr_update_from_shm(tokdata);
-   XProcUnLock();
+   XProcUnLock(tokdata);
 
    fa.hw_feature = FALSE;
    fa.hidden_object = FALSE;
@@ -1468,7 +1468,7 @@ object_mgr_restore_obj_withSize(STDLL_TokData_t  *tokdata, CK_BYTE *data,
 	    }
 	 }
 
-         XProcLock();
+         XProcLock(tokdata);
 
          if (priv) {
             if (tokdata->global_shm->priv_loaded == FALSE){
@@ -1490,7 +1490,7 @@ object_mgr_restore_obj_withSize(STDLL_TokData_t  *tokdata, CK_BYTE *data,
             }
          }
 
-         XProcUnLock();
+         XProcUnLock(tokdata);
       } else {
          TRACE_DEVEL("object_restore_withSize failed.\n");
       }
@@ -1596,7 +1596,7 @@ object_mgr_set_attribute_values( STDLL_TokData_t  *tokdata,
 
       save_token_object( tokdata, obj );
 
-      rc = XProcLock();
+      rc = XProcLock(tokdata);
       if (rc != CKR_OK){
          TRACE_ERROR("Failed to get Process Lock.\n");
          return rc;
@@ -1608,7 +1608,7 @@ object_mgr_set_attribute_values( STDLL_TokData_t  *tokdata,
 
          if (rc != CKR_OK) {
             TRACE_DEVEL("object_mgr_search_shm_for_obj failed.\n");
-            XProcUnLock();
+            XProcUnLock(tokdata);
             return rc;
          }
 
@@ -1620,7 +1620,7 @@ object_mgr_set_attribute_values( STDLL_TokData_t  *tokdata,
                                              obj, &index );
          if (rc != CKR_OK) {
             TRACE_DEVEL("object_mgr_search_shm_for_obj failed.\n");
-            XProcUnLock();
+            XProcUnLock(tokdata);
             return rc;
          }
 
@@ -1630,7 +1630,7 @@ object_mgr_set_attribute_values( STDLL_TokData_t  *tokdata,
       entry->count_lo = obj->count_lo;
       entry->count_hi = obj->count_hi;
 
-      XProcUnLock();
+      XProcUnLock(tokdata);
    }
 
    return rc;

--- a/usr/lib/pkcs11/common/tok_spec_struct.h
+++ b/usr/lib/pkcs11/common/tok_spec_struct.h
@@ -55,7 +55,7 @@ struct token_specific_struct {
 	int (*t_creatlock) (void);
 
 	// Create or attach to token's shared memory
-	CK_RV (*t_attach_shm) (CK_SLOT_ID slot_id, LW_SHM_TYPE **shmem);
+	CK_RV (*t_attach_shm) (STDLL_TokData_t *, CK_SLOT_ID slot_id);
 
 	// Initialization function
 	CK_RV(*t_init) (STDLL_TokData_t *, CK_SLOT_ID, char *);

--- a/usr/lib/pkcs11/common/tok_specific.h
+++ b/usr/lib/pkcs11/common/tok_specific.h
@@ -28,7 +28,7 @@
 #define _TOK_SPECIFIC
 
 int token_specific_creatlock(void);
-CK_RV token_specific_attach_shm(CK_SLOT_ID slot_id, LW_SHM_TYPE **shmem);
+CK_RV token_specific_attach_shm(STDLL_TokData_t *, CK_ULONG);
 CK_RV token_specific_rng(STDLL_TokData_t *, CK_BYTE *,  CK_ULONG);
 CK_RV token_specific_init(STDLL_TokData_t *,CK_SLOT_ID, char *);
 

--- a/usr/lib/pkcs11/common/utility.c
+++ b/usr/lib/pkcs11/common/utility.c
@@ -742,14 +742,15 @@ CK_RV parity_is_odd(CK_BYTE b)
 		return FALSE;
 }
 
-CK_RV attach_shm(CK_SLOT_ID slot_id, LW_SHM_TYPE **shm)
+CK_RV attach_shm(STDLL_TokData_t *tokdata, CK_SLOT_ID slot_id)
 {
 	CK_RV rc = CKR_OK;
 	int ret;
 	char buf[PATH_MAX];
+	LW_SHM_TYPE **shm = &tokdata->global_shm;
 
 	if (token_specific.t_attach_shm != NULL)
-		return token_specific.t_attach_shm(slot_id, shm);
+		return token_specific.t_attach_shm(tokdata, slot_id);
 
 	XProcLock();
 
@@ -770,13 +771,13 @@ done:
 	return rc;
 }
 
-CK_RV detach_shm(LW_SHM_TYPE *shm)
+CK_RV detach_shm(STDLL_TokData_t *tokdata)
 {
 	CK_RV rc = CKR_OK;
 
 	XProcLock();
 
-	if (sm_close((void *)shm, 0)) {
+	if (sm_close((void *)tokdata->global_shm, 0)) {
 		TRACE_DEVEL("sm_close failed.\n");
 		rc = CKR_FUNCTION_FAILED;
 	}

--- a/usr/lib/pkcs11/ep11_stdll/new_host.c
+++ b/usr/lib/pkcs11/ep11_stdll/new_host.c
@@ -173,7 +173,7 @@ CK_RV ST_Initialize(API_Slot_t *sltp, CK_SLOT_ID SlotNumber,
 	 */
 	if (sltp->TokData->initialized == FALSE) {
 
-		rc = attach_shm(SlotNumber, &(sltp->TokData->global_shm));
+		rc = attach_shm(sltp->TokData, SlotNumber);
 		if (rc != CKR_OK) {
 			TRACE_ERROR("Could not attach to shared memory.\n");
 			goto done;
@@ -249,7 +249,7 @@ CK_RV SC_Finalize(STDLL_TokData_t *tokdata, CK_SLOT_ID sid, SLOT_INFO *sinfp)
 
 	session_mgr_close_all_sessions();
 	object_mgr_purge_token_objects(tokdata);
-	detach_shm(tokdata->global_shm);
+	detach_shm(tokdata);
 	/* close spin lock file	*/
 	CloseXProcLock();
 	rc = ep11tok_final(tokdata);

--- a/usr/lib/pkcs11/ep11_stdll/new_host.c
+++ b/usr/lib/pkcs11/ep11_stdll/new_host.c
@@ -46,8 +46,6 @@ CK_ULONG  usage_count = 0;	/* track DLL usage */
 void Fork_Initializer(void)
 {
 
-	/* Initialize spinlock. */
-	XProcLock_Init();
 
 	/* Force logout.  This cleans out the private session and list
 	 * and cleans out the private object map
@@ -144,13 +142,6 @@ CK_RV ST_Initialize(API_Slot_t *sltp, CK_SLOT_ID SlotNumber,
 	MY_CreateMutex(&sess_list_mutex);
 	MY_CreateMutex(&login_mutex);
 
-	/* Create lockfile */
-	if (CreateXProcLock(sinfp->tokname) != CKR_OK) {
-		TRACE_ERROR("Process lock failed.\n");
-		rc = CKR_FUNCTION_FAILED;
-		goto done;
-	}
-
 	/*
 	 * Create separate memory area for each token specific data
 	 */
@@ -167,6 +158,16 @@ CK_RV ST_Initialize(API_Slot_t *sltp, CK_SLOT_ID SlotNumber,
 	}
 	else
 		init_data_store((char *)PK_DIR, sltp->TokData->data_store);
+
+	/* Initialize lock */
+	XProcLock_Init();
+
+	/* Create lockfile */
+	if (CreateXProcLock(sinfp->tokname) != CKR_OK) {
+		TRACE_ERROR("Process lock failed.\n");
+		rc = CKR_FUNCTION_FAILED;
+		goto done;
+	}
 
 	/* Handle global initialization issues first if we have not
 	 * been initialized.

--- a/usr/lib/pkcs11/icsf_stdll/icsf_specific.c
+++ b/usr/lib/pkcs11/icsf_stdll/icsf_specific.c
@@ -478,8 +478,8 @@ done:
 	return rc;
 }
 
-CK_RV login(LDAP **ld, CK_SLOT_ID slot_id, CK_BYTE *pin, CK_ULONG pin_len,
-	    const char *pass_file_type)
+CK_RV login(STDLL_TokData_t *tokdata, LDAP **ld, CK_SLOT_ID slot_id,
+	    CK_BYTE *pin, CK_ULONG pin_len, const char *pass_file_type)
 {
 	CK_RV rc = CKR_OK;
 	struct slot_data data;
@@ -625,8 +625,9 @@ CK_RV reset_token_data(STDLL_TokData_t *tokdata, CK_SLOT_ID slot_id,
 	return CKR_OK;
 }
 
-CK_RV destroy_objects(CK_SLOT_ID slot_id, CK_CHAR_PTR token_name,
-		      CK_CHAR_PTR pin, CK_ULONG pin_len)
+CK_RV destroy_objects(STDLL_TokData_t *tokdata, CK_SLOT_ID slot_id,
+		      CK_CHAR_PTR token_name, CK_CHAR_PTR pin,
+		      CK_ULONG pin_len)
 {
 	CK_RV rc = CKR_OK;
 	LDAP *ld = NULL;
@@ -635,7 +636,7 @@ CK_RV destroy_objects(CK_SLOT_ID slot_id, CK_CHAR_PTR token_name,
 	size_t i, records_len;
 	int reason = 0;
 
-	if (login(&ld, slot_id, pin, pin_len, RACFFILE))
+	if (login(tokdata, &ld, slot_id, pin, pin_len, RACFFILE))
 		return CKR_FUNCTION_FAILED;
 
 	TRACE_DEVEL("Destroying objects in slot %lu.\n", slot_id);
@@ -695,7 +696,7 @@ CK_RV icsftok_init_token(STDLL_TokData_t *tokdata, CK_SLOT_ID slot_id,
 	if ((rc = reset_token_data(tokdata, slot_id, pin, pin_len)))
 		goto done;
 
-	if ((rc = destroy_objects(slot_id,
+	if ((rc = destroy_objects(tokdata, slot_id,
 				  tokdata->nv_token_data->token_info.label,
 				  pin, pin_len)))
 		goto done;

--- a/usr/lib/pkcs11/icsf_stdll/icsf_specific.c
+++ b/usr/lib/pkcs11/icsf_stdll/icsf_specific.c
@@ -433,11 +433,12 @@ done:
  * this because it uses additional data in the shared memory and in the future
  * multiple slots should be supported for ICSF.
  */
-CK_RV token_specific_attach_shm(CK_SLOT_ID slot_id, LW_SHM_TYPE **shm)
+CK_RV token_specific_attach_shm(STDLL_TokData_t *tokdata, CK_SLOT_ID slot_id)
 {
 	CK_RV rc = CKR_OK;
 	int ret;
 	void *ptr;
+	LW_SHM_TYPE **shm = &tokdata->global_shm;
 	size_t len = sizeof(**shm) + sizeof(**slot_data);
 	char *shm_id = NULL;
 

--- a/usr/lib/pkcs11/icsf_stdll/new_host.c
+++ b/usr/lib/pkcs11/icsf_stdll/new_host.c
@@ -171,7 +171,7 @@ CK_RV ST_Initialize(API_Slot_t *sltp, CK_SLOT_ID SlotNumber,
 	 */
 	if (sltp->TokData->initialized == FALSE) {
 
-		rc = attach_shm(SlotNumber, &(sltp->TokData->global_shm));
+		rc = attach_shm(sltp->TokData, SlotNumber);
 		if (rc != CKR_OK) {
 			TRACE_ERROR("Could not attach to shared memory.\n");
 			goto done;
@@ -252,7 +252,7 @@ CK_RV SC_Finalize(STDLL_TokData_t *tokdata, CK_SLOT_ID sid, SLOT_INFO *sinfp)
 
 	session_mgr_close_all_sessions();
 	object_mgr_purge_token_objects(tokdata);
-	detach_shm(tokdata->global_shm);
+	detach_shm(tokdata);
 	/* close spin lock file	*/
 	CloseXProcLock();
 

--- a/usr/lib/pkcs11/icsf_stdll/new_host.c
+++ b/usr/lib/pkcs11/icsf_stdll/new_host.c
@@ -158,10 +158,10 @@ CK_RV ST_Initialize(API_Slot_t *sltp, CK_SLOT_ID SlotNumber,
 		init_data_store((char *)PK_DIR, sltp->TokData->data_store);
 
 	/* Initialize lock */
-	XProcLock_Init();
+	XProcLock_Init(sltp->TokData);
 
 	/* Create lockfile */
-	if (CreateXProcLock(sinfp->tokname) != CKR_OK) {
+	if (CreateXProcLock(sinfp->tokname, sltp->TokData) != CKR_OK) {
 		TRACE_ERROR("Process lock failed.\n");
 		rc = CKR_FUNCTION_FAILED;
 		goto done;
@@ -208,9 +208,9 @@ CK_RV ST_Initialize(API_Slot_t *sltp, CK_SLOT_ID SlotNumber,
 	 */
 	load_public_token_objects(sltp->TokData);
 
-	XProcLock();
+	XProcLock(sltp->TokData);
 	sltp->TokData->global_shm->publ_loaded = TRUE;
-	XProcUnLock();
+	XProcUnLock(sltp->TokData);
 
 	init_slotInfo(&(sltp->TokData->slot_info));
 
@@ -255,7 +255,7 @@ CK_RV SC_Finalize(STDLL_TokData_t *tokdata, CK_SLOT_ID sid, SLOT_INFO *sinfp)
 	object_mgr_purge_token_objects(tokdata);
 	detach_shm(tokdata);
 	/* close spin lock file	*/
-	CloseXProcLock();
+	CloseXProcLock(tokdata);
 
 	rc = icsftok_close_all_sessions();
 	if (rc != CKR_OK) {

--- a/usr/lib/pkcs11/icsf_stdll/new_host.c
+++ b/usr/lib/pkcs11/icsf_stdll/new_host.c
@@ -45,8 +45,6 @@ CK_ULONG  usage_count = 0;	/* track DLL usage */
 void Fork_Initializer(void)
 {
 
-	/* Initialize spinlock. */
-	XProcLock_Init();
 
 	/* Force logout.  This cleans out the private session and list
 	 * and cleans out the private object map
@@ -142,13 +140,6 @@ CK_RV ST_Initialize(API_Slot_t *sltp, CK_SLOT_ID SlotNumber,
 	MY_CreateMutex(&sess_list_mutex);
 	MY_CreateMutex(&login_mutex);
 
-	/* Create lockfile */
-	if (CreateXProcLock(sinfp->tokname) != CKR_OK) {
-		TRACE_ERROR("Process lock failed.\n");
-		rc = CKR_FUNCTION_FAILED;
-		goto done;
-	}
-
 	/*
 	 * Create separate memory area for each token specific data
 	 */
@@ -165,6 +156,16 @@ CK_RV ST_Initialize(API_Slot_t *sltp, CK_SLOT_ID SlotNumber,
 	}
 	else
 		init_data_store((char *)PK_DIR, sltp->TokData->data_store);
+
+	/* Initialize lock */
+	XProcLock_Init();
+
+	/* Create lockfile */
+	if (CreateXProcLock(sinfp->tokname) != CKR_OK) {
+		TRACE_ERROR("Process lock failed.\n");
+		rc = CKR_FUNCTION_FAILED;
+		goto done;
+	}
 
 	/* Handle global initialization issues first if we have not
 	 * been initialized.

--- a/usr/lib/pkcs11/tpm_stdll/tpm_specific.c
+++ b/usr/lib/pkcs11/tpm_stdll/tpm_specific.c
@@ -1696,9 +1696,9 @@ token_specific_login(STDLL_TokData_t *tokdata, SESSION *sess,
 
 		rc = load_private_token_objects(tokdata);
 
-		XProcLock();
+		XProcLock(tokdata);
 		tokdata->global_shm->priv_loaded = TRUE;
-		XProcUnLock();
+		XProcUnLock(tokdata);
 	} else {
 		/* SO path --
 		 */


### PR DESCRIPTION
The first patch ist just a update for the ep11 README document with an example configuration.
The second patch fix the access permission when creating new token directories.
The last 4 patches enable individual token locking instead having a single lock for all tokens. This is very useful when dealing with hundreds of tokens.

Developed by Ingo