### PR TITLE
Increase RSA max key length

### DIFF
--- a/usr/lib/pkcs11/common/defs.h
+++ b/usr/lib/pkcs11/common/defs.h
@@ -76,7 +76,7 @@ enum {
 #define ENCRYPT	1
 #define DECRYPT 0
 
-#define MAX_RSA_KEYLEN		512
+#define MAX_RSA_KEYLEN		1920
 
 #define MAX_AES_KEY_SIZE	64	/* encompasses CCA key size */
 #define AES_KEY_SIZE_256	32


### PR DESCRIPTION
While performing RSA OpenSSL speed test it was resulting on segmentation
fault when using ICA token for RSA key lengths bigger than 512. Increased the
MAX_RSA_KEYLEN to 1920 so we are able to perform RSA speed test
successfully.

Even though the SOFT token also uses the same MAX_RSA_KEYLEN parameter, we have a hack for SOFT token to fallback to OpenSSL, since the SOFT token by itself doesn't provide RSA algorithm implementation. That's why we only see this happening for ICA token.