### PR TITLE
 Fix testcase result mismatch and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,13 +17,10 @@ depcomp
 install-sh
 libtool
 ltmain.sh
-man/man1/pkcsconf.1
-man/man1/pkcsicsf.1
-man/man1/pkcscca.1
-man/man1/pkcsep11_migrate.1
-man/man5/opencryptoki.conf.5
-man/man7/opencryptoki.7
-man/man8/pkcsslotd.8
+man/man1/*.1
+man/man5/*.5
+man/man7/*.7
+man/man8/*.8
 misc/pkcsslotd
 misc/pkcsslotd.service
 missing
@@ -88,3 +85,4 @@ usr/sbin/pkcsslotd/lexer.c
 usr/sbin/pkcsicsf/pkcsicsf
 usr/sbin/pkcscca/pkcscca
 usr/sbin/pkcsep11_migrate/pkcsep11_migrate
+usr/sbin/pkcsep11_session/pkcsep11_session

--- a/testcases/pkcs11/gen_purpose.c
+++ b/testcases/pkcs11/gen_purpose.c
@@ -520,6 +520,8 @@ CK_RV do_SetPIN(void)
 
 	/* try to call C_SetPIN from a R/W public session, it should work.
 	 */
+    testcase_new_assertion();
+
 	flags = CKF_SERIAL_SESSION | CKF_RW_SESSION;
 	rc = funcs->C_OpenSession(slot_id, flags, NULL, NULL, &session);
 	if (rc != CKR_OK) {


### PR DESCRIPTION
The Total and Ran number of tests executed was not matching the Passed
number of tests, which was Total+1.
