### PR TITLE
Fix unresolved symbols

### DIFF
--- a/usr/lib/pkcs11/api/Makefile.am
+++ b/usr/lib/pkcs11/api/Makefile.am
@@ -10,7 +10,7 @@ opencryptoki_libopencryptoki_la_CFLAGS = -DAPI -DDEV -D_THREAD_SAFE 		\
 					 -I ../common -DSTDLL_NAME=\"api\"
 
 if ENABLE_LOCKS
-opencryptoki_libopencryptoki_la_LDFLAGS = -shared -Wl,-Bsymbolic -lc -ldl \
+opencryptoki_libopencryptoki_la_LDFLAGS = -shared -Wl,-z,defs,-Bsymbolic -lc -ldl \
 					  -lpthread -version-info   \
 					  $(SO_CURRENT):$(SO_REVISION):$(SO_AGE)
 
@@ -18,7 +18,7 @@ opencryptoki_libopencryptoki_la_SOURCES = api_interface.c shrd_mem.c \
 					  socket_client.c apiutil.c \
 					  ../common/trace.c ../common/lock_btree.c
 else
-opencryptoki_libopencryptoki_la_LDFLAGS = -shared -Wl,-Bsymbolic -lc -ldl \
+opencryptoki_libopencryptoki_la_LDFLAGS = -shared -Wl,-z,defs,-Bsymbolic -lc -ldl \
 					  -lpthread -litm -version-info   \
 					  $(SO_CURRENT):$(SO_REVISION):$(SO_AGE)
 

--- a/usr/lib/pkcs11/cca_stdll/Makefile.am
+++ b/usr/lib/pkcs11/cca_stdll/Makefile.am
@@ -19,7 +19,7 @@ opencryptoki_stdll_libpkcs11_cca_la_LDFLAGS = -shared -Wl,-z,defs,-Bsymbolic	\
 					      -lcrypto -lpthread	\
 					      -nostartfiles		\
 					      -Wl,-soname,$@		\
-					      -lrt
+					      -lrt -ldl
 
 opencryptoki_stdll_libpkcs11_cca_la_SOURCES = ../common/asn1.c		\
 					      ../common/lock_btree.c	\
@@ -27,6 +27,7 @@ opencryptoki_stdll_libpkcs11_cca_la_SOURCES = ../common/asn1.c		\
 					      ../common/hwf_obj.c	\
 					      ../common/trace.c		\
 					      ../common/key.c		\
+						  ../common/mech_list.c \
 					      ../common/mech_dh.c	\
 					      ../common/mech_rng.c	\
 					      ../common/new_host.c	\
@@ -63,7 +64,7 @@ opencryptoki_stdll_libpkcs11_cca_la_LDFLAGS = -shared -Wl,-z,defs,-Bsymbolic	\
 					      -lcrypto -lpthread -litm \
 					      -nostartfiles		\
 					      -Wl,-soname,$@		\
-					      -lrt
+					      -lrt -ldl
 
 opencryptoki_stdll_libpkcs11_cca_la_SOURCES = ../common/asn1.c		\
 					      ../common/btree.c		\
@@ -71,6 +72,7 @@ opencryptoki_stdll_libpkcs11_cca_la_SOURCES = ../common/asn1.c		\
 					      ../common/hwf_obj.c	\
 					      ../common/trace.c		\
 					      ../common/key.c		\
+						  ../common/mech_list.c \
 					      ../common/mech_dh.c	\
 					      ../common/mech_rng.c	\
 					      ../common/new_host.c	\

--- a/usr/lib/pkcs11/cca_stdll/Makefile.am
+++ b/usr/lib/pkcs11/cca_stdll/Makefile.am
@@ -15,7 +15,7 @@ opencryptoki_stdll_libpkcs11_cca_la_CFLAGS = -DLINUX -DNOCDMF		\
 					     -DSTDLL_NAME=\"ccatok\"
 
 if ENABLE_LOCKS
-opencryptoki_stdll_libpkcs11_cca_la_LDFLAGS = -shared -Wl,-Bsymbolic	\
+opencryptoki_stdll_libpkcs11_cca_la_LDFLAGS = -shared -Wl,-z,defs,-Bsymbolic	\
 					      -lcrypto -lpthread	\
 					      -nostartfiles		\
 					      -Wl,-soname,$@		\
