### PR TITLE
Fix token reinitialization

### DIFF
--- a/usr/lib/pkcs11/common/new_host.c
+++ b/usr/lib/pkcs11/common/new_host.c
@@ -459,7 +459,7 @@ CK_RV SC_InitToken(STDLL_TokData_t *tokdata, CK_SLOT_ID sid, CK_CHAR_PTR pPin,
 	object_mgr_destroy_token_objects(tokdata);
 	delete_token_data(tokdata);
 
-	init_token_data(tokdata, sid);
+    load_token_data(tokdata, sid);
 	init_slotInfo(&(tokdata->slot_info));
 	memcpy(tokdata->nv_token_data->so_pin_sha, hash_sha, SHA1_HASH_SIZE);
 	tokdata->nv_token_data->token_info.flags |= CKF_TOKEN_INITIALIZED;

--- a/usr/lib/pkcs11/ep11_stdll/new_host.c
+++ b/usr/lib/pkcs11/ep11_stdll/new_host.c
@@ -430,7 +430,7 @@ CK_RV SC_InitToken(STDLL_TokData_t *tokdata, CK_SLOT_ID sid, CK_CHAR_PTR pPin,
 	object_mgr_destroy_token_objects(tokdata);
 	delete_token_data(tokdata);
 
-	init_token_data(tokdata, sid);
+    load_token_data(tokdata, sid);
 	init_slotInfo(&(tokdata->slot_info));
 	memcpy(tokdata->nv_token_data->so_pin_sha, hash_sha, SHA1_HASH_SIZE);
 	tokdata->nv_token_data->token_info.flags |= CKF_TOKEN_INITIALIZED;

--- a/usr/lib/pkcs11/icsf_stdll/icsf_specific.c
+++ b/usr/lib/pkcs11/icsf_stdll/icsf_specific.c
@@ -595,19 +595,9 @@ CK_RV reset_token_data(STDLL_TokData_t *tokdata, CK_SLOT_ID slot_id,
 
 	/* Reset token data and keep token name */
 	slot_data[slot_id]->initialized = 0;
-	init_token_data(tokdata, slot_id);
+    load_token_data(tokdata, slot_id);
 	init_slotInfo(&tokdata->slot_info);
 	tokdata->nv_token_data->token_info.flags |= CKF_TOKEN_INITIALIZED;
-
-	/* Reset SO pin to default and user pin to invalid */
-	pin_len = strlen((pin = "87654321"));
-	if (compute_sha1(tokdata, pin, pin_len,
-			 tokdata->nv_token_data->so_pin_sha)) {
-		TRACE_ERROR("Failed to reset so pin.\n");
-		return CKR_FUNCTION_FAILED;
-	}
-	memset(tokdata->nv_token_data->user_pin_sha, 0,
-	       sizeof(tokdata->nv_token_data->user_pin_sha));
 
 	if (slot_data[slot_id]->mech == ICSF_CFG_MECH_SIMPLE) {
 		/* Save master key */

--- a/usr/lib/pkcs11/tpm_stdll/tpm_specific.c
+++ b/usr/lib/pkcs11/tpm_stdll/tpm_specific.c
@@ -2174,7 +2174,7 @@ done:
 
 	// META This should be fine since the open session checking should occur at
 	// the API not the STDLL
-	init_token_data(tokdata, sid);
+    load_token_data(tokdata, sid);
 	init_slotInfo(&tokdata->slot_info);
 	memcpy(tokdata->nv_token_data->so_pin_sha, hash_sha, SHA1_HASH_SIZE);
 	tokdata->nv_token_data->token_info.flags |= CKF_TOKEN_INITIALIZED;


### PR DESCRIPTION
During a token reinitialization, to set up a SO PIN or a User PIN again,
the operation would fail mentioning that the hash of the old PIN doesn't
match the entered old PIN. This happens because during InitToken
operation we are resetting the NV data, and with this we are loosing the
hash and md5 of the old PIN.
To fix this, instead of calling init_token_data on every InitToken, we
do a load_token_data, that will check if we have a NV data already
created. If yes, it just loads it. If not, it calls init_token_data.

Signed-off-by: Eduardo Barretto <ebarretto@linux.vnet.ibm.com>