### PR TITLE
Fix error message when dlsym fails

### DIFF
--- a/usr/sbin/pkcsconf/pkcsconf.c
+++ b/usr/sbin/pkcsconf/pkcsconf.c
@@ -1043,8 +1043,7 @@ init(void){
    /* Get the list of the PKCS11 functions this token support */
    symPtr = (void (*)())dlsym(dllPtr, "C_GetFunctionList");
    if (!symPtr) {
-      rc = errno;
-      printf("Error getting function list: 0x%lX (%s)\n", rc, p11_get_ckr(rc));
+      printf("Error getting function list, symbol not found, error: %s\n", strerror(errno));
       fflush(stdout);
       return rc;
    }


### PR DESCRIPTION
This patch fixes #4

Signed-off-by: Eduardo Barretto <ebarretto@linux.vnet.ibm.com>