@@ -59,7 +59,7 @@ opencryptoki_stdll_libpkcs11_cca_la_SOURCES = ../common/asn1.c		\
 					      ../common/shared_memory.c	\
 					      cca_specific.c
 else
-opencryptoki_stdll_libpkcs11_cca_la_LDFLAGS = -shared -Wl,-Bsymbolic	\
+opencryptoki_stdll_libpkcs11_cca_la_LDFLAGS = -shared -Wl,-z,defs,-Bsymbolic	\
 					      -lcrypto -lpthread -litm \
 					      -nostartfiles		\
 					      -Wl,-soname,$@		\

--- a/usr/lib/pkcs11/ep11_stdll/Makefile.am
+++ b/usr/lib/pkcs11/ep11_stdll/Makefile.am
@@ -13,7 +13,7 @@ opencryptoki_stdll_libpkcs11_ep11_la_CFLAGS = -DDEV -D_THREAD_SAFE            \
 					    -I../common -DSTDLL_NAME=\"ep11tok\"
 
 if ENABLE_LOCKS
-opencryptoki_stdll_libpkcs11_ep11_la_LDFLAGS = -shared -Wl,-Bsymbolic	\
+opencryptoki_stdll_libpkcs11_ep11_la_LDFLAGS = -shared -Wl,-z,defs,-Bsymbolic	\
 					     -lc -lpthread -lcrypto -lrt -llber -ldl
 
 opencryptoki_stdll_libpkcs11_ep11_la_SOURCES = ../common/asn1.c		\
@@ -46,7 +46,7 @@ opencryptoki_stdll_libpkcs11_ep11_la_SOURCES = ../common/asn1.c		\
 					     ../common/sw_crypt.c       \
 					     ep11_specific.c
 else
-opencryptoki_stdll_libpkcs11_ep11_la_LDFLAGS = -shared -Wl,-Bsymbolic	\
+opencryptoki_stdll_libpkcs11_ep11_la_LDFLAGS = -shared -Wl,-z,defs,-Bsymbolic	\
 					     -lc -lpthread -litm -lcrypto -lrt -llber -ldl
 
 opencryptoki_stdll_libpkcs11_ep11_la_SOURCES = ../common/asn1.c		\

--- a/usr/lib/pkcs11/ep11_stdll/Makefile.am
+++ b/usr/lib/pkcs11/ep11_stdll/Makefile.am
@@ -23,28 +23,40 @@ opencryptoki_stdll_libpkcs11_ep11_la_SOURCES = ../common/asn1.c		\
 					     ../common/dp_obj.c		\
 					     ../common/data_obj.c	\
 					     ../common/dig_mgr.c	\
+					     ../common/encr_mgr.c	\
+					     ../common/decr_mgr.c	\
 					     ../common/globals.c	\
 					     ../common/loadsave.c	\
+					     ../common/mech_aes.c       \
+                         ../common/mech_des.c       \
+                         ../common/mech_des3.c      \
 					     ../common/mech_ec.c	\
 					     ../common/mech_md5.c	\
 					     ../common/mech_md2.c	\
 					     ../common/mech_rng.c	\
+					     ../common/mech_rsa.c       \
 					     ../common/mech_sha.c	\
 					     ../common/mech_dsa.c	\
 					     ../common/mech_dh.c	\
-					     new_host.c			\
+					     ../common/mech_ssl3.c      \
 					     ../common/obj_mgr.c	\
 					     ../common/object.c		\
 					     ../common/lock_sess_mgr.c	\
+					     ../common/sign_mgr.c	\
+					     ../common/verify_mgr.c	\
 					     ../common/key.c		\
+					     ../common/key_mgr.c        \
 					     ../common/template.c	\
 					     ../common/p11util.c	\
 					     ../common/utility.c	\
 					     ../common/trace.c		\
+					     ../common/mech_list.c	\
 					     ../common/shared_memory.c	\
 					     ../common/attributes.c     \
 					     ../common/sw_crypt.c       \
+					     new_host.c			\
 					     ep11_specific.c
+
 else
 opencryptoki_stdll_libpkcs11_ep11_la_LDFLAGS = -shared -Wl,-z,defs,-Bsymbolic	\
 					     -lc -lpthread -litm -lcrypto -lrt -llber -ldl
