### PR TITLE
Fix CKA_ALWAYS_AUTHENTICATE attribute for priv. keys

### DIFF
--- a/usr/include/pkcs11/pkcs11types.h
+++ b/usr/include/pkcs11/pkcs11types.h
@@ -510,6 +510,7 @@ typedef CK_ULONG          CK_ATTRIBUTE_TYPE;
 /* The following are new for v2.11 */
 #define CKA_SECONDARY_AUTH     0x00000200
 #define CKA_AUTH_PIN_FLAGS     0x00000201
+#define CKA_ALWAYS_AUTHENTICATE 0x00000202
 #define CKA_HW_FEATURE_TYPE    0x00000300
 #define CKA_RESET_ON_INIT      0x00000301
 #define CKA_HAS_RESET          0x00000302

--- a/usr/lib/pkcs11/common/key.c
+++ b/usr/lib/pkcs11/common/key.c
@@ -413,6 +413,7 @@ priv_key_set_default_attributes( TEMPLATE *tmpl, CK_ULONG mode )
    CK_ATTRIBUTE    *extractable_attr  = NULL;
    CK_ATTRIBUTE    *never_extr_attr   = NULL;
    CK_ATTRIBUTE    *always_sens_attr  = NULL;
+   CK_ATTRIBUTE    *always_auth_attr  = NULL;
    CK_RV            rc;
 
 
@@ -433,10 +434,11 @@ priv_key_set_default_attributes( TEMPLATE *tmpl, CK_ULONG mode )
    extractable_attr  = (CK_ATTRIBUTE *)malloc( sizeof(CK_ATTRIBUTE) + sizeof(CK_BBOOL) );
    never_extr_attr   = (CK_ATTRIBUTE *)malloc( sizeof(CK_ATTRIBUTE) + sizeof(CK_BBOOL) );
    always_sens_attr  = (CK_ATTRIBUTE *)malloc( sizeof(CK_ATTRIBUTE) + sizeof(CK_BBOOL) );
+   always_auth_attr  = (CK_ATTRIBUTE *)malloc( sizeof(CK_ATTRIBUTE) + sizeof(CK_BBOOL) );
 
    if (!class_attr || !subject_attr      || !sensitive_attr || !decrypt_attr ||
        !sign_attr  || !sign_recover_attr || !unwrap_attr    || !extractable_attr ||
-       !never_extr_attr || !always_sens_attr )
+       !never_extr_attr || !always_sens_attr || !always_auth_attr)
    {
       if (class_attr)        free( class_attr );
       if (subject_attr)      free( subject_attr );
@@ -448,6 +450,7 @@ priv_key_set_default_attributes( TEMPLATE *tmpl, CK_ULONG mode )
       if (extractable_attr)  free( extractable_attr );
       if (always_sens_attr)  free( always_sens_attr );
       if (never_extr_attr)   free( never_extr_attr );
+      if (always_auth_attr)  free( always_auth_attr );
 
       TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
       return CKR_HOST_MEMORY;
@@ -505,6 +508,11 @@ priv_key_set_default_attributes( TEMPLATE *tmpl, CK_ULONG mode )
    always_sens_attr->pValue     = (CK_BYTE *)always_sens_attr + sizeof(CK_ATTRIBUTE);
    *(CK_BBOOL *)always_sens_attr->pValue = FALSE;
 
+   always_auth_attr->type       = CKA_ALWAYS_AUTHENTICATE;
+   always_auth_attr->ulValueLen = sizeof(CK_BBOOL);
+   always_auth_attr->pValue     = (CK_BYTE *)always_auth_attr + sizeof(CK_ATTRIBUTE);
+   *(CK_BBOOL *)always_auth_attr->pValue = FALSE;
+
    template_update_attribute( tmpl, class_attr );
    template_update_attribute( tmpl, subject_attr );
    template_update_attribute( tmpl, sensitive_attr );
@@ -515,6 +523,7 @@ priv_key_set_default_attributes( TEMPLATE *tmpl, CK_ULONG mode )
    template_update_attribute( tmpl, extractable_attr );
    template_update_attribute( tmpl, never_extr_attr );
    template_update_attribute( tmpl, always_sens_attr );
+   template_update_attribute( tmpl, always_auth_attr );
 
    return CKR_OK;
 }

--- a/usr/lib/pkcs11/common/p11util.c
+++ b/usr/lib/pkcs11/common/p11util.c
@@ -163,6 +163,7 @@ is_attribute_defined( CK_ATTRIBUTE_TYPE type )
       case  CKA_LOCAL:
       case  CKA_NEVER_EXTRACTABLE:
       case  CKA_ALWAYS_SENSITIVE:
+      case  CKA_ALWAYS_AUTHENTICATE:
       case  CKA_MODIFIABLE:
       case  CKA_ECDSA_PARAMS:
       case  CKA_EC_POINT:

--- a/usr/lib/pkcs11/common/template.c
+++ b/usr/lib/pkcs11/common/template.c
@@ -1316,6 +1316,11 @@ CK_RV template_validate_base_attribute(TEMPLATE *tmpl, CK_ATTRIBUTE *attr,
 			     MODE_UNWRAP)) != 0)
 			return CKR_OK;
 		break;
+	case CKA_ALWAYS_AUTHENTICATE:
+		if ((mode & (MODE_CREATE|MODE_COPY|MODE_DERIVE|MODE_KEYGEN|
+			     MODE_UNWRAP)) != 0)
+			return CKR_OK;
+		break;
 
 	case CKA_LABEL:
 		return CKR_OK;


### PR DESCRIPTION
The PKCS#11 standard requires the CKA_ALWAYS_AUTHENTICATE attribute
to be present in private key objects. Actually this attribute is not
set as one of the default attributes. Further, it will be rejected
when it's declared within the application defined key template.

This fix will add the CKA_ALWAYS_AUTHENTICATE attribute by default
to any private key object. The value is set to 'false'. The calling
application is free to overrule by setting the attribute value
within the key template to 'true'.

Signed-off-by: Ingo Tuchscherer <ingo.tuchscherer@linux.vnet.ibm.com>