### PR TITLE
Add locking mechanism as alternative to transactional memory

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -50,7 +50,7 @@ if test "x$YACC" = "xyacc"; then
     fi
 fi
 
-AC_CHECK_LIB([itm], [_ITM_commitTransaction], [], AC_MSG_ERROR(["libitm couldn't be found"]))
+AC_CHECK_LIB([itm], [_ITM_commitTransaction], [itm=yes], [itm=no])
 
 dnl Define custom variables
 
@@ -134,6 +134,13 @@ AC_ARG_ENABLE([pkcsep11_migrate],
 	AS_HELP_STRING([--enable-pkcsep11_migrate],[build pkcsep11_migrate (EP11 token key migration tool) @<:@default=enabled if EP11 library is present@:>@]),
 	[],
 	[enable_pkcsep11_migrate=check])
+
+dnl --- locking support
+AC_ARG_ENABLE([locks],
+	AS_HELP_STRING([--enable-locks],[build opencryptoki with locks instead of transactional memory @<:@default=disabled@:>@]),
+	[enable_locks=yes],
+	[enable_locks=no])
+
 dnl ---
 dnl --- Check for external software
 dnl --- Define what to check based on enabled features
@@ -559,16 +566,30 @@ if test "x$enable_pkcsep11_migrate" = "xyes"; then
 		enable_pkcsep11_migrate=no
 	fi
 fi
-
 if test "x$enable_pkcsep11_migrate" != "xno" -a "x$with_zcrypt" != "xno"; then
         enable_pkcsep11_migrate=yes
 else
         enable_pkcsep11_migrate=no
 fi
-
 AM_CONDITIONAL([ENABLE_PKCSEP11_MIGRATE], [test "x$enable_pkcsep11_migrate" = "xyes"])
 
-CFLAGS="$CFLAGS -DPKCS64 -D_XOPEN_SOURCE=600 -Wall -Wno-pointer-sign -fgnu-tm"
+dnl --- enable_locks
+if test "x$enable_locks" = "xno"; then
+	if test "x$itm" != "xyes"; then
+		AC_MSG_ERROR([in order to build opencryptoki with transactional memory,
+libitm and gcc>=4.7 is required])
+    fi
+fi
+if test "x$enable_locks" != "xno"; then
+        enable_locks=yes
+        CFLAGS="$CFLAGS -DENABLE_LOCKS"
+else
+        enable_locks=no
+        CFLAGS="$CFLAGS -fgnu-tm"
+fi
+AM_CONDITIONAL([ENABLE_LOCKS], [test "x$enable_locks" = "xyes"])
+
+CFLAGS="$CFLAGS -DPKCS64 -D_XOPEN_SOURCE=600 -Wall -Wno-pointer-sign"
 
 CFLAGS+=' -DCONFIG_PATH=\"$(localstatedir)/lib/opencryptoki\" -DSBIN_PATH=\"$(sbindir)\" -DLIB_PATH=\"$(libdir)\" -DLOCKDIR_PATH=\"$(lockdir)\" -DOCK_CONFDIR=\"$(sysconfdir)/opencryptoki\" -DOCK_LOGDIR=\"$(logdir)\"'
 

--- a/usr/lib/pkcs11/api/Makefile.am
+++ b/usr/lib/pkcs11/api/Makefile.am
@@ -4,18 +4,28 @@ SO_CURRENT=0
 SO_REVISION=0
 SO_AGE=0
 
-opencryptoki_libopencryptoki_la_LDFLAGS = -shared -Wl,-Bsymbolic -lc -ldl \
-					  -lpthread -litm -version-info   \
-					  $(SO_CURRENT):$(SO_REVISION):$(SO_AGE)
-
 # Not all versions of automake observe libname_CFLAGS
 opencryptoki_libopencryptoki_la_CFLAGS = -DAPI -DDEV -D_THREAD_SAFE 		\
 					 -fPIC -I../. -I../../../include/pkcs11 \
 					 -I ../common -DSTDLL_NAME=\"api\"
 
+if ENABLE_LOCKS
+opencryptoki_libopencryptoki_la_LDFLAGS = -shared -Wl,-Bsymbolic -lc -ldl \
+					  -lpthread -version-info   \
+					  $(SO_CURRENT):$(SO_REVISION):$(SO_AGE)
+
 opencryptoki_libopencryptoki_la_SOURCES = api_interface.c shrd_mem.c \
 					  socket_client.c apiutil.c \
-					  ../common/btree.c ../common/trace.c
+					  ../common/trace.c ../common/lock_btree.c
+else
+opencryptoki_libopencryptoki_la_LDFLAGS = -shared -Wl,-Bsymbolic -lc -ldl \
+					  -lpthread -litm -version-info   \
+					  $(SO_CURRENT):$(SO_REVISION):$(SO_AGE)
+
+opencryptoki_libopencryptoki_la_SOURCES = api_interface.c shrd_mem.c \
+					  socket_client.c apiutil.c \
+					  ../common/trace.c ../common/btree.c
+endif
 
 install-data-hook:
 	$(MKDIR_P) $(DESTDIR)$(libdir)/opencryptoki/stdll

--- a/usr/lib/pkcs11/cca_stdll/Makefile.am
+++ b/usr/lib/pkcs11/cca_stdll/Makefile.am
@@ -14,8 +14,53 @@ opencryptoki_stdll_libpkcs11_cca_la_CFLAGS = -DLINUX -DNOCDMF		\
 					     -I../common		\
 					     -DSTDLL_NAME=\"ccatok\"
 
+if ENABLE_LOCKS
 opencryptoki_stdll_libpkcs11_cca_la_LDFLAGS = -shared -Wl,-Bsymbolic	\
-					      -lcrypto -lpthread -litm	\
+					      -lcrypto -lpthread	\
+					      -nostartfiles		\
+					      -Wl,-soname,$@		\
+					      -lrt
+
+opencryptoki_stdll_libpkcs11_cca_la_SOURCES = ../common/asn1.c		\
+					      ../common/lock_btree.c	\
+					      ../common/dig_mgr.c	\
+					      ../common/hwf_obj.c	\
+					      ../common/trace.c		\
+					      ../common/key.c		\
+					      ../common/mech_dh.c	\
+					      ../common/mech_rng.c	\
+					      ../common/new_host.c	\
+					      ../common/sign_mgr.c	\
+					      ../common/cert.c		\
+					      ../common/dp_obj.c	\
+					      ../common/mech_aes.c	\
+					      ../common/mech_rsa.c	\
+					      ../common/mech_ec.c	\
+					      ../common/obj_mgr.c	\
+					      ../common/template.c	\
+					      ../common/data_obj.c	\
+					      ../common/encr_mgr.c	\
+					      ../common/key_mgr.c	\
+					      ../common/mech_md2.c	\
+					      ../common/mech_sha.c	\
+					      ../common/object.c	\
+					      ../common/decr_mgr.c	\
+					      ../common/globals.c	\
+					      ../common/loadsave.c	\
+					      ../common/utility.c	\
+					      ../common/mech_des.c	\
+					      ../common/mech_des3.c	\
+					      ../common/mech_md5.c	\
+					      ../common/mech_ssl3.c	\
+					      ../common/lock_sess_mgr.c	\
+					      ../common/verify_mgr.c	\
+					      ../common/p11util.c	\
+					      ../common/sw_crypt.c	\
+					      ../common/shared_memory.c	\
+					      cca_specific.c
+else
+opencryptoki_stdll_libpkcs11_cca_la_LDFLAGS = -shared -Wl,-Bsymbolic	\
+					      -lcrypto -lpthread -litm \
 					      -nostartfiles		\
 					      -Wl,-soname,$@		\
 					      -lrt
@@ -57,6 +102,7 @@ opencryptoki_stdll_libpkcs11_cca_la_SOURCES = ../common/asn1.c		\
 					      ../common/sw_crypt.c	\
 					      ../common/shared_memory.c	\
 					      cca_specific.c
+endif
 
 noinst_HEADERS = defs.h		\
 		 csulincl.h	\

