### PR TITLE
Fix pkcsconf for upstart (init.d) and fix spec file when building --with-systemd

### DIFF
--- a/misc/Makefile.am
+++ b/misc/Makefile.am
@@ -43,6 +43,7 @@ install-data-hook:
 	mkdir -p $(DESTDIR)/usr/lib/tmpfiles.d
 	cp tmpfiles.conf $(DESTDIR)/usr/lib/tmpfiles.d/opencryptoki.conf
 	$(CHMOD) 0644 $(DESTDIR)/usr/lib/tmpfiles.d/opencryptoki.conf
+	rm -f $(DESTDIR)/usr/lib/systemd/system/tmpfiles.conf
 
 uninstall-hook:
 	if test -e $(DESTDIR)/usr/lib/tmpfiles.d/opencryptoki.conf; then \

--- a/misc/pkcsslotd.in
+++ b/misc/pkcsslotd.in
@@ -2,12 +2,12 @@
 #
 # pkcsslotd        Starts pkcsslotd
 #
-# Authors:	Kent E. Yoder <yoder1@us.ibm.com>
-#		Serge E. Hallyn <serue@us.ibm.com>
-#               Daniel H. Jones <danjones@us.ibm.com>
+# Authors:  Kent E. Yoder <yoder1@us.ibm.com>
+#           Serge E. Hallyn <serue@us.ibm.com>
+#           Daniel H. Jones <danjones@us.ibm.com>
 #
 # chkconfig: - 50 50
-# description: pkcsslotd is a daemon which manages cryptographic hardware \
+# description: pkcsslotd is a daemon which manages cryptographic hardware
 # tokens for the openCryptoki package.
 
 . /etc/init.d/functions
@@ -15,62 +15,57 @@
 PIDFILE=/var/run/pkcsslotd.pid
 LOCKFILE=/var/lock/subsys/pkcsslotd
 SLOTDBIN=@sbindir@/pkcsslotd
-CONFSTART=@sbindir@/pkcs11_startup
 
 
 start() {
-	[ -x $SLOTDBIN ] || exit 5
-	[ -x $CONFSTART ] || exit 5
+    [ -x $SLOTDBIN ] || exit 5
 
- 	echo -n $"Starting pkcsslotd: "
+    echo -n $"Starting pkcsslotd: "
 
-        # Generate the configuration information
-        $CONFSTART
+    daemon $SLOTDBIN
 
-        daemon $SLOTDBIN
-
-	RETVAL=$?
-	echo
-	[ $RETVAL -eq 0 ] && touch $LOCKFILE
-	return $RETVAL
+    RETVAL=$?
+    echo
+    [ $RETVAL -eq 0 ] && touch $LOCKFILE
+    return $RETVAL
 }	
 
 stop() {
-	echo -n $"Shutting down pkcsslotd:"
-	killproc pkcsslotd
-	RETVAL=$?
-	echo
-	[ $RETVAL -eq 0 ] && rm -f $LOCKFILE
-	return $RETVAL
+    echo -n $"Shutting down pkcsslotd:"
+    killproc pkcsslotd
+    RETVAL=$?
+    echo
+    [ $RETVAL -eq 0 ] && rm -f $LOCKFILE
+    return $RETVAL
 }
 
 restart() {
-	stop
-	start
+    stop
+    start
 }
 
 RETVAL=0
 umask 077
 
 case "$1" in
-  start)
-  	start
-	;;
-  stop)
-  	stop
-	;;
-  status)
-  	status pkcsslotd $SLOTDBIN
-	;;
-  restart|reload|force-reload)
-  	restart
-	;;
-  condrestart)
-  	[ -f $LOCKFILE ] && restart || :
-	;;
-  *)
-	echo $"Usage: $0 {start|stop|status|restart|condrestart|reload|force-reload}"
-	exit 2
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    status)
+        status pkcsslotd $SLOTDBIN
+        ;;
+    restart|reload|force-reload)
+        restart
+        ;;
+    condrestart)
+        [ -f $LOCKFILE ] && restart || :
+        ;;
+    *)
+        echo $"Usage: $0 {start|stop|status|restart|condrestart|reload|force-reload}"
+        exit 2
 esac
 
 exit $?

--- a/rpm/opencryptoki.spec
+++ b/rpm/opencryptoki.spec
@@ -229,8 +229,8 @@ exit 0
 
 
 %files
-%doc ChangeLog FAQ README
-%doc doc/openCryptoki-HOWTO.pdf
+%doc ChangeLog FAQ README.md
+%doc doc/opencryptoki-howto.md
 %doc doc/README.token_data
 %dir %{_sysconfdir}/%{name}
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.conf
@@ -295,7 +295,6 @@ exit 0
 %dir %attr(770,root,pkcs11) %{_sharedstatedir}/%{name}/lite/TOK_OBJ/
 
 %files ccatok
-%doc doc/README-IBM_CCA_users
 %doc doc/README.cca_stdll
 %{_sbindir}/pkcscca
 %{_mandir}/man1/pkcscca.1*

--- a/rpm/opencryptoki.spec
+++ b/rpm/opencryptoki.spec
@@ -253,7 +253,6 @@ exit 0
 %{_sysconfdir}/ld.so.conf.d/*
 # Unversioned .so symlinks usually belong to -devel packages, but opencryptoki
 # needs them in the main package, because:
-#   pkcs11_startup looks for opencryptoki/stdll/*.so, and
 #   documentation suggests that programs should dlopen "PKCS11_API.so".
 %dir %{_libdir}/opencryptoki
 %{_libdir}/opencryptoki/libopencryptoki.*

--- a/testcases/Makefile.am
+++ b/testcases/Makefile.am
@@ -23,7 +23,6 @@ init_token.sh: init_token.sh.in
 
 installcheck-local: all
 	killall -HUP pkcsslotd || true
-	@sbindir@/pkcs11_startup
 	@sbindir@/pkcsslotd
 	if test ! -z ${PKCS11_TEST_USER}; then \
 		su ${PKCS11_TEST_USER} -c "PKCS11_SO_PIN=76543210 PKCS11_USER_PIN=01234567 PKCSLIB=@libdir@/opencryptoki/libopencryptoki.so sh ./ock_tests.sh"; \

--- a/usr/sbin/pkcsslotd/shmem.c
+++ b/usr/sbin/pkcsslotd/shmem.c
@@ -136,8 +136,7 @@ int CreateSharedMemory ( void ) {
 
    grp = getgrnam("pkcs11");
    if ( !grp ) {
-     ErrLog("Group \"pkcs11\" does not exist! Please run %s/pkcs11_startup.",
-		     SBIN_PATH);
+     ErrLog("Group \"pkcs11\" does not exist! Opencryptoki setup is incorrect.");
      return FALSE;  // Group does not exist... setup is wrong..
    }
 


### PR DESCRIPTION
Remove some pkcs11_startup leftovers
The old (previous version 3) pkcs11_startup configuration script was still being
called and mentioned in some of the code. Removed it to fix.
There is still mentioning of pkcs11_startup in some documents, those should be
maintained.

Remove tmpfiles.conf from install and fix doc names
During install the tmpfiles.conf is copied together with pkcsslotd.service into
the usr/lib/systemd/system/. But we already have tmpfiles.conf as
opencryptoki.conf in the correct folder usr/lib/tmpfiles.d/. So we can remove
it.
Also fixed some documents name in spec file.

Signed-off-by: Eduardo Barretto <ebarretto@linux.vnet.ibm.com>