@@ -61,8 +73,8 @@ opencryptoki_stdll_libpkcs11_ep11_la_SOURCES = ../common/asn1.c		\
 					     ../common/globals.c	\
 					     ../common/loadsave.c	\
 					     ../common/mech_aes.c       \
-                                             ../common/mech_des.c       \
-                                             ../common/mech_des3.c      \
+                         ../common/mech_des.c       \
+                         ../common/mech_des3.c      \
 					     ../common/mech_ec.c	\
 					     ../common/mech_md5.c	\
 					     ../common/mech_md2.c	\
@@ -72,7 +84,6 @@ opencryptoki_stdll_libpkcs11_ep11_la_SOURCES = ../common/asn1.c		\
 					     ../common/mech_dsa.c	\
 					     ../common/mech_dh.c	\
 					     ../common/mech_ssl3.c      \
-					     new_host.c			\
 					     ../common/obj_mgr.c	\
 					     ../common/object.c		\
 					     ../common/sess_mgr.c	\
@@ -88,6 +99,7 @@ opencryptoki_stdll_libpkcs11_ep11_la_SOURCES = ../common/asn1.c		\
 					     ../common/shared_memory.c	\
 					     ../common/attributes.c     \
 					     ../common/sw_crypt.c       \
+					     new_host.c			\
 					     ep11_specific.c
 endif
 

--- a/usr/lib/pkcs11/ica_s390_stdll/Makefile.am
+++ b/usr/lib/pkcs11/ica_s390_stdll/Makefile.am
@@ -13,9 +13,9 @@ if ENABLE_LOCKS
 opencryptoki_stdll_libpkcs11_ica_la_LDFLAGS = $(LCRYPTO)		\
 					     $(ICA_LIB_DIRS)		\
 					     -nostartfiles -shared	\
-					     -Wl,-Bsymbolic		\
+					     -Wl,-z,defs,-Bsymbolic		\
 					     -Wl,-soname,$@		\
-					     -Wl,-Bsymbolic -lc		\
+					     -lc		\
 					     -lpthread -lica -ldl \
 					     -lcrypto
 
@@ -60,9 +60,9 @@ else
 opencryptoki_stdll_libpkcs11_ica_la_LDFLAGS = $(LCRYPTO)		\
 					     $(ICA_LIB_DIRS)		\
 					     -nostartfiles -shared	\
-					     -Wl,-Bsymbolic		\
+					     -Wl,-z,defs,-Bsymbolic		\
 					     -Wl,-soname,$@		\
-					     -Wl,-Bsymbolic -lc		\
+					     -lc		\
 					     -lpthread -litm -lica -ldl \
 					     -lcrypto
 

--- a/usr/lib/pkcs11/icsf_stdll/Makefile.am
+++ b/usr/lib/pkcs11/icsf_stdll/Makefile.am
@@ -21,7 +21,7 @@ opencryptoki_stdll_libpkcs11_icsf_la_CFLAGS = -DNOCDMF			\
 
 if ENABLE_LOCKS
 opencryptoki_stdll_libpkcs11_icsf_la_LDFLAGS = -shared			\
-					       -Wl,-Bsymbolic		\
+					       -Wl,-z,defs,-Bsymbolic		\
 					       -lcrypto			\
 					       -lldap			\
 					       -lpthread		\
@@ -73,7 +73,7 @@ opencryptoki_stdll_libpkcs11_icsf_la_SOURCES = ../common/asn1.c		\
 					       icsf.c
 else
 opencryptoki_stdll_libpkcs11_icsf_la_LDFLAGS = -shared			\
-					       -Wl,-Bsymbolic		\
+					       -Wl,-z,defs,-Bsymbolic		\
 					       -lcrypto			\
 					       -lldap			\
 					       -lpthread		\

--- a/usr/lib/pkcs11/icsf_stdll/icsf.c
+++ b/usr/lib/pkcs11/icsf_stdll/icsf.c
@@ -3210,7 +3210,7 @@ cleanup:
  * Devive multiple keys at once.
  */
 int
