### PR TITLE
Amendments/Fixes for MTI

### DIFF
--- a/usr/lib/pkcs11/common/host_defs.h
+++ b/usr/lib/pkcs11/common/host_defs.h
@@ -225,7 +225,6 @@ typedef struct _TOKEN_DATA
 
    CK_BYTE   user_pin_sha[3 * DES_BLOCK_SIZE];
    CK_BYTE   so_pin_sha[3 * DES_BLOCK_SIZE];
-   CK_BYTE   user_pin_md5[MD5_HASH_SIZE];
    CK_BYTE   so_pin_md5[MD5_HASH_SIZE];
    CK_BYTE   master_key[MAX_KEY_SIZE];
    CK_BYTE   next_token_object_name[8];
@@ -295,6 +294,7 @@ typedef struct _STDLL_TokData_t {
 	CK_SLOT_INFO    slot_info;
 	int             spinxplfd;              // token specific lock
 	char		data_store[256];	// path information of the token directory
+	CK_BYTE		user_pin_md5[MD5_HASH_SIZE];
 	CK_BBOOL        initialized;
 	CK_ULONG 	ro_session_count;
 	CK_STATE 	global_login_state;;

--- a/usr/lib/pkcs11/common/host_defs.h
+++ b/usr/lib/pkcs11/common/host_defs.h
@@ -225,7 +225,6 @@ typedef struct _TOKEN_DATA
 
    CK_BYTE   user_pin_sha[3 * DES_BLOCK_SIZE];
    CK_BYTE   so_pin_sha[3 * DES_BLOCK_SIZE];
-   CK_BYTE   master_key[MAX_KEY_SIZE];
    CK_BYTE   next_token_object_name[8];
    TWEAK_VEC tweak_vector;
 } TOKEN_DATA;