--- a/usr/lib/pkcs11/common/lock_btree.c
+++ b/usr/lib/pkcs11/common/lock_btree.c
@@ -1,0 +1,359 @@
+/*
+ * COPYRIGHT (c) International Business Machines Corp. 2005-2017
+ *
+ * This program is provided under the terms of the Common Public License,
+ * version 1.0 (CPL-1.0). Any use, reproduction or distribution for this
+ * software constitutes recipient's acceptance of CPL-1.0 terms which can be
+ * found in the file LICENSE file or at
+ * https://opensource.org/licenses/cpl1.0.php
+ */
+
+/*
+ * btree.c
+ * Author: Kent Yoder <yoder1@us.ibm.com>
+ *
+ * v1 Binary tree functions 4/5/2011
+ *
+ */
+
+
+#include <stdio.h>
+#include <malloc.h>
+#include <pthread.h>
+
+#include "pkcs11types.h"
+#include "local_types.h"
+#include "trace.h"
+
+#define GET_NODE_HANDLE(n)	get_node_handle(n, 1)
+#define TREE_DUMP(t)		tree_dump((t)->top, 0)
+
+pthread_rwlock_t btree_rwlock = PTHREAD_RWLOCK_INITIALIZER;
+
+/*
+ * bt_get_node
+ *
+ * Return a node of the tree @t with position @node_num. If the node has been
+ * freed or doesn't exist, return NULL
+ */
+struct btnode *bt_get_node(struct btree *t, unsigned long node_num)
+{
+    struct btnode *temp = t->top;
+    unsigned long i;
+
+    if (pthread_rwlock_rdlock(&btree_rwlock)) {
+        TRACE_ERROR("Read Lock failed.\n");
+        return NULL;
+    }
+
+    if (!node_num || node_num > t->size)
+        return NULL;
+    if (node_num == 1) {
+        temp = t->top;
+        goto done;
+    }
+
+    i = node_num;
+    while (i != 1) {
+        if (i & 1) {
+            /* If the bit is 1, traverse right*/
+            temp = temp->right;
+        } else {
+            /* If the bit is 0, traverse left*/
+            temp = temp->left;
+        }
+        i >>= 1;
+    }
+
+done:
+    pthread_rwlock_unlock(&btree_rwlock);
+    return ((temp->flags & BT_FLAG_FREE) ? NULL : temp);
+}
+
+void *bt_get_node_value(struct btree *t, unsigned long node_num)
+{
+    struct btnode *n = bt_get_node(t, node_num);
+
+    return ((n) ? n->value : NULL);
+}
+
+/* create a new node and set @parent_ptr to its location */
+static struct btnode *node_create(struct btnode **child_ptr,
+                                  struct btnode *parent_ptr, void *value)
+{
+    struct btnode *node = malloc(sizeof(struct btnode));
+
+    if (!node)
+        return NULL;
+
+    node->left = node->right = NULL;
+    node->flags = 0;
+    node->value = value;
+    *child_ptr = node;
+    node->parent = parent_ptr;
+
+    return node;
+}
+
+/*
+ * get_node_handle
+ *
+ * Recursively construct a node's handle by tracing its path back to the root
+ * node
+ */
+static unsigned long get_node_handle(struct btnode *node,
+                                     unsigned long handle_so_far)
+{
+    if (!node->parent)
+        return handle_so_far;
+    else if (node->parent->left == node)
+        return get_node_handle(node->parent, handle_so_far << 1);
+    else
+        return get_node_handle(node->parent, (handle_so_far << 1) + 1);
+}
+
+/* return node number (handle) of newly created node, or 0 for failure */
+unsigned long bt_node_add(struct btree *t, void *value)
+{
+    struct btnode *temp = t->top;
+    unsigned long new_node_index;
+
+    if (pthread_rwlock_wrlock(&btree_rwlock)) {
+        TRACE_ERROR("Write Lock failed.\n");
+        return 0;
+    }
+
+    if (!temp) { /* no root node yet exists, create it */
+        t->size = 1;
+        if (!node_create(&t->top, NULL, value)) {
+            pthread_rwlock_unlock(&btree_rwlock);
+            return 0;
+        }
+
+        pthread_rwlock_unlock(&btree_rwlock);
+        return 1;
+    } else if (t->free_list) {
+        /* there's a node on the free list,
+         * use it instead of mallocing new
+         */
+        temp = t->free_list;
+        t->free_list = temp->value;
+        temp->value = value;
+        temp->flags &= (~BT_FLAG_FREE);
+        t->free_nodes--;
+        new_node_index = GET_NODE_HANDLE(temp);
+        pthread_rwlock_unlock(&btree_rwlock);
+        return new_node_index;
+    }
+
+    new_node_index = t->size + 1;
+
+    while (new_node_index != 1) {
+        if (new_node_index & 1) {
+            if (!temp->right) {
+                if (!(node_create(&temp->right,
+                                temp,
+                                value))) {
+                    pthread_rwlock_unlock(&btree_rwlock);
+                    return 0;
+                }
+                break;
+            } else {
+                /* If the bit is 1, traverse right */
+                temp = temp->right;
+            }
+        } else {
+            if (!temp->left) {
+                if (!(node_create(&temp->left,
+                                temp,
+                                value))) {
+                    pthread_rwlock_unlock(&btree_rwlock);
+                    return 0;
+                }
+                break;
+            } else {
+                /* If the bit is 0, traverse left */
+                temp = temp->left;
+            }
+        }
+
+        new_node_index >>= 1;
+    }
+
+    t->size++;
+
+    pthread_rwlock_unlock(&btree_rwlock);
+    return t->size;
+}
+
+void tree_dump(struct btnode *n, int depth)
+{
+    int i;
+
+    if (!n)
+        return;
+
+    for (i = 0; i < depth; i++)
+        printf("  ");
+
+    if (n->flags & BT_FLAG_FREE)
+        printf("`- (deleted node)\n");
+    else
+        printf("`- %p\n", n->value);
+
+    tree_dump(n->left, depth+1);
+    tree_dump(n->right, depth+1);
+}
+
+/*
+ * bt_node_free
+ *
+ * Move @node_num in tree @t to the free list, calling @delete_func on its 
+ * value first.
+ *
+ * Note that bt_get_node will return NULL if the node is already on the free
+ * list, so no double freeing can occur
+ */
+struct btnode *bt_node_free(struct btree *t, unsigned long node_num,
+                            void (*delete_func)(void *))
+{
+    struct btnode *node = bt_get_node(t, node_num);
+
+    if (pthread_rwlock_wrlock(&btree_rwlock)) {
+        TRACE_ERROR("Write Lock failed.\n");
+        return NULL;
+    }
+
+    if (node) {
+        if (delete_func)
+            (*delete_func)(node->value);
+
+        node->flags |= BT_FLAG_FREE;
+
+        /* add node to the free list,
+         * which is chained by using
+         * the value pointer
+         */
+        node->value = t->free_list;
+        t->free_list = node;
+        t->free_nodes++;
+    }
+
+    pthread_rwlock_unlock(&btree_rwlock);
+    return node;
+}
+
+/* bt_is_empty
+ *
+ * return 0 if binary tree has at least 1 node in use, !0 otherwise
+ */
+int bt_is_empty(struct btree *t)
+{
+    CK_RV rc;
+
+    if (pthread_rwlock_rdlock(&btree_rwlock)) {
+        TRACE_ERROR("Write Lock failed.\n");
+        return 0;
+    }
+
+    rc = (t->free_nodes == t->size);
+
+    pthread_rwlock_unlock(&btree_rwlock);
+
+    return rc;
+}
+
+/* bt_nodes_in_use
+ *
+ * return the number of nodes in the binary tree that are not free'd
+ */
+unsigned long bt_nodes_in_use(struct btree *t)
+{
+    CK_RV rc;
+
+    if (pthread_rwlock_rdlock(&btree_rwlock)) {
+        TRACE_ERROR("Write Lock failed.\n");
+        return -1;
+    }
+
+    rc = (t->size - t->free_nodes);
+
+    pthread_rwlock_unlock(&btree_rwlock);
+
+    return rc;
+}
+
+/* bt_for_each_node
+ *
+ * For each non-free'd node in the tree, run @func on it
+ *
+ * @func:
+ *  p1 is the node's value
+ *  p2 is the node's handle
+ *  p3 is passed through this function for the caller
+ */
+void bt_for_each_node(struct btree *t,
+                      void (*func)(void *p1, unsigned long p2, void *p3),
+                      void *p3)
+{
+    unsigned int i;
+    struct btnode *node;
+
+    for (i = 1; i < t->size+1; i++) {
+        node = bt_get_node(t, i);
+
+        if (node) {
+            (*func)(node->value, i, p3);
+        }
+    }
+}
+
+/* bt_destroy
+ *
+ * Walk a binary tree backwards (largest index to smallest), deleting nodes along the way.
+ * Call @func on node->value before freeing the node.
+ */
+void bt_destroy(struct btree *t, void (*func)(void *))
+{
+    unsigned long i;
+    struct btnode *temp;
+
+    if (pthread_rwlock_wrlock(&btree_rwlock)) {
+        TRACE_ERROR("Write Lock failed.\n");
+        return;
+    }
+
+    while (t->size) {
+        temp = t->top;
+        i = t->size;
+        while (i != 1) {
+            if (i & 1) {
+                /* If the bit is 1, traverse right */
+                temp = temp->right;
+            } else {
+                /* If the bit is 0, traverse left */
+                temp = temp->left;
+            }
+            i >>= 1;
+        }
+
+        /*
+         * The value pointed by value in a node marked as freed points
+         * to the next node element in free_list and it shouldn't be
+         * freed here because the loop will iterate through each node,
+         * freed or not.
+         */
+        if (func && !(temp->flags & BT_FLAG_FREE))
+            (*func)(temp->value);
+
+        free(temp);
+        t->size--;
+    }
+
+    /* the tree is gone now, clear all the other variables */
+    t->top = NULL;
+    t->free_list = NULL;
+    t->free_nodes = 0;
+
+    pthread_rwlock_unlock(&btree_rwlock);
+}

