### PR TITLE
Fix problem with EP11 token loading

### DIFF
--- a/usr/lib/pkcs11/common/mech_dsa.c
+++ b/usr/lib/pkcs11/common/mech_dsa.c
@@ -52,7 +52,7 @@ dsa_sign( STDLL_TokData_t     * tokdata,
       if (rc == CKR_OBJECT_HANDLE_INVALID)
           return CKR_KEY_HANDLE_INVALID;
       else
-        return rc
+        return rc;
    }
 
    // must be a PRIVATE key operation
@@ -119,7 +119,7 @@ dsa_verify( STDLL_TokData_t     * tokdata,
       if (rc == CKR_OBJECT_HANDLE_INVALID)
           return CKR_KEY_HANDLE_INVALID;
       else
-        return rc
+        return rc;
    }
 
    // must be a PUBLIC key operation
@@ -164,15 +164,6 @@ ckm_dsa_key_pair_gen( STDLL_TokData_t *tokdata,
 		      TEMPLATE  * publ_tmpl,
                       TEMPLATE  * priv_tmpl )
 {
-   CK_ATTRIBUTE       * prime     = NULL;
-   CK_ATTRIBUTE       * subprime  = NULL;
-   CK_ATTRIBUTE       * base      = NULL;
-   CK_ATTRIBUTE       * priv_exp  = NULL;
-   CK_ATTRIBUTE       * publ_exp  = NULL;
-   CK_ATTRIBUTE       * attr      = NULL;
-   CK_BYTE            * ptr       = NULL;
-   CK_BYTE              repl_buf[5500];
-   CK_BBOOL             flag;
    CK_RV                rc;
 
 
@@ -196,12 +187,7 @@ ckm_dsa_sign( STDLL_TokData_t *tokdata,
               CK_BYTE   * signature,
               OBJECT    * priv_key )
 {
-   CK_ATTRIBUTE     * prime     = NULL;
-   CK_ATTRIBUTE     * subprime  = NULL;
-   CK_ATTRIBUTE     * base      = NULL;
-   CK_ATTRIBUTE     * exponent  = NULL;
    CK_ATTRIBUTE     * attr      = NULL;
-   CK_BYTE          * ptr       = NULL;
    CK_OBJECT_CLASS    keyclass;
    CK_RV              rc;
 
@@ -240,12 +226,7 @@ ckm_dsa_verify( STDLL_TokData_t *tokdata,
                 CK_BYTE   * data,
                 OBJECT    * publ_key )
 {
-   CK_ATTRIBUTE     * prime     = NULL;
-   CK_ATTRIBUTE     * subprime  = NULL;
-   CK_ATTRIBUTE     * base      = NULL;
-   CK_ATTRIBUTE     * exponent  = NULL;
    CK_ATTRIBUTE     * attr      = NULL;
-   CK_BYTE          * ptr       = NULL;
    CK_OBJECT_CLASS    keyclass;
    CK_RV              rc;
 

--- a/usr/lib/pkcs11/ep11_stdll/Makefile.am
+++ b/usr/lib/pkcs11/ep11_stdll/Makefile.am
@@ -14,7 +14,7 @@ opencryptoki_stdll_libpkcs11_ep11_la_CFLAGS = -DDEV -D_THREAD_SAFE            \
 
 if ENABLE_LOCKS
 opencryptoki_stdll_libpkcs11_ep11_la_LDFLAGS = -shared -Wl,-Bsymbolic	\
-					     -lc -lpthread -lcrypto -lrt -llber
+					     -lc -lpthread -lcrypto -lrt -llber -ldl
 
 opencryptoki_stdll_libpkcs11_ep11_la_SOURCES = ../common/asn1.c		\
 					     ../common/lock_btree.c		\
@@ -30,6 +30,8 @@ opencryptoki_stdll_libpkcs11_ep11_la_SOURCES = ../common/asn1.c		\
 					     ../common/mech_md2.c	\
 					     ../common/mech_rng.c	\
 					     ../common/mech_sha.c	\
+					     ../common/mech_dsa.c	\
+					     ../common/mech_dh.c	\
 					     new_host.c			\
 					     ../common/obj_mgr.c	\
 					     ../common/object.c		\
@@ -45,7 +47,7 @@ opencryptoki_stdll_libpkcs11_ep11_la_SOURCES = ../common/asn1.c		\
 					     ep11_specific.c
 else
 opencryptoki_stdll_libpkcs11_ep11_la_LDFLAGS = -shared -Wl,-Bsymbolic	\
-					     -lc -lpthread -litm -lcrypto -lrt -llber
+					     -lc -lpthread -litm -lcrypto -lrt -llber -ldl
 
 opencryptoki_stdll_libpkcs11_ep11_la_SOURCES = ../common/asn1.c		\
 					     ../common/btree.c		\
@@ -67,6 +69,8 @@ opencryptoki_stdll_libpkcs11_ep11_la_SOURCES = ../common/asn1.c		\
 					     ../common/mech_rng.c	\
 					     ../common/mech_rsa.c       \
 					     ../common/mech_sha.c	\
+					     ../common/mech_dsa.c	\
+					     ../common/mech_dh.c	\
 					     ../common/mech_ssl3.c      \
 					     new_host.c			\
 					     ../common/obj_mgr.c	\


### PR DESCRIPTION
A tester reported a problem with the EP11 token when using the 3.8.1 release of OpenCryptoki. He got the following error when loading the EP11 token:

pkcsconf[55687]: apiutil.c DL_Load: dlopen() failed for [libpkcs11_ep11.so]; dlerror = [/usr/lib64/opencryptoki/stdll/libpkcs11_ep11.so: undefined symbol: dsa_sign]

This is caused by unresolved symbols in the EP11 token shared library. 