### PR TITLE
Token private data field in STDLL_TokData_t for multi-instance-token support

### DIFF
--- a/usr/lib/pkcs11/common/host_defs.h
+++ b/usr/lib/pkcs11/common/host_defs.h
@@ -300,7 +300,7 @@ typedef struct _STDLL_TokData_t {
 	CK_STATE 	global_login_state;;
 	LW_SHM_TYPE	*global_shm;
 	TOKEN_DATA	*nv_token_data;
-	uint64_t	*target_list;		// pointer to adapter target list
+    void        *private_data;
 } STDLL_TokData_t;
 
 // These are the same for both AIX and Linux...


### PR DESCRIPTION
Introduce a field private_data in structure STDLL_TokData_t that allows
a token to anchor a pointer to a private control block to store all its
variables that are supposed to be global on a per token instance basis.

Instead of adding token specific fields for this purpose to the STDLL_TokData_t
structure (which is part of common code), the private_data field provides a
token implementation independent way of storing information on a per token
instance basis.

This patch also removes the EP11 specific field target_list from STDLL_TokData_t
into a EP11 specific private data block to keep STDLL_TokData_t free from any
token implementation specific fields.

Signed-off-by: Ingo Franzki <ifranzki@linux.vnet.ibm.com>