--- a/usr/lib/pkcs11/common/lock_sess_mgr.c
+++ b/usr/lib/pkcs11/common/lock_sess_mgr.c
@@ -1,0 +1,988 @@
+/*
+ * COPYRIGHT (c) International Business Machines Corp. 2001-2017
+ *
+ * This program is provided under the terms of the Common Public License,
+ * version 1.0 (CPL-1.0). Any use, reproduction or distribution for this
+ * software constitutes recipient's acceptance of CPL-1.0 terms which can be
+ * found in the file LICENSE file or at
+ * https://opensource.org/licenses/cpl1.0.php
+ */
+
+// File:  session.c
+//
+// Session manager related functions
+//
+#include <stdlib.h>
+#include <string.h>  // for memcmp() et al
+#include <pthread.h>
+
+#include "pkcs11types.h"
+#include "local_types.h"
+#include "defs.h"
+#include "host_defs.h"
+#include "h_extern.h"
+#include "tok_spec_struct.h"
+#include "trace.h"
+
+pthread_rwlock_t sess_list_rwlock = PTHREAD_RWLOCK_INITIALIZER;
+// session_mgr_find()
+//
+// search for the specified session.  returning a pointer to the session
+// might be dangerous, but performs well
+//
+// Returns:  SESSION * or NULL
+//
+SESSION *
+session_mgr_find( CK_SESSION_HANDLE handle )
+{
+   SESSION  * result = NULL;
+
+   if (!handle) {
+      return NULL;
+   }
+
+   result = bt_get_node_value(&sess_btree, handle);
+
+   return result;
+}
+
+
+// session_mgr_new()
+//
+// creates a new session structure and adds it to the process's list
+// of sessions
+//
+// Args:  CK_ULONG      flags : session flags                   (INPUT)
+//        SESSION **     sess : new session pointer             (OUTPUT)
+//
+// Returns:  CK_RV
+//
+CK_RV
+session_mgr_new( CK_ULONG flags, CK_SLOT_ID slot_id, CK_SESSION_HANDLE_PTR phSession )
+{
+   SESSION  * new_session  = NULL;
+   CK_BBOOL   user_session = FALSE;
+   CK_BBOOL   so_session   = FALSE;
+   CK_RV      rc = CKR_OK;
+
+
+   new_session = (SESSION *)malloc(sizeof(SESSION));
+   if (!new_session) {
+      TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
+      rc = CKR_HOST_MEMORY;
+      goto done;
+   }
+
+   memset( new_session, 0x0, sizeof(SESSION) );
+
+   // find an unused session handle.  session handles will wrap
+   // automatically...
+   //
+   new_session->session_info.slotID        = slot_id;
+   new_session->session_info.flags         = flags;
+   new_session->session_info.ulDeviceError = 0;
+
+
+   // determine the login/logout status of the new session.  PKCS 11 requires
+   // that all sessions belonging to a process have the same login/logout status
+   //
+   so_session = session_mgr_so_session_exists();
+   user_session = session_mgr_user_session_exists();
+
+   // we don't have to worry about having a user and SO session at the same time.
+   // that is prevented in the login routine
+   //
+   if (user_session) {
+      if (new_session->session_info.flags & CKF_RW_SESSION)
+         new_session->session_info.state = CKS_RW_USER_FUNCTIONS;
+      else {
+         new_session->session_info.state = CKS_RO_USER_FUNCTIONS;
+         ro_session_count++;
+      }
+   }
+   else if (so_session) {
+      new_session->session_info.state = CKS_RW_SO_FUNCTIONS;
+   }
+   else {
+      if (new_session->session_info.flags & CKF_RW_SESSION)
+         new_session->session_info.state = CKS_RW_PUBLIC_SESSION;
+      else {
+         new_session->session_info.state = CKS_RO_PUBLIC_SESSION;
+         ro_session_count++;
+      }
+   }
+
+   *phSession = bt_node_add(&sess_btree, new_session);
+   if (*phSession == 0) {
+      rc = CKR_HOST_MEMORY;
+      /* new_session will be free'd below */
+   }
+
+done:
+   if (rc != CKR_OK && new_session != NULL){
+      TRACE_ERROR("Failed to add session to the btree.\n");
+      free( new_session );
+   }
+   return rc;
+}
+
+
+// session_mgr_so_session_exists()
+//
+// determines whether a RW_SO session exists for the specified process
+//
+// Returns:  TRUE or FALSE
+//
+CK_BBOOL session_mgr_so_session_exists(void)
+{
+    CK_BBOOL result;
+
+    /* we must acquire sess_list_rwlock in order to inspect glogal_login_state */
+    if (pthread_rwlock_rdlock(&sess_list_rwlock)) {
+        TRACE_ERROR("Read Lock failed.\n");
+        return FALSE;
+    }
+    result = (global_login_state == CKS_RW_SO_FUNCTIONS);
+    pthread_rwlock_unlock(&sess_list_rwlock);
+
+    return result;
+}
+
+
+// session_mgr_user_session_exists()
+//
+// determines whether a USER session exists for the specified process
+//
+// Returns:  TRUE or FALSE
+//
+CK_BBOOL
+session_mgr_user_session_exists( void )
+{
+    CK_BBOOL result;
+
+    /* we must acquire sess_list_rwlock in order to inspect glogal_login_state */
+    if (pthread_rwlock_rdlock(&sess_list_rwlock)) {
+        TRACE_ERROR("Read Lock failed.\n");
+        return FALSE;
+    }
+    result = ((global_login_state == CKS_RO_USER_FUNCTIONS) ||
+			  (global_login_state == CKS_RW_USER_FUNCTIONS));
+
+    pthread_rwlock_unlock(&sess_list_rwlock);
+
+    return result;
+}
+
+
+// session_mgr_public_session_exists()
+//
+// determines whether a PUBLIC session exists for the specified process
+//
+// Returns:  TRUE or FALSE
+//
+CK_BBOOL session_mgr_public_session_exists(void)
+{
+    CK_BBOOL result;
+
+    /* we must acquire sess_list_rwlock in order to inspect glogal_login_state */
+    if (pthread_rwlock_rdlock(&sess_list_rwlock)) {
+        TRACE_ERROR("Read Lock failed.\n");
+        return FALSE;
+    }
+    result = ((global_login_state == CKS_RO_PUBLIC_SESSION) ||
+			  (global_login_state == CKS_RW_PUBLIC_SESSION));
+
+    pthread_rwlock_unlock(&sess_list_rwlock);
+    
+    return result;
+}
+
+
+// session_mgr_readonly_exists()
+//
+// determines whether the specified process owns any read-only sessions.  this is useful
+// because the SO cannot log in if a read-only session exists.
+//
+CK_BBOOL session_mgr_readonly_session_exists(void)
+{
+    CK_BBOOL result;
+
+    /* we must acquire sess_list_rwlock in order to inspect ro_session_count */
+    if (pthread_rwlock_rdlock(&sess_list_rwlock)) {
+        TRACE_ERROR("Read Lock failed.\n");
+        return FALSE;
+    }
+
+    result = (ro_session_count > 0);
+
+    pthread_rwlock_unlock(&sess_list_rwlock);
+
+    return result;
+}
+
+
+// session_mgr_close_session()
+//
+// removes the specified session from the process' session list
+//
+// Args:   PROCESS *    proc  :  parent process
+//         SESSION * session  :  session to remove
+//
+// Returns:  TRUE on success else FALSE
+//
+CK_RV
+session_mgr_close_session( CK_SESSION_HANDLE handle )
+{
+    SESSION *sess;
+    CK_RV      rc = CKR_OK;
+
+    sess = bt_get_node_value(&sess_btree, handle);
+    if (!sess) {
+        TRACE_ERROR("%s\n", ock_err(ERR_SESSION_HANDLE_INVALID));
+        rc = CKR_SESSION_HANDLE_INVALID;
+        goto done;
+   }
+
+    if (pthread_rwlock_wrlock(&sess_list_rwlock)) {
+        TRACE_ERROR("Read Lock failed.\n");
+        return FALSE;
+    }
+    
+    object_mgr_purge_session_objects( sess, ALL );
+    
+    if ((sess->session_info.state == CKS_RO_PUBLIC_SESSION) ||
+		(sess->session_info.state == CKS_RO_USER_FUNCTIONS)) {
+        ro_session_count--;
+    }
+
+    /* Make sure this address is now invalid */
+    sess->handle = CK_INVALID_HANDLE;
+    
+    if (sess->find_list)
+        free(sess->find_list);
+
+    if (sess->encr_ctx.context)
+        free(sess->encr_ctx.context);
+
+    if (sess->encr_ctx.mech.pParameter)
+        free(sess->encr_ctx.mech.pParameter);
+
+    if (sess->decr_ctx.context)
+        free(sess->decr_ctx.context);
+
+    if (sess->decr_ctx.mech.pParameter)
+        free(sess->decr_ctx.mech.pParameter);
+
+    if (sess->digest_ctx.context)
+        free(sess->digest_ctx.context);
+
+    if (sess->digest_ctx.mech.pParameter)
+        free(sess->digest_ctx.mech.pParameter);
+
+    if (sess->sign_ctx.context)
+        free(sess->sign_ctx.context);
+
+    if (sess->sign_ctx.mech.pParameter)
+        free(sess->sign_ctx.mech.pParameter);
+
+    if (sess->verify_ctx.context)
+        free(sess->verify_ctx.context);
+
+    if (sess->verify_ctx.mech.pParameter)
+        free(sess->verify_ctx.mech.pParameter);
+
+    bt_node_free(&sess_btree, handle, free);
+
+    // XXX XXX  Not having this is a problem
+    // for IHS.  The spec states that there is an implicit logout
+    // when the last session is closed.  Cannonicaly this is what other
+    // implementaitons do.  however on linux for some reason IHS can't seem
+    // to keep the session open, which means that they go through the login
+    // path EVERY time, which of course causes a reload of the private
+    // objects EVERY time.   If we are logged out, we MUST purge the private
+    // objects from this process..
+    if (bt_is_empty(&sess_btree)) {
+        // SAB  XXX  if all sessions are closed.  Is this effectivly logging out
+        if (token_specific.t_logout) {
+            rc = token_specific.t_logout();
+        }
+        object_mgr_purge_private_token_objects();
+
+		global_login_state = CKS_RO_PUBLIC_SESSION;
+        // The objects really need to be purged .. but this impacts the
+        // performance under linux.   So we need to make sure that the
+        // login state is valid.    I don't really like this.
+        object_mgr_purge_map((SESSION *)0xFFFF, PRIVATE);
+    }
+
+done:
+    pthread_rwlock_unlock(&sess_list_rwlock);
+    return rc;
+}
+
+/* session_free
+ *
+ * Callback used to free an individual SESSION object
+ */
+void
+session_free(void *node_value, unsigned long node_idx, void *p3)
+{
+   SESSION *sess = (SESSION *)node_value;
+
+   object_mgr_purge_session_objects( sess, ALL );
+   sess->handle = CK_INVALID_HANDLE;
+
+   if (sess->find_list)
+      free( sess->find_list );
+
+   if (sess->encr_ctx.context)
+      free( sess->encr_ctx.context );
+
+   if (sess->encr_ctx.mech.pParameter)
+      free( sess->encr_ctx.mech.pParameter);
+
+   if (sess->decr_ctx.context)
+      free( sess->decr_ctx.context );
+
+   if (sess->decr_ctx.mech.pParameter)
+      free( sess->decr_ctx.mech.pParameter);
+
+   if (sess->digest_ctx.context)
+      free( sess->digest_ctx.context );
+
+   if (sess->digest_ctx.mech.pParameter)
+      free( sess->digest_ctx.mech.pParameter);
+
+   if (sess->sign_ctx.context)
+      free( sess->sign_ctx.context );
+
+   if (sess->sign_ctx.mech.pParameter)
+      free( sess->sign_ctx.mech.pParameter);
+
+   if (sess->verify_ctx.context)
+      free( sess->verify_ctx.context );
+
+   if (sess->verify_ctx.mech.pParameter)
+      free( sess->verify_ctx.mech.pParameter);
+
+   /* NB: any access to sess or @node_value after this returns will segfault */
+   bt_node_free(&sess_btree, node_idx, free);
+}
+
+// session_mgr_close_all_sessions()
+//
+// removes all sessions from the specified process
+//
+CK_RV session_mgr_close_all_sessions(void)
+{
+   bt_for_each_node(&sess_btree, session_free, NULL);
+
+   if (pthread_rwlock_wrlock(&sess_list_rwlock)) {
+        TRACE_ERROR("Read Lock failed.\n");
+        return FALSE;
+   }
+
+   global_login_state = CKS_RO_PUBLIC_SESSION;
+   ro_session_count = 0;
+
+   pthread_rwlock_unlock(&sess_list_rwlock);
+
+   return CKR_OK;
+}
+
+/* session_login
+ *
+ * Callback used to update a SESSION object's login state to logged in based on user type
+ */
+void
+session_login(void *node_value, unsigned long node_idx, void *p3)
+{
+   SESSION *s = (SESSION *)node_value;
+   CK_USER_TYPE user_type = *(CK_USER_TYPE *)p3;
+
+   if (s->session_info.flags & CKF_RW_SESSION) {
+      if (user_type == CKU_USER)
+         s->session_info.state = CKS_RW_USER_FUNCTIONS;
+      else
+         s->session_info.state = CKS_RW_SO_FUNCTIONS;
+   } else {
+      if (user_type == CKU_USER)
+         s->session_info.state = CKS_RO_USER_FUNCTIONS;
+   }
+
+   global_login_state = s->session_info.state; // SAB
+}
+
+// session_mgr_login_all()
+//
+// changes the login status of all sessions in the token
+//
+// Arg:  CK_USER_TYPE  user_type : USER or SO
+//
+CK_RV
+session_mgr_login_all( CK_USER_TYPE user_type )
+{
+   bt_for_each_node(&sess_btree, session_login, (void *)&user_type);
+
+   return CKR_OK;
+}
+
+/* session_logout
+ *
+ * Callback used to update a SESSION object's login state to be logged out
+ */
+void
+session_logout(void *node_value, unsigned long node_idx, void *p3)
+{
+   SESSION *s = (SESSION *)node_value;
+
+   // all sessions get logged out so destroy any private objects
+   // public objects are left alone
+   //
+   object_mgr_purge_session_objects( s, PRIVATE );
+
+   if (s->session_info.flags & CKF_RW_SESSION)
+      s->session_info.state = CKS_RW_PUBLIC_SESSION;
+   else
+      s->session_info.state = CKS_RO_PUBLIC_SESSION;
+
+   global_login_state = s->session_info.state; // SAB
+}
+
+// session_mgr_logout_all()
+//
+// changes the login status of all sessions in the token
+//
+CK_RV
+session_mgr_logout_all( void )
+{
+   bt_for_each_node(&sess_btree, session_logout, NULL);
+
+   return CKR_OK;
+}
+
+
+//
+//
+CK_RV
+session_mgr_get_op_state( SESSION   *sess,
+                          CK_BBOOL   length_only,
+                          CK_BYTE   *data,
+                          CK_ULONG  *data_len )
+{
+   OP_STATE_DATA  *op_data = NULL;
+   CK_ULONG        op_data_len = 0;
+   CK_ULONG        offset;
+
+   if (!sess){
+      TRACE_ERROR("Invalid function arguments.\n");
+      return CKR_FUNCTION_FAILED;
+   }
+
+   // ensure that at least one operation is active
+   //
+   if (sess->find_active == TRUE){
+      TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
+      return CKR_STATE_UNSAVEABLE;
+   }
+   if (sess->encr_ctx.active == TRUE) {
+      if (op_data != NULL){
+         TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
+         return CKR_STATE_UNSAVEABLE;
+      }
+      op_data_len = sizeof(OP_STATE_DATA)      +
+                    sizeof(ENCR_DECR_CONTEXT)  +
+                    sess->encr_ctx.context_len +
+                    sess->encr_ctx.mech.ulParameterLen;
+
+      if (length_only == FALSE) {
+         op_data = (OP_STATE_DATA *)data;
+
+         op_data->data_len         = op_data_len - sizeof(OP_STATE_DATA);
+         op_data->session_state    = sess->session_info.state;
+         op_data->active_operation = STATE_ENCR;
+
+         offset = sizeof(OP_STATE_DATA);
+
+         memcpy( (CK_BYTE *)op_data + offset,
+                 &sess->encr_ctx,
+                 sizeof(ENCR_DECR_CONTEXT) );
+
+         offset += sizeof(ENCR_DECR_CONTEXT);
+
+         if (sess->encr_ctx.context_len != 0) {
+            memcpy( (CK_BYTE *)op_data + offset,
+                    sess->encr_ctx.context,
+                    sess->encr_ctx.context_len );
+
+            offset += sess->encr_ctx.context_len;
+         }
+
+         if (sess->encr_ctx.mech.ulParameterLen != 0) {
+            memcpy( (CK_BYTE *)op_data + offset,
+                    sess->encr_ctx.mech.pParameter,
+                    sess->encr_ctx.mech.ulParameterLen );
+         }
+      }
+   }
+
+   if (sess->decr_ctx.active == TRUE) {
+      if (op_data != NULL){
+         TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
+         return CKR_STATE_UNSAVEABLE;
+      }
+      op_data_len = sizeof(OP_STATE_DATA)      +
+                    sizeof(ENCR_DECR_CONTEXT)  +
+                    sess->decr_ctx.context_len +
+                    sess->decr_ctx.mech.ulParameterLen;
+
+      if (length_only == FALSE) {
+         op_data = (OP_STATE_DATA *)data;
+
+         op_data->data_len         = op_data_len - sizeof(OP_STATE_DATA);
+         op_data->session_state    = sess->session_info.state;
+         op_data->active_operation = STATE_DECR;
+
+         offset = sizeof(OP_STATE_DATA);
+
+         memcpy( (CK_BYTE *)op_data + offset,
+                 &sess->decr_ctx,
+                 sizeof(ENCR_DECR_CONTEXT) );
+
+         offset += sizeof(ENCR_DECR_CONTEXT);
+
+         if (sess->decr_ctx.context_len != 0) {
+            memcpy( (CK_BYTE *)op_data + offset,
+                    sess->decr_ctx.context,
+                    sess->decr_ctx.context_len );
+
+            offset += sess->decr_ctx.context_len;
+         }
+
+         if (sess->decr_ctx.mech.ulParameterLen != 0) {
+            memcpy( (CK_BYTE *)op_data + offset,
+                    sess->decr_ctx.mech.pParameter,
+                    sess->decr_ctx.mech.ulParameterLen );
+         }
+      }
+   }
+
+   if (sess->digest_ctx.active == TRUE) {
+      if (op_data != NULL){
+         TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
+         return CKR_STATE_UNSAVEABLE;
+      }
+      op_data_len = sizeof(OP_STATE_DATA)        +
+                    sizeof(DIGEST_CONTEXT)       +
+                    sess->digest_ctx.context_len +
+                    sess->digest_ctx.mech.ulParameterLen;
+
+      if (length_only == FALSE) {
+         op_data = (OP_STATE_DATA *)data;
+
+         op_data->data_len         = op_data_len - sizeof(OP_STATE_DATA);
+         op_data->session_state    = sess->session_info.state;
+         op_data->active_operation = STATE_DIGEST;
+
+         offset = sizeof(OP_STATE_DATA);
+
+         memcpy( (CK_BYTE *)op_data + offset,
+                 &sess->digest_ctx,
+                 sizeof(DIGEST_CONTEXT) );
+
+         offset += sizeof(DIGEST_CONTEXT);
+
+         if (sess->digest_ctx.context_len != 0) {
+            memcpy( (CK_BYTE *)op_data + offset,
+                    sess->digest_ctx.context,
+                    sess->digest_ctx.context_len );
+
+            offset += sess->digest_ctx.context_len;
+         }
+
+         if (sess->digest_ctx.mech.ulParameterLen != 0) {
+            memcpy( (CK_BYTE *)op_data + offset,
+                    sess->digest_ctx.mech.pParameter,
+                    sess->digest_ctx.mech.ulParameterLen );
+         }
+      }
+   }
+
+   if (sess->sign_ctx.active == TRUE) {
+      if (op_data != NULL){
+         TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
+         return CKR_STATE_UNSAVEABLE;
+      }
+      op_data_len = sizeof(OP_STATE_DATA)       +
+                    sizeof(SIGN_VERIFY_CONTEXT) +
+                    sess->sign_ctx.context_len  +
+                    sess->sign_ctx.mech.ulParameterLen;
+
+      if (length_only == FALSE) {
+         op_data = (OP_STATE_DATA *)data;
+
+         op_data->data_len         = op_data_len - sizeof(OP_STATE_DATA);
+         op_data->session_state    = sess->session_info.state;
+         op_data->active_operation = STATE_SIGN;
+
+         offset = sizeof(OP_STATE_DATA);
+
+         memcpy( (CK_BYTE *)op_data + offset,
+                 &sess->sign_ctx,
+                 sizeof(SIGN_VERIFY_CONTEXT) );
+
+         offset += sizeof(SIGN_VERIFY_CONTEXT);
+
+         if (sess->sign_ctx.context_len != 0) {
+            memcpy( (CK_BYTE *)op_data + offset,
+                    sess->sign_ctx.context,
+                    sess->sign_ctx.context_len );
+
+            offset += sess->sign_ctx.context_len;
+         }
+
+         if (sess->sign_ctx.mech.ulParameterLen != 0) {
+            memcpy( (CK_BYTE *)op_data + offset,
+                    sess->sign_ctx.mech.pParameter,
+                    sess->sign_ctx.mech.ulParameterLen );
+         }
+      }
+   }
+
+   if (sess->verify_ctx.active == TRUE) {
+      if (op_data != NULL){
+         TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
+         return CKR_STATE_UNSAVEABLE;
+      }
+      op_data_len = sizeof(OP_STATE_DATA)        +
+                    sizeof(SIGN_VERIFY_CONTEXT)  +
+                    sess->verify_ctx.context_len +
+                    sess->verify_ctx.mech.ulParameterLen;
+
+      if (length_only == FALSE) {
+         op_data = (OP_STATE_DATA *)data;
+
+         op_data->data_len         = op_data_len - sizeof(OP_STATE_DATA);
+         op_data->session_state    = sess->session_info.state;
+         op_data->active_operation = STATE_SIGN;
+
+         offset = sizeof(OP_STATE_DATA);
+
+         memcpy( (CK_BYTE *)op_data + offset,
+                 &sess->verify_ctx,
+                 sizeof(SIGN_VERIFY_CONTEXT) );
+
+         offset += sizeof(SIGN_VERIFY_CONTEXT);
+
+         if (sess->verify_ctx.context_len != 0) {
+            memcpy( (CK_BYTE *)op_data + offset,
+                    sess->verify_ctx.context,
+                    sess->verify_ctx.context_len );
+
+            offset += sess->verify_ctx.context_len;
+         }
+
+         if (sess->verify_ctx.mech.ulParameterLen != 0) {
+            memcpy( (CK_BYTE *)op_data + offset,
+                    sess->verify_ctx.mech.pParameter,
+                    sess->verify_ctx.mech.ulParameterLen );
+         }
+      }
+   }
+
+   *data_len = op_data_len;
+   return CKR_OK;
+}
+
+
+//
+//
+CK_RV
+session_mgr_set_op_state( SESSION           * sess,
+                          CK_OBJECT_HANDLE    encr_key,
+                          CK_OBJECT_HANDLE    auth_key,
+                          CK_BYTE           * data,
+                          CK_ULONG            data_len )
+{
+   OP_STATE_DATA  *op_data    = NULL;
+   CK_BYTE        *mech_param = NULL;
+   CK_BYTE        *context    = NULL;
+   CK_BYTE        *ptr1       = NULL;
+   CK_BYTE        *ptr2       = NULL;
+   CK_BYTE        *ptr3       = NULL;
+   CK_ULONG        len;
+
+
+   if (!sess || !data){
+      TRACE_ERROR("%s received bad argument(s)\n", __FUNCTION__);
+      return CKR_FUNCTION_FAILED;
+   }
+   op_data = (OP_STATE_DATA *)data;
+
+   // make sure the session states are compatible
+   //
+   if (sess->session_info.state != op_data->session_state){
+      TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
+      return CKR_SAVED_STATE_INVALID;
+   }
+   // validate the new state information.  don't touch the session
+   // until the new state is valid.
+   //
+   switch (op_data->active_operation) {
+      case STATE_ENCR:
+      case STATE_DECR:
+         {
+            ENCR_DECR_CONTEXT *ctx = (ENCR_DECR_CONTEXT *)(data + sizeof(OP_STATE_DATA));
+
+            len = sizeof(ENCR_DECR_CONTEXT) + ctx->context_len + ctx->mech.ulParameterLen;
+            if (len != op_data->data_len){
+               TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
+               return CKR_SAVED_STATE_INVALID;
+            }
+            if (auth_key != 0){
+               TRACE_ERROR("%s\n", ock_err(ERR_KEY_NOT_NEEDED));
+               return CKR_KEY_NOT_NEEDED;
+            }
+            if (encr_key == 0){
+               TRACE_ERROR("%s\n", ock_err(ERR_KEY_NEEDED));
+               return CKR_KEY_NEEDED;
+            }
+            ptr1 = (CK_BYTE *)ctx;
+            ptr2 = ptr1 + sizeof(ENCR_DECR_CONTEXT);
+            ptr3 = ptr2 + ctx->context_len;
+
+            if (ctx->context_len) {
+               context = (CK_BYTE *)malloc( ctx->context_len );
+               if (!context){
+                  TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
+                  return CKR_HOST_MEMORY;
+               }
+               memcpy( context, ptr2, ctx->context_len );
+            }
+
+            if (ctx->mech.ulParameterLen) {
+               mech_param = (CK_BYTE *)malloc( ctx->mech.ulParameterLen );
+               if (!mech_param) {
+                  if (context)
+                     free( context );
+                  TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
+                  return CKR_HOST_MEMORY;
+               }
+               memcpy( mech_param, ptr3, ctx->mech.ulParameterLen );
+            }
+         }
+         break;
+
+      case STATE_SIGN:
+      case STATE_VERIFY:
+         {
+            SIGN_VERIFY_CONTEXT *ctx = (SIGN_VERIFY_CONTEXT *)(data + sizeof(OP_STATE_DATA));
+
+            len = sizeof(SIGN_VERIFY_CONTEXT) + ctx->context_len + ctx->mech.ulParameterLen;
+            if (len != op_data->data_len){
+               TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
+               return CKR_SAVED_STATE_INVALID;
+            }
+            if (auth_key == 0){
+               TRACE_ERROR("%s\n", ock_err(ERR_KEY_NEEDED));
+               return CKR_KEY_NEEDED;
+            }
+            if (encr_key != 0){
+               TRACE_ERROR("%s\n", ock_err(ERR_KEY_NOT_NEEDED));
+               return CKR_KEY_NOT_NEEDED;
+            }
+            ptr1 = (CK_BYTE *)ctx;
+            ptr2 = ptr1 + sizeof(SIGN_VERIFY_CONTEXT);
+            ptr3 = ptr2 + ctx->context_len;
+
+            if (ctx->context_len) {
+               context = (CK_BYTE *)malloc( ctx->context_len );
+               if (!context){
+                  TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
+                  return CKR_HOST_MEMORY;
+               }
+               memcpy( context, ptr2, ctx->context_len );
+            }
+
+            if (ctx->mech.ulParameterLen) {
+               mech_param = (CK_BYTE *)malloc( ctx->mech.ulParameterLen );
+               if (!mech_param) {
+                  if (context)
+                     free( context );
+                  TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
+                  return CKR_HOST_MEMORY;
+               }
+               memcpy( mech_param, ptr3, ctx->mech.ulParameterLen );
+            }
+         }
+         break;
+
+      case STATE_DIGEST:
+         {
+            DIGEST_CONTEXT *ctx = (DIGEST_CONTEXT *)(data + sizeof(OP_STATE_DATA));
+
+            len = sizeof(DIGEST_CONTEXT) + ctx->context_len + ctx->mech.ulParameterLen;
+            if (len != op_data->data_len){
+               TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
+               return CKR_SAVED_STATE_INVALID;
+            }
+            if (auth_key != 0){
+               TRACE_ERROR("%s\n", ock_err(ERR_KEY_NOT_NEEDED));
+               return CKR_KEY_NOT_NEEDED;
+            }
+            if (encr_key != 0){
+               TRACE_ERROR("%s\n", ock_err(ERR_KEY_NOT_NEEDED));
+               return CKR_KEY_NOT_NEEDED;
+            }
+            ptr1 = (CK_BYTE *)ctx;
+            ptr2 = ptr1 + sizeof(DIGEST_CONTEXT);
+            ptr3 = ptr2 + ctx->context_len;
+
+            if (ctx->context_len) {
+               context = (CK_BYTE *)malloc( ctx->context_len );
+               if (!context){
+                  TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
+                  return CKR_HOST_MEMORY;
+               }
+               memcpy( context, ptr2, ctx->context_len );
+            }
+
+            if (ctx->mech.ulParameterLen) {
+               mech_param = (CK_BYTE *)malloc( ctx->mech.ulParameterLen );
+               if (!mech_param) {
+                  if (context)
+                     free( context );
+                  TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
+                  return CKR_HOST_MEMORY;
+               }
+               memcpy( mech_param, ptr3, ctx->mech.ulParameterLen );
+            }
+         }
+         break;
+
+      default:
+         TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
+         return CKR_SAVED_STATE_INVALID;
+   }
+
+
+   // state information looks okay.  cleanup the current session state, first
+   //
+   if (sess->encr_ctx.active)
+      encr_mgr_cleanup( &sess->encr_ctx );
+
+   if (sess->decr_ctx.active)
+      decr_mgr_cleanup( &sess->decr_ctx );
+
+   if (sess->digest_ctx.active)
+      digest_mgr_cleanup( &sess->digest_ctx );
+
+   if (sess->sign_ctx.active)
+      sign_mgr_cleanup( &sess->sign_ctx );
+
+   if (sess->verify_ctx.active)
+      verify_mgr_cleanup( &sess->verify_ctx );
+
+
+   // copy the new state information
+   //
+   switch (op_data->active_operation) {
+      case STATE_ENCR:
+         memcpy( &sess->encr_ctx, ptr1, sizeof(ENCR_DECR_CONTEXT) );
+
+         sess->encr_ctx.key             = encr_key;
+         sess->encr_ctx.context         = context;
+         sess->encr_ctx.mech.pParameter = mech_param;
+         break;
+
+      case STATE_DECR:
+         memcpy( &sess->decr_ctx, ptr1, sizeof(ENCR_DECR_CONTEXT) );
+
+         sess->decr_ctx.key             = encr_key;
+         sess->decr_ctx.context         = context;
+         sess->decr_ctx.mech.pParameter = mech_param;
+         break;
+
+      case STATE_SIGN:
+         memcpy( &sess->sign_ctx, ptr1, sizeof(SIGN_VERIFY_CONTEXT) );
+
+         sess->sign_ctx.key             = auth_key;
+         sess->sign_ctx.context         = context;
+         sess->sign_ctx.mech.pParameter = mech_param;
+         break;
+
+      case STATE_VERIFY:
+         memcpy( &sess->verify_ctx, ptr1, sizeof(SIGN_VERIFY_CONTEXT) );
+
+         sess->verify_ctx.key             = auth_key;
+         sess->verify_ctx.context         = context;
+         sess->verify_ctx.mech.pParameter = mech_param;
+         break;
+
+      case STATE_DIGEST:
+         memcpy( &sess->digest_ctx, ptr1, sizeof(DIGEST_CONTEXT) );
+
+         sess->digest_ctx.context         = context;
+         sess->digest_ctx.mech.pParameter = mech_param;
+         break;
+   }
+
+   return CKR_OK;
+}
+
+// Return TRUE if the session we're in has its PIN
+// expired.
+CK_BBOOL pin_expired(CK_SESSION_INFO *si, CK_FLAGS flags)
+{
+   // If this is an SO session
+   if (	(flags & CKF_SO_PIN_TO_BE_CHANGED) &&
+	   (si->state == CKS_RW_SO_FUNCTIONS) )
+	   return TRUE;
+
+   // Else we're a User session
+   return( (flags & CKF_USER_PIN_TO_BE_CHANGED) &&
+	  ((si->state == CKS_RO_USER_FUNCTIONS) ||
+	   (si->state == CKS_RW_USER_FUNCTIONS)) );
+}
+
+// Return TRUE if the session we're in has its PIN
+// locked.
+CK_BBOOL pin_locked(CK_SESSION_INFO *si, CK_FLAGS flags)
+{
+   // If this is an SO session
+   if (	(flags & CKF_SO_PIN_LOCKED) &&
+	   (si->state == CKS_RW_SO_FUNCTIONS) )
+	   return TRUE;
+
+   // Else we're a User session
+   return( (flags & CKF_USER_PIN_LOCKED) &&
+	  ((si->state == CKS_RO_USER_FUNCTIONS) ||
+	   (si->state == CKS_RW_USER_FUNCTIONS)) );
+}
+
+// Increment the login flags after an incorrect password
+// has been passed to C_Login. New for v2.11. - KEY
+void set_login_flags(CK_USER_TYPE userType, CK_FLAGS_32 *flags)
+{
+	if(userType == CKU_USER) {
+		if(*flags & CKF_USER_PIN_FINAL_TRY) {
+			*flags |= CKF_USER_PIN_LOCKED;
+			*flags &= ~(CKF_USER_PIN_FINAL_TRY);
+		} else if (*flags & CKF_USER_PIN_COUNT_LOW) {
+			*flags |= CKF_USER_PIN_FINAL_TRY;
+			*flags &= ~(CKF_USER_PIN_COUNT_LOW);
+		} else {
+			*flags |= CKF_USER_PIN_COUNT_LOW;
+		}
+	} else {
+		if(*flags & CKF_SO_PIN_FINAL_TRY) {
+			*flags |= CKF_SO_PIN_LOCKED;
+			*flags &= ~(CKF_SO_PIN_FINAL_TRY);
+		} else if (*flags & CKF_SO_PIN_COUNT_LOW) {
+			*flags |= CKF_SO_PIN_FINAL_TRY;
+			*flags &= ~(CKF_SO_PIN_COUNT_LOW);
+		} else {
+			*flags |= CKF_SO_PIN_COUNT_LOW;
+		}
+	}
+}

