### PR TITLE
Define CK_FALSE and CK_TRUE macros

### DIFF
--- a/usr/include/pkcs11/pkcs11types.h
+++ b/usr/include/pkcs11/pkcs11types.h
@@ -25,12 +25,17 @@ extern "C"
 {
 #endif
 
+#define CK_TRUE  1
+#define CK_FALSE 0
+
+#ifndef CK_DISABLE_TRUE_FALSE
 #ifndef FALSE
-#define FALSE             0
+#define FALSE CK_FALSE
 #endif
 
 #ifndef TRUE
-#define TRUE              (!FALSE)
+#define TRUE  CK_TRUE
+#endif
 #endif
 
 // AIX Addition for 64Bit work.


### PR DESCRIPTION
PKCS#11 v2.20 defines two macros (CK_TRUE and CK_FALSE) for use with
values of type CK_BBOOL. For backwards compatibility, we keep defining
TRUE and FALSE and CK_DISABLE_TRUE_VENDOR which may be set by the
application vendor.
Fix #23.

Signed-off-by: Eduardo Barretto <ebarretto@linux.vnet.ibm.com>