### PR TITLE
Fix check for user or effective user

### DIFF
--- a/usr/lib/pkcs11/common/utility.c
+++ b/usr/lib/pkcs11/common/utility.c
@@ -906,7 +906,7 @@ CK_RV check_user_and_group()
 	euid = geteuid();
 
 	/* Root or effective Root is ok */
-	if (uid == 0 && euid == 0)
+	if (uid == 0 || euid == 0)
 		return CKR_OK;
 
 	/*


### PR DESCRIPTION
The check_user_and_group function checks for Root or effetive Root as
mentioned on the code comment, but the way that it is implemented it is
checking for Root AND effective Root, which is a totally different
logic.
Fix proposed by Red Hat.

Signed-off-by: Eduardo Barretto <ebarretto@linux.vnet.ibm.com>