--- a/usr/lib/pkcs11/common/new_host.c
+++ b/usr/lib/pkcs11/common/new_host.c
@@ -46,9 +46,6 @@
 
 #include "../api/apiproto.h"
 
-/* Declared in obj_mgr.c */
-extern pthread_rwlock_t obj_list_rw_mutex;
-
 void SC_SetFunctionList(void);
 
 CK_ULONG  usage_count = 0;	/* track DLL usage */
@@ -147,9 +144,6 @@ CK_RV ST_Initialize(API_Slot_t *sltp, CK_SLOT_ID SlotNumber,
 
 	MY_CreateMutex(&pkcs_mutex);
 	MY_CreateMutex(&obj_list_mutex);
-	if (pthread_rwlock_init(&obj_list_rw_mutex, NULL)) {
-		TRACE_ERROR("Mutex lock failed.\n");
-	}
 	MY_CreateMutex(&sess_list_mutex);
 	MY_CreateMutex(&login_mutex);
 
@@ -258,12 +252,20 @@ CK_RV SC_Finalize(STDLL_TokData_t *tokdata, CK_SLOT_ID sid, SLOT_INFO *sinfp)
 		return CKR_CRYPTOKI_NOT_INITIALIZED;
 	}
 
+#ifdef ENABLE_LOCKS
+    MY_LockMutex(&pkcs_mutex);
+#else
 	__transaction_atomic { /* start transaction */
+#endif
 		usage_count--;
 		if (usage_count == 0) {
 			initialized = FALSE;
 		}
+#ifdef ENABLE_LOCKS
+    MY_UnlockMutex(&pkcs_mutex);
+#else
 	} /* end transaction */
