### PR TITLE
Update pkcsep11_migrate man page

### DIFF
--- a/man/man1/pkcsep11_migrate.1.in
+++ b/man/man1/pkcsep11_migrate.1.in
@@ -25,7 +25,10 @@ Trusted Key Entry console (TKE) before using this utility.
 .br
 3. Before using this tool make a back-up of the token objects in ep11tok/TOK_OBJ/.
 .br
-4. After successfully execution of the migrate utility and before (re)starting
+4. Also, before using this tool make sure you've set the environment variable
+PKCS11_USER_PIN with the correct User PIN.
+.br
+5. After successfully execution of the migrate utility and before (re)starting
    programs using the EP11 token the new master key must be activated using the TKE.
 
 .SH "COMMAND SUMMARY"


### PR DESCRIPTION
This man page was lacking the necessity of setting the PKCS11_USER_PIN
environment variable before executing the pkcsep11_migrate tool.

Signed-off-by: Eduardo Barretto <ebarretto@linux.vnet.ibm.com>