-icsf_derive_multple_keys(LDAP *ld, int *p_reason, CK_MECHANISM_PTR mech,
+icsf_derive_multiple_keys(LDAP *ld, int *p_reason, CK_MECHANISM_PTR mech,
 			 struct icsf_object_record *key,
 			 CK_ATTRIBUTE_PTR attrs, CK_ULONG attrs_len,
 			 struct icsf_object_record *client_mac_handle,

--- a/usr/lib/pkcs11/soft_stdll/Makefile.am
+++ b/usr/lib/pkcs11/soft_stdll/Makefile.am
@@ -11,7 +11,7 @@ opencryptoki_stdll_libpkcs11_sw_la_CFLAGS = -DDEV -D_THREAD_SAFE            \
 					    -I../common -DSTDLL_NAME=\"swtok\"
 
 if ENABLE_LOCKS
-opencryptoki_stdll_libpkcs11_sw_la_LDFLAGS = -shared -Wl,-Bsymbolic	\
+opencryptoki_stdll_libpkcs11_sw_la_LDFLAGS = -shared -Wl,-z,defs,-Bsymbolic	\
 					     -lc -lpthread -lcrypto -lrt
 
 opencryptoki_stdll_libpkcs11_sw_la_SOURCES = ../common/asn1.c		\
@@ -53,7 +53,7 @@ opencryptoki_stdll_libpkcs11_sw_la_SOURCES = ../common/asn1.c		\
 					     ../common/shared_memory.c	\
 					     soft_specific.c
 else
-opencryptoki_stdll_libpkcs11_sw_la_LDFLAGS = -shared -Wl,-Bsymbolic	\
+opencryptoki_stdll_libpkcs11_sw_la_LDFLAGS = -shared -Wl,-z,defs,-Bsymbolic	\
 					     -lc -lpthread -litm -lcrypto -lrt
 
 opencryptoki_stdll_libpkcs11_sw_la_SOURCES = ../common/asn1.c		\

--- a/usr/lib/pkcs11/tpm_stdll/Makefile.am
+++ b/usr/lib/pkcs11/tpm_stdll/Makefile.am
@@ -17,7 +17,7 @@ opencryptoki_stdll_libpkcs11_tpm_la_CFLAGS = -DLINUX -DNOCDMF		\
 					     -DSTDLL_NAME=\"tpmtok\"
 
 if ENABLE_LOCKS
-opencryptoki_stdll_libpkcs11_tpm_la_LDFLAGS = -shared -Wl,-Bsymbolic	\
+opencryptoki_stdll_libpkcs11_tpm_la_LDFLAGS = -shared -Wl,-z,defs,-Bsymbolic	\
 					      -lcrypto -ltspi -lpthread	\
 					      -lrt
 
@@ -34,7 +34,6 @@ opencryptoki_stdll_libpkcs11_tpm_la_SOURCES = ../common/asn1.c		\
 					      ../common/cert.c		\
 					      ../common/dp_obj.c	\
 					      ../common/mech_aes.c	\
-					      ../common/$(MECH_DSA)	\
 					      ../common/mech_rsa.c	\
 					      ../common/mech_ec.c	\
 					      ../common/obj_mgr.c	\
@@ -64,7 +63,7 @@ opencryptoki_stdll_libpkcs11_tpm_la_SOURCES = ../common/asn1.c		\
 					      tpm_util.c
 
 else
-opencryptoki_stdll_libpkcs11_tpm_la_LDFLAGS = -shared -Wl,-Bsymbolic	\
+opencryptoki_stdll_libpkcs11_tpm_la_LDFLAGS = -shared -Wl,-z,defs,-Bsymbolic	\
 					      -lcrypto -ltspi -lpthread -litm -lrt
 
 opencryptoki_stdll_libpkcs11_tpm_la_SOURCES = ../common/asn1.c		\
@@ -80,7 +79,6 @@ opencryptoki_stdll_libpkcs11_tpm_la_SOURCES = ../common/asn1.c		\
 					      ../common/cert.c		\
 					      ../common/dp_obj.c	\
 					      ../common/mech_aes.c	\
-					      ../common/$(MECH_DSA)	\
 					      ../common/mech_rsa.c	\
 					      ../common/mech_ec.c	\
 					      ../common/obj_mgr.c	\


### PR DESCRIPTION
While building the rpm some unresolved symbols issues came up.
To help on this we integrated #31 solution and fixed what was needed.

Signed-off-by: Eduardo Barretto <ebarretto@linux.vnet.ibm.com>