@@ -295,6 +294,7 @@ typedef struct _STDLL_TokData_t {
 	char		data_store[256];	// path information of the token directory
 	CK_BYTE		user_pin_md5[MD5_HASH_SIZE];
 	CK_BYTE		so_pin_md5[MD5_HASH_SIZE];
+	CK_BYTE		master_key[MAX_KEY_SIZE];
 	CK_BBOOL        initialized;
 	CK_ULONG 	ro_session_count;
 	CK_STATE 	global_login_state;;

--- a/usr/lib/pkcs11/common/host_defs.h
+++ b/usr/lib/pkcs11/common/host_defs.h
@@ -225,7 +225,6 @@ typedef struct _TOKEN_DATA
 
    CK_BYTE   user_pin_sha[3 * DES_BLOCK_SIZE];
    CK_BYTE   so_pin_sha[3 * DES_BLOCK_SIZE];
-   CK_BYTE   so_pin_md5[MD5_HASH_SIZE];
    CK_BYTE   master_key[MAX_KEY_SIZE];
    CK_BYTE   next_token_object_name[8];
    TWEAK_VEC tweak_vector;
@@ -295,6 +294,7 @@ typedef struct _STDLL_TokData_t {
 	int             spinxplfd;              // token specific lock
 	char		data_store[256];	// path information of the token directory
 	CK_BYTE		user_pin_md5[MD5_HASH_SIZE];
+	CK_BYTE		so_pin_md5[MD5_HASH_SIZE];
 	CK_BBOOL        initialized;
 	CK_ULONG 	ro_session_count;
 	CK_STATE 	global_login_state;;

--- a/usr/lib/pkcs11/common/loadsave.c
+++ b/usr/lib/pkcs11/common/loadsave.c
@@ -1065,8 +1065,8 @@ CK_RV load_masterkey_so(STDLL_TokData_t *tokdata)
 	// decrypt the master key data using the MD5 of the SO key
 	// (we can't use the SHA of the SO key since the SHA of the key is
 	// stored in the token data file).
-	memcpy(key, tokdata->nv_token_data->so_pin_md5, MD5_HASH_SIZE);
-	memcpy(key + MD5_HASH_SIZE, tokdata->nv_token_data->so_pin_md5,
+	memcpy(key, tokdata->so_pin_md5, MD5_HASH_SIZE);
+	memcpy(key + MD5_HASH_SIZE, tokdata->so_pin_md5,
 	       key_len - MD5_HASH_SIZE);
 
 	rc = decrypt_data_with_clear_key(tokdata, key, key_len,
@@ -1265,8 +1265,8 @@ CK_RV save_masterkey_so(STDLL_TokData_t *tokdata)
 			 clear_len);
 
 	// encrypt the key data
-	memcpy(key, tokdata->nv_token_data->so_pin_md5, MD5_HASH_SIZE);
-	memcpy(key + MD5_HASH_SIZE, tokdata->nv_token_data->so_pin_md5,
+	memcpy(key, tokdata->so_pin_md5, MD5_HASH_SIZE);
+	memcpy(key + MD5_HASH_SIZE, tokdata->so_pin_md5,
 	       key_len - MD5_HASH_SIZE);
 
 	rc = encrypt_data_with_clear_key(tokdata, key, key_len,

--- a/usr/lib/pkcs11/common/loadsave.c
+++ b/usr/lib/pkcs11/common/loadsave.c
@@ -1170,8 +1170,8 @@ CK_RV load_masterkey_user(STDLL_TokData_t *tokdata)
 	// decrypt the master key data using the MD5 of the SO key
 	// (we can't use the SHA of the SO key since the SHA of the key is
 	// stored in the token data file).
-	memcpy(key, tokdata->nv_token_data->user_pin_md5, MD5_HASH_SIZE);
-	memcpy(key + MD5_HASH_SIZE, tokdata->nv_token_data->user_pin_md5,
+	memcpy(key, tokdata->user_pin_md5, MD5_HASH_SIZE);
+	memcpy(key + MD5_HASH_SIZE, tokdata->user_pin_md5,
 	       key_len - MD5_HASH_SIZE);
 
 	rc = decrypt_data_with_clear_key(tokdata, key, key_len,
@@ -1356,8 +1356,8 @@ CK_RV save_masterkey_user(STDLL_TokData_t *tokdata)
 			 clear_len);
 
 	// encrypt the key data
-	memcpy(key, tokdata->nv_token_data->user_pin_md5, MD5_HASH_SIZE);
-	memcpy(key + MD5_HASH_SIZE, tokdata->nv_token_data->user_pin_md5,
+	memcpy(key, tokdata->user_pin_md5, MD5_HASH_SIZE);
+	memcpy(key + MD5_HASH_SIZE, tokdata->user_pin_md5,
 	       key_len - MD5_HASH_SIZE);
 
 	rc = encrypt_data_with_clear_key(tokdata, key, key_len,

--- a/usr/lib/pkcs11/common/loadsave.c
+++ b/usr/lib/pkcs11/common/loadsave.c
@@ -664,7 +664,7 @@ CK_RV save_private_token_object(STDLL_TokData_t *tokdata, OBJECT * obj)
 	key = malloc(key_len);
 	if (!key)
 		goto oom_error;
-	memcpy(key, tokdata->nv_token_data->master_key, key_len);
+	memcpy(key, tokdata->master_key, key_len);
 
 
 	clear_len = sizeof(CK_ULONG_32) + obj_data_len_32 + SHA1_HASH_SIZE;
@@ -939,7 +939,7 @@ CK_RV restore_private_token_object(STDLL_TokData_t *tokdata, CK_BYTE * data,
 		rc = ERR_HOST_MEMORY;
 		goto done;
 	}
-	memcpy(key, tokdata->nv_token_data->master_key, key_len);
+	memcpy(key, tokdata->master_key, key_len);
 
 	rc = decrypt_data_with_clear_key(tokdata, key, key_len,
 			  token_specific.data_store.obj_initial_vector,
@@ -1029,7 +1029,7 @@ CK_RV load_masterkey_so(STDLL_TokData_t *tokdata)
 	if ((rc = get_encryption_info(&master_key_len, NULL)) != CKR_OK)
 		goto done;
 
-	memset(tokdata->nv_token_data->master_key, 0x0, master_key_len);
+	memset(tokdata->master_key, 0x0, master_key_len);
 
 	data_len = master_key_len + SHA1_HASH_SIZE;
 	clear_len = cipher_len = (data_len + block_size - 1)
@@ -1096,7 +1096,7 @@ CK_RV load_masterkey_so(STDLL_TokData_t *tokdata)
 		goto done;
 	}
 
-	memcpy(tokdata->nv_token_data->master_key, clear, master_key_len);
+	memcpy(tokdata->master_key, clear, master_key_len);
 	rc = CKR_OK;
 
 done:
@@ -1135,7 +1135,7 @@ CK_RV load_masterkey_user(STDLL_TokData_t *tokdata)
 	if ((rc = get_encryption_info(&master_key_len, NULL)) != CKR_OK)
 		goto done;
 
-	memset(tokdata->nv_token_data->master_key, 0x0, master_key_len);
+	memset(tokdata->master_key, 0x0, master_key_len);
 
 	data_len = master_key_len + SHA1_HASH_SIZE;
 	clear_len = cipher_len = (data_len + block_size - 1)
@@ -1201,7 +1201,7 @@ CK_RV load_masterkey_user(STDLL_TokData_t *tokdata)
 		goto done;
 	}
 
-	memcpy(tokdata->nv_token_data->master_key, clear, master_key_len);
+	memcpy(tokdata->master_key, clear, master_key_len);
 	rc = CKR_OK;
 
 done:
@@ -1257,8 +1257,8 @@ CK_RV save_masterkey_so(STDLL_TokData_t *tokdata)
 	}
 
 	// Copy data to buffer (key+hash)
-	memcpy(clear, tokdata->nv_token_data->master_key, master_key_len);
-	if ((rc = compute_sha1(tokdata, tokdata->nv_token_data->master_key,
+	memcpy(clear, tokdata->master_key, master_key_len);
+	if ((rc = compute_sha1(tokdata, tokdata->master_key,
 			       master_key_len, clear + master_key_len)) != CKR_OK)
 		goto done;
 	add_pkcs_padding(clear + data_len, block_size, data_len,
@@ -1348,8 +1348,8 @@ CK_RV save_masterkey_user(STDLL_TokData_t *tokdata)
 	}
 
 	// Copy data to buffer (key+hash)
-	memcpy(clear, tokdata->nv_token_data->master_key, master_key_len);
-	if ((rc = compute_sha1(tokdata, tokdata->nv_token_data->master_key,
+	memcpy(clear, tokdata->master_key, master_key_len);
+	if ((rc = compute_sha1(tokdata, tokdata->master_key,
 			       master_key_len, clear + master_key_len)) != CKR_OK)
 		goto done;
 	add_pkcs_padding(clear + data_len, block_size , data_len,

--- a/usr/lib/pkcs11/common/new_host.c
+++ b/usr/lib/pkcs11/common/new_host.c
@@ -551,7 +551,7 @@ CK_RV SC_InitPIN(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
 	tokdata->nv_token_data->token_info.flags &= ~(CKF_USER_PIN_TO_BE_CHANGED);
 	tokdata->nv_token_data->token_info.flags &= ~(CKF_USER_PIN_LOCKED);
 	XProcUnLock(tokdata);
-	memcpy(tokdata->nv_token_data->user_pin_md5, hash_md5, MD5_HASH_SIZE);
+	memcpy(tokdata->user_pin_md5, hash_md5, MD5_HASH_SIZE);
 	rc = save_token_data(tokdata, sess->session_info.slotID);
 	if (rc != CKR_OK) {
 		TRACE_DEVEL("Failed to save token data.\n");
@@ -649,7 +649,7 @@ CK_RV SC_SetPIN(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
 		}
 		memcpy(tokdata->nv_token_data->user_pin_sha, new_hash_sha,
 		       SHA1_HASH_SIZE);
-		memcpy(tokdata->nv_token_data->user_pin_md5, hash_md5, MD5_HASH_SIZE);
+		memcpy(tokdata->user_pin_md5, hash_md5, MD5_HASH_SIZE);
 		tokdata->nv_token_data->token_info.flags &=
 			~(CKF_USER_PIN_TO_BE_CHANGED);
 		XProcUnLock(tokdata);
@@ -1013,8 +1013,7 @@ CK_RV SC_Login(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
 				  CKF_USER_PIN_FINAL_TRY |
 				  CKF_USER_PIN_COUNT_LOW);
 
-		compute_md5( tokdata, pPin, ulPinLen,
-			     tokdata->nv_token_data->user_pin_md5 );
+		compute_md5( tokdata, pPin, ulPinLen, tokdata->user_pin_md5 );
 		memset(tokdata->nv_token_data->so_pin_md5, 0x0, MD5_HASH_SIZE);
 
 		rc = load_masterkey_user(tokdata);
@@ -1068,7 +1067,7 @@ CK_RV SC_Login(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
 
 		compute_md5(tokdata, pPin, ulPinLen,
 			    tokdata->nv_token_data->so_pin_md5);
-		memset(tokdata->nv_token_data->user_pin_md5, 0x0, MD5_HASH_SIZE);
+		memset(tokdata->user_pin_md5, 0x0, MD5_HASH_SIZE);
 
 		rc = load_masterkey_so(tokdata);
 		if (rc != CKR_OK)
@@ -1127,7 +1126,7 @@ CK_RV SC_Logout(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession)
 		goto done;
 	}
 
-	memset(tokdata->nv_token_data->user_pin_md5, 0x0, MD5_HASH_SIZE);
+	memset(tokdata->user_pin_md5, 0x0, MD5_HASH_SIZE);
 	memset(tokdata->nv_token_data->so_pin_md5, 0x0, MD5_HASH_SIZE);
 
 	object_mgr_purge_private_token_objects(tokdata);

--- a/usr/lib/pkcs11/common/new_host.c
+++ b/usr/lib/pkcs11/common/new_host.c
@@ -688,7 +688,7 @@ CK_RV SC_SetPIN(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
 			goto done;
 		}
 		memcpy(tokdata->nv_token_data->so_pin_sha, new_hash_sha, SHA1_HASH_SIZE);
-		memcpy(tokdata->nv_token_data->so_pin_md5, hash_md5, MD5_HASH_SIZE);
+		memcpy(tokdata->so_pin_md5, hash_md5, MD5_HASH_SIZE);
 		tokdata->nv_token_data->token_info.flags &= ~(CKF_SO_PIN_TO_BE_CHANGED);
 		XProcUnLock(tokdata);
 		rc = save_token_data(tokdata, sess->session_info.slotID);
@@ -1014,7 +1014,7 @@ CK_RV SC_Login(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
 				  CKF_USER_PIN_COUNT_LOW);
 
 		compute_md5( tokdata, pPin, ulPinLen, tokdata->user_pin_md5 );
-		memset(tokdata->nv_token_data->so_pin_md5, 0x0, MD5_HASH_SIZE);
+		memset(tokdata->so_pin_md5, 0x0, MD5_HASH_SIZE);
 
 		rc = load_masterkey_user(tokdata);
 		if (rc != CKR_OK){
@@ -1065,8 +1065,7 @@ CK_RV SC_Login(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
 		*flags &= ~(CKF_SO_PIN_LOCKED | CKF_SO_PIN_FINAL_TRY |
 			    CKF_SO_PIN_COUNT_LOW);
 
-		compute_md5(tokdata, pPin, ulPinLen,
-			    tokdata->nv_token_data->so_pin_md5);
+		compute_md5(tokdata, pPin, ulPinLen, tokdata->so_pin_md5);
 		memset(tokdata->user_pin_md5, 0x0, MD5_HASH_SIZE);
 
 		rc = load_masterkey_so(tokdata);
@@ -1127,7 +1126,7 @@ CK_RV SC_Logout(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession)
 	}
 
 	memset(tokdata->user_pin_md5, 0x0, MD5_HASH_SIZE);
-	memset(tokdata->nv_token_data->so_pin_md5, 0x0, MD5_HASH_SIZE);
+	memset(tokdata->so_pin_md5, 0x0, MD5_HASH_SIZE);
 
 	object_mgr_purge_private_token_objects(tokdata);
 

--- a/usr/lib/pkcs11/common/utility.c
+++ b/usr/lib/pkcs11/common/utility.c
@@ -529,7 +529,7 @@ CK_RV init_token_data(STDLL_TokData_t *tokdata, CK_SLOT_ID slot_id)
 	memcpy(tokdata->nv_token_data->so_pin_sha, default_so_pin_sha, SHA1_HASH_SIZE);
 
 	memset(tokdata->user_pin_md5, 0x0, MD5_HASH_SIZE);
-	memcpy(tokdata->nv_token_data->so_pin_md5, default_so_pin_md5, MD5_HASH_SIZE);
+	memcpy(tokdata->so_pin_md5, default_so_pin_md5, MD5_HASH_SIZE);
 
 	memcpy(tokdata->nv_token_data->next_token_object_name, "00000000", 8);
 

--- a/usr/lib/pkcs11/common/utility.c
+++ b/usr/lib/pkcs11/common/utility.c
@@ -528,7 +528,7 @@ CK_RV init_token_data(STDLL_TokData_t *tokdata, CK_SLOT_ID slot_id)
 	       SHA1_HASH_SIZE);
 	memcpy(tokdata->nv_token_data->so_pin_sha, default_so_pin_sha, SHA1_HASH_SIZE);
 
-	memset(tokdata->nv_token_data->user_pin_md5, 0x0, MD5_HASH_SIZE);
+	memset(tokdata->user_pin_md5, 0x0, MD5_HASH_SIZE);
 	memcpy(tokdata->nv_token_data->so_pin_md5, default_so_pin_md5, MD5_HASH_SIZE);
 
 	memcpy(tokdata->nv_token_data->next_token_object_name, "00000000", 8);

--- a/usr/lib/pkcs11/common/utility.c
+++ b/usr/lib/pkcs11/common/utility.c
@@ -554,7 +554,7 @@ CK_RV init_token_data(STDLL_TokData_t *tokdata, CK_SLOT_ID slot_id)
 		//
 		// FIXME: erase the token object index file (and all token objects)
 		//
-		rc = generate_master_key(tokdata, tokdata->nv_token_data->master_key);
+		rc = generate_master_key(tokdata, tokdata->master_key);
 		if (rc != CKR_OK) {
 			TRACE_DEVEL("generate_master_key failed.\n");
 			return CKR_FUNCTION_FAILED;

--- a/usr/lib/pkcs11/ep11_stdll/new_host.c
+++ b/usr/lib/pkcs11/ep11_stdll/new_host.c
@@ -628,7 +628,7 @@ CK_RV SC_SetPIN(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession, CK_CHAR_P
 			goto done;
 		}
 		memcpy(tokdata->nv_token_data->so_pin_sha, new_hash_sha, SHA1_HASH_SIZE);
-		memcpy(tokdata->nv_token_data->so_pin_md5, hash_md5, MD5_HASH_SIZE);
+		memcpy(tokdata->so_pin_md5, hash_md5, MD5_HASH_SIZE);
 		tokdata->nv_token_data->token_info.flags &= ~(CKF_SO_PIN_TO_BE_CHANGED);
 		XProcUnLock(tokdata);
 		rc = save_token_data(tokdata, sess->session_info.slotID);
@@ -937,7 +937,7 @@ CK_RV SC_Login(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
 				  CKF_USER_PIN_COUNT_LOW);
 
 		compute_md5(tokdata, pPin, ulPinLen, tokdata->user_pin_md5);
-		memset(tokdata->nv_token_data->so_pin_md5, 0x0, MD5_HASH_SIZE);
+		memset(tokdata->so_pin_md5, 0x0, MD5_HASH_SIZE);
 
 		rc = load_masterkey_user(tokdata);
 		if (rc != CKR_OK){
@@ -972,8 +972,7 @@ CK_RV SC_Login(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
 		*flags &= ~(CKF_SO_PIN_LOCKED | CKF_SO_PIN_FINAL_TRY |
 			    CKF_SO_PIN_COUNT_LOW);
 
-		compute_md5(tokdata, pPin, ulPinLen,
-			    tokdata->nv_token_data->so_pin_md5);
+		compute_md5(tokdata, pPin, ulPinLen, tokdata->so_pin_md5);
 		memset(tokdata->user_pin_md5, 0x0, MD5_HASH_SIZE);
 
 		rc = load_masterkey_so(tokdata);
@@ -1024,7 +1023,7 @@ CK_RV SC_Logout(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession)
 		TRACE_DEVEL("session_mgr_logout_all failed.\n");
 
 	memset(tokdata->user_pin_md5, 0x0, MD5_HASH_SIZE);
-	memset(tokdata->nv_token_data->so_pin_md5, 0x0, MD5_HASH_SIZE);
+	memset(tokdata->so_pin_md5, 0x0, MD5_HASH_SIZE);
 
 	object_mgr_purge_private_token_objects(tokdata);
 

--- a/usr/lib/pkcs11/ep11_stdll/new_host.c
+++ b/usr/lib/pkcs11/ep11_stdll/new_host.c
@@ -496,7 +496,7 @@ CK_RV SC_InitPIN(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
 	tokdata->nv_token_data->token_info.flags &= ~(CKF_USER_PIN_TO_BE_CHANGED);
 	tokdata->nv_token_data->token_info.flags &= ~(CKF_USER_PIN_LOCKED);
 	XProcUnLock(tokdata);
-	memcpy(tokdata->nv_token_data->user_pin_md5, hash_md5, MD5_HASH_SIZE);
+	memcpy(tokdata->user_pin_md5, hash_md5, MD5_HASH_SIZE);
 	rc = save_token_data(tokdata, sess->session_info.slotID);
 	if (rc != CKR_OK) {
 		TRACE_DEVEL("Failed to save token data.\n");
@@ -588,7 +588,7 @@ CK_RV SC_SetPIN(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession, CK_CHAR_P
 		}
 		memcpy(tokdata->nv_token_data->user_pin_sha, new_hash_sha,
 		       SHA1_HASH_SIZE);
-		memcpy(tokdata->nv_token_data->user_pin_md5, hash_md5,
+		memcpy(tokdata->user_pin_md5, hash_md5,
 		       MD5_HASH_SIZE);
 		tokdata->nv_token_data->token_info.flags &=
 			~(CKF_USER_PIN_TO_BE_CHANGED);
@@ -936,8 +936,7 @@ CK_RV SC_Login(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
 				  CKF_USER_PIN_FINAL_TRY |
 				  CKF_USER_PIN_COUNT_LOW);
 
-		compute_md5(tokdata, pPin, ulPinLen,
-			    tokdata->nv_token_data->user_pin_md5);
+		compute_md5(tokdata, pPin, ulPinLen, tokdata->user_pin_md5);
 		memset(tokdata->nv_token_data->so_pin_md5, 0x0, MD5_HASH_SIZE);
 
 		rc = load_masterkey_user(tokdata);
@@ -975,7 +974,7 @@ CK_RV SC_Login(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
 
 		compute_md5(tokdata, pPin, ulPinLen,
 			    tokdata->nv_token_data->so_pin_md5);
-		memset(tokdata->nv_token_data->user_pin_md5, 0x0, MD5_HASH_SIZE);
+		memset(tokdata->user_pin_md5, 0x0, MD5_HASH_SIZE);
 
 		rc = load_masterkey_so(tokdata);
 		if (rc != CKR_OK)
@@ -1024,7 +1023,7 @@ CK_RV SC_Logout(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession)
 	if (rc != CKR_OK)
 		TRACE_DEVEL("session_mgr_logout_all failed.\n");
 
-	memset(tokdata->nv_token_data->user_pin_md5, 0x0, MD5_HASH_SIZE);
+	memset(tokdata->user_pin_md5, 0x0, MD5_HASH_SIZE);
 	memset(tokdata->nv_token_data->so_pin_md5, 0x0, MD5_HASH_SIZE);
 
 	object_mgr_purge_private_token_objects(tokdata);

--- a/usr/lib/pkcs11/icsf_stdll/icsf_specific.c
+++ b/usr/lib/pkcs11/icsf_stdll/icsf_specific.c
@@ -737,7 +737,7 @@ CK_RV icsftok_init_pin(STDLL_TokData_t *tokdata, SESSION *sess,
 	if (slot_data[sid]->mech == ICSF_CFG_MECH_SIMPLE) {
 		sprintf(fname, "%s/MK_USER", get_pk_dir(pk_dir_buf));
 
-		rc = secure_masterkey(tokdata->nv_token_data->master_key,
+		rc = secure_masterkey(tokdata->master_key,
 				      AES_KEY_SIZE_256, pPin,
 				      ulPinLen, fname);
 		if (rc != CKR_OK) {
@@ -803,7 +803,7 @@ CK_RV icsftok_set_pin(STDLL_TokData_t *tokdata, SESSION *sess,
 		/* if using simple auth, encrypt masterkey with new pin */
 		if (slot_data[sid]->mech == ICSF_CFG_MECH_SIMPLE) {
 			sprintf (fname, "%s/MK_USER", get_pk_dir(pk_dir_buf));
-			rc = secure_masterkey(tokdata->nv_token_data->master_key,
+			rc = secure_masterkey(tokdata->master_key,
 					      AES_KEY_SIZE_256,
 					      pNewPin, ulNewLen, fname);
 			if (rc != CKR_OK) {
@@ -841,7 +841,7 @@ CK_RV icsftok_set_pin(STDLL_TokData_t *tokdata, SESSION *sess,
 			 * if using simle auth, encrypt masterkey with new pin
 			 */
 			sprintf (fname, "%s/MK_SO", get_pk_dir(pk_dir_buf));
-			rc = secure_masterkey(tokdata->nv_token_data->master_key,
+			rc = secure_masterkey(tokdata->master_key,
 					      AES_KEY_SIZE_256,
 					      pNewPin, ulNewLen, fname);
 			if (rc != CKR_OK) {
@@ -889,7 +889,7 @@ LDAP *getLDAPhandle(STDLL_TokData_t *tokdata, CK_SLOT_ID slot_id)
 	if (slot_data[slot_id]->mech == ICSF_CFG_MECH_SIMPLE) {
 		TRACE_INFO("Using SIMPLE auth with slot ID: %lu\n", slot_id);
 		/* get racf passwd */
-		rc = get_racf(tokdata->nv_token_data->master_key,
+		rc = get_racf(tokdata->master_key,
 			      AES_KEY_SIZE_256, racfpwd, &racflen);
 		if (rc != CKR_OK) {
 			TRACE_DEVEL("Failed to get racf passwd.\n");
@@ -1164,7 +1164,7 @@ CK_RV icsftok_login(STDLL_TokData_t *tokdata, SESSION *sess,
 		if (slot_data[slot_id]->mech == ICSF_CFG_MECH_SIMPLE) {
 			sprintf(fname, "%s/MK_USER", get_pk_dir(pk_dir_buf));
 			rc = get_masterkey(pPin, ulPinLen, fname,
-					   tokdata->nv_token_data->master_key,
+					   tokdata->master_key,
 					   &mklen);
 			if (rc != CKR_OK) {
 				TRACE_DEVEL("Failed to load master key.\n");
@@ -1186,7 +1186,7 @@ CK_RV icsftok_login(STDLL_TokData_t *tokdata, SESSION *sess,
 			/* now load the master key */
 			sprintf(fname, "%s/MK_SO", get_pk_dir(pk_dir_buf));
 			rc = get_masterkey(pPin, ulPinLen, fname,
-					   tokdata->nv_token_data->master_key,
+					   tokdata->master_key,
 					   &mklen);
 			if (rc != CKR_OK) {
 				TRACE_DEVEL("Failed to load master key.\n");

--- a/usr/lib/pkcs11/icsf_stdll/new_host.c
+++ b/usr/lib/pkcs11/icsf_stdll/new_host.c
@@ -884,7 +884,7 @@ CK_RV SC_Logout(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession)
 
 
 	memset(tokdata->user_pin_md5, 0x0, MD5_HASH_SIZE);
-	memset(tokdata->nv_token_data->so_pin_md5, 0x0, MD5_HASH_SIZE);
+	memset(tokdata->so_pin_md5, 0x0, MD5_HASH_SIZE);
 
 	object_mgr_purge_private_token_objects(tokdata);
 

--- a/usr/lib/pkcs11/icsf_stdll/new_host.c
+++ b/usr/lib/pkcs11/icsf_stdll/new_host.c
@@ -883,7 +883,7 @@ CK_RV SC_Logout(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession)
 		TRACE_DEVEL("session_mgr_logout_all failed.\n");
 
 
-	memset(tokdata->nv_token_data->user_pin_md5, 0x0, MD5_HASH_SIZE);
+	memset(tokdata->user_pin_md5, 0x0, MD5_HASH_SIZE);
 	memset(tokdata->nv_token_data->so_pin_md5, 0x0, MD5_HASH_SIZE);
 
 	object_mgr_purge_private_token_objects(tokdata);

--- a/usr/sbin/pkcsslotd/Makefile.am
+++ b/usr/sbin/pkcsslotd/Makefile.am
@@ -3,7 +3,7 @@ BUILT_SOURCES = parser.h
 AM_YFLAGS = -v -d
 EXTRA_DIST=opencryptoki.conf
 
-pkcsslotd_LDFLAGS = -lpthread
+pkcsslotd_LDFLAGS = -lpthread -lcrypto
 
 # Not all versions of automake observe sbinname_CFLAGS
 pkcsslotd_CFLAGS =  -DPROGRAM_NAME=\"$(@)\" \

--- a/usr/sbin/pkcsslotd/pkcsslotd.h
+++ b/usr/sbin/pkcsslotd/pkcsslotd.h
@@ -44,6 +44,12 @@
 
 #endif /* DEV */
 
+#define HASH_SHA1   1
+#define HASH_MD5    2
+#define compute_md5(a,b,c)      compute_hash(HASH_MD5,b,a,c)
+
+int compute_hash(int hash_type, int buf_size, char* buf, char* digest);
+
 /********************
  * Global Variables *
  ********************/


### PR DESCRIPTION
1. Fix migration problem due to incompatible size of shared memory objects.
    Keep the old TOKEN_DATA structure to ensure shared memory objects has the same size
    as  before. Additional data are moved the the token individual data storage.
2. Added some logic to check for duplicate token directories at slot daemon start.
    Established hash table for token directories to check for redundancy.