+#endif
 
 	session_mgr_close_all_sessions();
 	object_mgr_purge_token_objects(tokdata);

--- a/usr/lib/pkcs11/common/obj_mgr.c
+++ b/usr/lib/pkcs11/common/obj_mgr.c
@@ -28,8 +28,6 @@
 
 #include "../api/apiproto.h"
 
-pthread_rwlock_t obj_list_rw_mutex = PTHREAD_RWLOCK_INITIALIZER;
-
 CK_RV
 object_mgr_add( STDLL_TokData_t  * tokdata,
 		SESSION          * sess,

--- a/usr/lib/pkcs11/ep11_stdll/Makefile.am
+++ b/usr/lib/pkcs11/ep11_stdll/Makefile.am
@@ -2,9 +2,6 @@
 #
 nobase_lib_LTLIBRARIES = opencryptoki/stdll/libpkcs11_ep11.la
 
-opencryptoki_stdll_libpkcs11_ep11_la_LDFLAGS = -shared -Wl,-Bsymbolic	\
-					     -lc -lpthread -litm -lcrypto -lrt -llber
-
 # Not all versions of automake observe libname_CFLAGS
 opencryptoki_stdll_libpkcs11_ep11_la_CFLAGS = -DDEV -D_THREAD_SAFE            \
 					    -DSHALLOW=0 -DEPSWTOK=1 -DLITE=0  \
@@ -14,6 +11,41 @@ opencryptoki_stdll_libpkcs11_ep11_la_CFLAGS = -DDEV -D_THREAD_SAFE            \
 					    -I../../../include/pkcs11/stdll \
 					    -I../../../include/pkcs11	    \
 					    -I../common -DSTDLL_NAME=\"ep11tok\"
+
+if ENABLE_LOCKS
+opencryptoki_stdll_libpkcs11_ep11_la_LDFLAGS = -shared -Wl,-Bsymbolic	\
+					     -lc -lpthread -lcrypto -lrt -llber
+
+opencryptoki_stdll_libpkcs11_ep11_la_SOURCES = ../common/asn1.c		\
+					     ../common/lock_btree.c		\
+					     ../common/cert.c		\
+					     ../common/hwf_obj.c	\
+					     ../common/dp_obj.c		\
+					     ../common/data_obj.c	\
+					     ../common/dig_mgr.c	\
+					     ../common/globals.c	\
+					     ../common/loadsave.c	\
+					     ../common/mech_ec.c	\
+					     ../common/mech_md5.c	\
+					     ../common/mech_md2.c	\
+					     ../common/mech_rng.c	\
+					     ../common/mech_sha.c	\
+					     new_host.c			\
+					     ../common/obj_mgr.c	\
+					     ../common/object.c		\
+					     ../common/lock_sess_mgr.c	\
+					     ../common/key.c		\
+					     ../common/template.c	\
+					     ../common/p11util.c	\
+					     ../common/utility.c	\
+					     ../common/trace.c		\
+					     ../common/shared_memory.c	\
+					     ../common/attributes.c     \
+					     ../common/sw_crypt.c       \
+					     ep11_specific.c
+else
+opencryptoki_stdll_libpkcs11_ep11_la_LDFLAGS = -shared -Wl,-Bsymbolic	\
+					     -lc -lpthread -litm -lcrypto -lrt -llber
 
 opencryptoki_stdll_libpkcs11_ep11_la_SOURCES = ../common/asn1.c		\
 					     ../common/btree.c		\
@@ -53,6 +85,7 @@ opencryptoki_stdll_libpkcs11_ep11_la_SOURCES = ../common/asn1.c		\
 					     ../common/attributes.c     \
 					     ../common/sw_crypt.c       \
 					     ep11_specific.c
+endif
 
 noinst_HEADERS = ep11.h
 

--- a/usr/lib/pkcs11/ica_s390_stdll/Makefile.am
+++ b/usr/lib/pkcs11/ica_s390_stdll/Makefile.am
@@ -1,14 +1,5 @@
 nobase_lib_LTLIBRARIES = opencryptoki/stdll/libpkcs11_ica.la
 
-opencryptoki_stdll_libpkcs11_ica_la_LDFLAGS = $(LCRYPTO)		\
-					     $(ICA_LIB_DIRS)		\
-					     -nostartfiles -shared	\
-					     -Wl,-Bsymbolic		\
-					     -Wl,-soname,$@		\
-					     -Wl,-Bsymbolic -lc		\
-					     -lpthread -lica -ldl -litm	\
-					     -lcrypto
-
 # Not all versions of automake observe libname_CFLAGS
 opencryptoki_stdll_libpkcs11_ica_la_CFLAGS = -DDEV			\
 					     -D_THREAD_SAFE -fPIC	\
@@ -17,6 +8,63 @@ opencryptoki_stdll_libpkcs11_ica_la_CFLAGS = -DDEV			\
 					     -DNOCDMF -DNOMD2 -DNODSA	\
 					     -DSTDLL_NAME=\"icatok\"	\
 					     -lrt
+
+if ENABLE_LOCKS
+opencryptoki_stdll_libpkcs11_ica_la_LDFLAGS = $(LCRYPTO)		\
+					     $(ICA_LIB_DIRS)		\
+					     -nostartfiles -shared	\
+					     -Wl,-Bsymbolic		\
+					     -Wl,-soname,$@		\
+					     -Wl,-Bsymbolic -lc		\
+					     -lpthread -lica -ldl \
+					     -lcrypto
+
+opencryptoki_stdll_libpkcs11_ica_la_SOURCES = ../common/asn1.c		\
+					      ../common/lock_btree.c		\
+					      ../common/cert.c		\
+					      ../common/hwf_obj.c	\
+					      ../common/dp_obj.c	\
+					      ../common/data_obj.c	\
+					      ../common/decr_mgr.c	\
+					      ../common/dig_mgr.c	\
+					      ../common/encr_mgr.c	\
+					      ../common/globals.c	\
+					      ../common/sw_crypt.c	\
+					      ../common/loadsave.c	\
+					      ../common/key.c		\
+					      ../common/key_mgr.c	\
+					      ../common/mech_des.c	\
+					      ../common/mech_des3.c	\
+					      ../common/mech_aes.c	\
+					      ../common/mech_md5.c	\
+					      ../common/mech_md2.c	\
+					      ../common/mech_rng.c	\
+					      ../common/mech_rsa.c	\
+					      ../common/mech_sha.c	\
+					      ../common/mech_ssl3.c	\
+					      ../common/mech_ec.c	\
+					      ../common/new_host.c	\
+					      ../common/obj_mgr.c	\
+					      ../common/object.c	\
+					      ../common/lock_sess_mgr.c	\
+					      ../common/sign_mgr.c	\
+					      ../common/template.c	\
+					      ../common/p11util.c	\
+					      ../common/utility.c	\
+					      ../common/verify_mgr.c	\
+					      ../common/trace.c		\
+					      ../common/mech_list.c	\
+					      ../common/shared_memory.c	\
+					      ica_specific.c
+else
+opencryptoki_stdll_libpkcs11_ica_la_LDFLAGS = $(LCRYPTO)		\
+					     $(ICA_LIB_DIRS)		\
+					     -nostartfiles -shared	\
+					     -Wl,-Bsymbolic		\
+					     -Wl,-soname,$@		\
+					     -Wl,-Bsymbolic -lc		\
+					     -lpthread -litm -lica -ldl \
+					     -lcrypto
 
 opencryptoki_stdll_libpkcs11_ica_la_SOURCES = ../common/asn1.c		\
 					      ../common/btree.c		\
@@ -55,6 +103,7 @@ opencryptoki_stdll_libpkcs11_ica_la_SOURCES = ../common/asn1.c		\
 					      ../common/mech_list.c	\
 					      ../common/shared_memory.c	\
 					      ica_specific.c
+endif
 
 AM_CPPFLAGS = $(ICA_INC_DIRS) -I. -I../../../include/pkcs11/stdll		\
 	   -I../../../include/pkcs11 -I../common -I../../../ica/inc	\

--- a/usr/lib/pkcs11/icsf_stdll/Makefile.am
+++ b/usr/lib/pkcs11/icsf_stdll/Makefile.am
@@ -19,12 +19,65 @@ opencryptoki_stdll_libpkcs11_icsf_la_CFLAGS = -DNOCDMF			\
 					      -I../common		\
 					      -DSTDLL_NAME=\"icsftok\"
 
+if ENABLE_LOCKS
 opencryptoki_stdll_libpkcs11_icsf_la_LDFLAGS = -shared			\
 					       -Wl,-Bsymbolic		\
 					       -lcrypto			\
 					       -lldap			\
 					       -lpthread		\
-					       -litm			\
+					       -lrt			\
+					       -llber
+
+opencryptoki_stdll_libpkcs11_icsf_la_SOURCES = ../common/asn1.c		\
+					       ../common/lock_btree.c	\
+					       ../common/dig_mgr.c	\
+					       ../common/hwf_obj.c	\
+					       ../common/trace.c	\
+					       ../common/key.c		\
+					       ../common/mech_dh.c	\
+					       ../common/mech_rng.c	\
+					       new_host.c		\
+					       ../common/sign_mgr.c	\
+					       ../common/cert.c		\
+					       ../common/dp_obj.c	\
+					       ../common/mech_aes.c	\
+					       ../common/mech_rsa.c	\
+					       ../common/mech_ec.c	\
+					       ../common/obj_mgr.c	\
+					       ../common/template.c	\
+					       ../common/p11util.c	\
+					       ../common/data_obj.c	\
+					       ../common/encr_mgr.c	\
+					       ../common/key_mgr.c	\
+					       ../common/mech_md2.c	\
+					       ../common/mech_sha.c	\
+					       ../common/object.c	\
+					       ../common/decr_mgr.c	\
+					       ../common/globals.c	\
+					       ../common/sw_crypt.c	\
+					       ../common/loadsave.c	\
+					       ../common/utility.c	\
+					       ../common/mech_des.c	\
+					       ../common/mech_des3.c	\
+					       ../common/mech_md5.c	\
+					       ../common/mech_ssl3.c	\
+					       ../common/lock_sess_mgr.c	\
+					       ../common/verify_mgr.c	\
+					       ../common/mech_list.c	\
+					       ../common/shared_memory.c\
+					       ../common/attributes.c	\
+					       pbkdf.c			\
+					       icsf_specific.c		\
+					       icsf_config_parse.y	\
+					       icsf_config_lexer.l	\
+					       icsf.c
+else
+opencryptoki_stdll_libpkcs11_icsf_la_LDFLAGS = -shared			\
+					       -Wl,-Bsymbolic		\
+					       -lcrypto			\
+					       -lldap			\
+					       -lpthread		\
+						   -litm		\
 					       -lrt			\
 					       -llber
 
@@ -71,7 +124,7 @@ opencryptoki_stdll_libpkcs11_icsf_la_SOURCES = ../common/asn1.c		\
 					       icsf_config_parse.y	\
 					       icsf_config_lexer.l	\
 					       icsf.c
-
+endif
 
 noinst_HEADERS = icsf.h pbkdf.h
 

--- a/usr/lib/pkcs11/icsf_stdll/new_host.c
+++ b/usr/lib/pkcs11/icsf_stdll/new_host.c
@@ -35,9 +35,6 @@
 #include "icsf_specific.h"
 #include "../api/apiproto.h"
 
-/* Declared in obj_mgr.c */
-extern pthread_rwlock_t obj_list_rw_mutex;
-
 void SC_SetFunctionList(void);
 
 CK_ULONG  usage_count = 0;	/* track DLL usage */
@@ -134,9 +131,6 @@ CK_RV ST_Initialize(API_Slot_t *sltp, CK_SLOT_ID SlotNumber,
 
 	MY_CreateMutex(&pkcs_mutex);
 	MY_CreateMutex(&obj_list_mutex);
-	if (pthread_rwlock_init(&obj_list_rw_mutex, NULL)) {
-		TRACE_ERROR("Mutex lock failed.\n");
-	}
 	MY_CreateMutex(&sess_list_mutex);
 	MY_CreateMutex(&login_mutex);
 
@@ -244,12 +238,20 @@ CK_RV SC_Finalize(STDLL_TokData_t *tokdata, CK_SLOT_ID sid, SLOT_INFO *sinfp)
 		return CKR_CRYPTOKI_NOT_INITIALIZED;
 	}
 
+#ifdef ENABLE_LOCKS
+    MY_LockMutex(&pkcs_mutex);
+#else
 	__transaction_atomic { /* start transaction */
+#endif
 		usage_count--;
 		if (usage_count == 0) {
 			tokdata->initialized = FALSE;
 		}
+#ifdef ENABLE_LOCKS
+    MY_UnlockMutex(&pkcs_mutex);
+#else
 	} /* end transaction */
+#endif
 
 	session_mgr_close_all_sessions();
 	object_mgr_purge_token_objects(tokdata);

--- a/usr/lib/pkcs11/soft_stdll/Makefile.am
+++ b/usr/lib/pkcs11/soft_stdll/Makefile.am
@@ -1,8 +1,5 @@
 nobase_lib_LTLIBRARIES = opencryptoki/stdll/libpkcs11_sw.la
 
-opencryptoki_stdll_libpkcs11_sw_la_LDFLAGS = -shared -Wl,-Bsymbolic	\
-					     -lc -lpthread -litm -lcrypto -lrt
-
 # Not all versions of automake observe libname_CFLAGS
 opencryptoki_stdll_libpkcs11_sw_la_CFLAGS = -DDEV -D_THREAD_SAFE            \
 					    -DSHALLOW=0 -DSWTOK=1 -DLITE=0  \
@@ -12,6 +9,52 @@ opencryptoki_stdll_libpkcs11_sw_la_CFLAGS = -DDEV -D_THREAD_SAFE            \
 					    -I../../../include/pkcs11/stdll \
 					    -I../../../include/pkcs11	    \
 					    -I../common -DSTDLL_NAME=\"swtok\"
+
+if ENABLE_LOCKS
+opencryptoki_stdll_libpkcs11_sw_la_LDFLAGS = -shared -Wl,-Bsymbolic	\
+					     -lc -lpthread -lcrypto -lrt
+
+opencryptoki_stdll_libpkcs11_sw_la_SOURCES = ../common/asn1.c		\
+					     ../common/lock_btree.c		\
+					     ../common/cert.c		\
+					     ../common/hwf_obj.c	\
+					     ../common/dp_obj.c		\
+					     ../common/data_obj.c	\
+					     ../common/decr_mgr.c	\
+					     ../common/dig_mgr.c	\
+					     ../common/encr_mgr.c	\
+					     ../common/globals.c	\
+					     ../common/sw_crypt.c	\
+					     ../common/loadsave.c	\
+					     ../common/key.c		\
+					     ../common/key_mgr.c	\
+					     ../common/mech_aes.c	\
+					     ../common/mech_des.c	\
+					     ../common/mech_des3.c	\
+					     ../common/mech_dh.c	\
+					     ../common/mech_md5.c	\
+					     ../common/mech_md2.c	\
+					     ../common/mech_rng.c	\
+					     ../common/mech_rsa.c	\
+					     ../common/mech_sha.c	\
+					     ../common/mech_ssl3.c	\
+					     ../common/mech_ec.c	\
+					     ../common/new_host.c	\
+					     ../common/obj_mgr.c	\
+					     ../common/object.c		\
+					     ../common/lock_sess_mgr.c	\
+					     ../common/sign_mgr.c	\
+					     ../common/template.c	\
+					     ../common/p11util.c	\
+					     ../common/utility.c	\
+					     ../common/verify_mgr.c	\
+					     ../common/trace.c		\
+					     ../common/mech_list.c      \
+					     ../common/shared_memory.c	\
+					     soft_specific.c
+else
+opencryptoki_stdll_libpkcs11_sw_la_LDFLAGS = -shared -Wl,-Bsymbolic	\
+					     -lc -lpthread -litm -lcrypto -lrt
 
 opencryptoki_stdll_libpkcs11_sw_la_SOURCES = ../common/asn1.c		\
 					     ../common/btree.c		\
@@ -51,6 +94,7 @@ opencryptoki_stdll_libpkcs11_sw_la_SOURCES = ../common/asn1.c		\
 					     ../common/mech_list.c      \
 					     ../common/shared_memory.c	\
 					     soft_specific.c
+endif
 
 install-data-hook:
 	cd $(DESTDIR)$(libdir)/opencryptoki/stdll && \

--- a/usr/lib/pkcs11/tpm_stdll/Makefile.am
+++ b/usr/lib/pkcs11/tpm_stdll/Makefile.am
@@ -16,12 +16,59 @@ opencryptoki_stdll_libpkcs11_tpm_la_CFLAGS = -DLINUX -DNOCDMF		\
 					     -I../common -DMMAP		\
 					     -DSTDLL_NAME=\"tpmtok\"
 
+if ENABLE_LOCKS
 opencryptoki_stdll_libpkcs11_tpm_la_LDFLAGS = -shared -Wl,-Bsymbolic	\
 					      -lcrypto -ltspi -lpthread	\
-					      -litm -lrt
+					      -lrt
 
 opencryptoki_stdll_libpkcs11_tpm_la_SOURCES = ../common/asn1.c		\
-					      ../common/btree.c		\
+					      ../common/lock_btree.c		\
+					      ../common/dig_mgr.c	\
+					      ../common/hwf_obj.c	\
+					      ../common/trace.c		\
+					      ../common/key.c		\
+					      ../common/mech_dh.c	\
+					      ../common/mech_rng.c	\
+					      ../common/new_host.c	\
+					      ../common/sign_mgr.c	\
+					      ../common/cert.c		\
+					      ../common/dp_obj.c	\
+					      ../common/mech_aes.c	\
+					      ../common/$(MECH_DSA)	\
+					      ../common/mech_rsa.c	\
+					      ../common/mech_ec.c	\
+					      ../common/obj_mgr.c	\
+					      ../common/template.c	\
+					      ../common/p11util.c	\
+					      ../common/data_obj.c	\
+					      ../common/encr_mgr.c	\
+					      ../common/key_mgr.c	\
+					      ../common/mech_md2.c	\
+					      ../common/mech_sha.c	\
+					      ../common/object.c	\
+					      ../common/decr_mgr.c	\
+					      ../common/globals.c	\
+					      ../common/sw_crypt.c	\
+					      ../common/loadsave.c	\
+					      ../common/utility.c	\
+					      ../common/mech_des.c	\
+					      ../common/mech_des3.c	\
+					      ../common/mech_md5.c	\
+					      ../common/mech_ssl3.c	\
+					      ../common/lock_sess_mgr.c	\
+					      ../common/verify_mgr.c	\
+					      ../common/mech_list.c	\
+					      ../common/shared_memory.c	\
+					      tpm_specific.c		\
+					      tpm_openssl.c		\
+					      tpm_util.c
+
+else
+opencryptoki_stdll_libpkcs11_tpm_la_LDFLAGS = -shared -Wl,-Bsymbolic	\
+					      -lcrypto -ltspi -lpthread -litm -lrt
+
+opencryptoki_stdll_libpkcs11_tpm_la_SOURCES = ../common/asn1.c		\
+					      ../common/btree.c	\
 					      ../common/dig_mgr.c	\
 					      ../common/hwf_obj.c	\
 					      ../common/trace.c		\
@@ -62,6 +109,7 @@ opencryptoki_stdll_libpkcs11_tpm_la_SOURCES = ../common/asn1.c		\
 					      tpm_openssl.c		\
 					      tpm_util.c
 
+endif
 
 noinst_HEADERS = defs.h		\
 		 tpm_specific.h


### PR DESCRIPTION
As an alternative solution to transactional memory, the user can specify during
build time if he wants to make use of read/write locks implementation. Just
include --enable-locks in configure step.

Signed-off-by: Eduardo Barretto <ebarretto@linux.vnet.ibm.com>