### PR TITLE
Fix writing of trace messages

### DIFF
--- a/usr/lib/pkcs11/common/trace.c
+++ b/usr/lib/pkcs11/common/trace.c
@@ -237,7 +237,7 @@ void ock_traceit(trace_level_t level, const char *fmt, ...)
 
 		/* serialize appends to the file */
 		pthread_mutex_lock(&tlmtx);
-		if (write(trace.fd, buf, strlen(buf) == -1))
+		if (write(trace.fd, buf, strlen(buf)) == -1)
 			fprintf(stderr, "cannot write to trace file\n");
 		pthread_mutex_unlock(&tlmtx);
 	}


### PR DESCRIPTION
A recent change in commit ecf145ec74f3febf727ea1c2c590da2890e4ea4a
causes that no trace messages are written into the trace file.
This commit fixes the problem.

Signed-off-by: Ingo Franzki <ifranzki@linux.vnet.ibm.com>