### PR TITLE
Improve pkcsslotd logging

### DIFF
--- a/usr/sbin/pkcsslotd/shmem.c
+++ b/usr/sbin/pkcsslotd/shmem.c
@@ -44,7 +44,6 @@ int CreateSharedMemory ( void ) {
   if ( ((Path = getenv("PKCS11_SHMEM_FILE")) == NULL ) || ( Path[0] == '\0' ) ) {
     Path = TOK_PATH;
   }
-  InfoLog( "Shared memory file is %s", Path);
 
    // Get shared memory key token all users of the shared memory
    // need to get the same token

--- a/usr/sbin/pkcsslotd/slotmgr.c
+++ b/usr/sbin/pkcsslotd/slotmgr.c
@@ -473,6 +473,7 @@ int main ( int argc, char *argv[], char *envp[]) {
 		if (pidfile) {
 			fprintf(pidfile,"%d",getpid());
 			fclose(pidfile);
+            InfoLog("PID File created");
 		}
 	}
 


### PR DESCRIPTION
Removed a misleading pkcsslotd log message that was causing wrong
interpretations and also because it is not necessary. Created a new
informational log message to inform when PID file is created. This will
help in the future to know about systemd timing issues.