### PR TITLE
Make sure the creation of tmpfiles.d

### DIFF
--- a/misc/Makefile.am
+++ b/misc/Makefile.am
@@ -40,6 +40,7 @@ tmpfiles.conf: tmpfiles.conf.in
 	mv $@-t $@
 
 install-data-hook:
+	mkdir -p $(DESTDIR)/usr/lib/tmpfiles.d
 	cp tmpfiles.conf $(DESTDIR)/usr/lib/tmpfiles.d/opencryptoki.conf
 	$(CHMOD) 0644 $(DESTDIR)/usr/lib/tmpfiles.d/opencryptoki.conf
 


### PR DESCRIPTION
Add rule in Makefile to create the /usr/lib/tmpfiles.d directory
during the installation step.

Signed-off-by: Paulo Vital <pvital@linux.vnet.ibm.com>