### PR TITLE
Fix TPM data-structure reset function.

### DIFF
--- a/usr/lib/pkcs11/tpm_stdll/tpm_specific.c
+++ b/usr/lib/pkcs11/tpm_stdll/tpm_specific.c
@@ -144,8 +144,6 @@ clear_internal_structures()
 	memset(master_key_private, 0, MK_SIZE);
 	memset(current_so_pin_sha, 0, SHA1_HASH_SIZE);
 	memset(current_user_pin_sha, 0, SHA1_HASH_SIZE);
-
-	object_mgr_purge_private_token_objects();
 }
 
 CK_RV


### PR DESCRIPTION
After the implementation of the Multi Token Instances (MTI) some
of the function signatures have changed and old patches provided
by the distros were not reflected.

This patch removes the call of the function
object_mgr_purge_private_token_objects() from the
clear_internal_structures(), since it has being called by the TPM
functions that calls clear_internal_structures().

Signed-off-by: Paulo Vital <pvital@linux.vnet.ibm.com>