### PR TITLE
Fix copy object when template is null

### DIFF
--- a/usr/lib/pkcs11/common/obj_mgr.c
+++ b/usr/lib/pkcs11/common/obj_mgr.c
@@ -331,7 +331,7 @@ object_mgr_copy( STDLL_TokData_t  * tokdata,
    CK_RV       rc;
    unsigned long obj_handle;
 
-   if (!sess || !pTemplate || !new_handle){
+   if (!sess || (!pTemplate && ulCount) || !new_handle) {
       TRACE_ERROR("Invalid function arguments.\n");
       return CKR_FUNCTION_FAILED;
    }

--- a/usr/lib/pkcs11/common/object.c
+++ b/usr/lib/pkcs11/common/object.c
@@ -199,7 +199,7 @@ object_copy( STDLL_TokData_t * tokdata,
    CK_RV       rc;
 
 
-   if (!old_obj || !pTemplate || !new_obj){
+   if (!old_obj || (!pTemplate && ulCount) || !new_obj){
       TRACE_ERROR("Invalid function arguments.\n");
       return CKR_FUNCTION_FAILED;
    }


### PR DESCRIPTION
When some application call C_CopyObject and passes a null template and a
count of 0 then we should be able to continue and execute the copy, but
this was failing because of some wrong checks.
As a consequence I've also added a testcase to copyobjects to try to
copy an object when we pass a null template and check if the new object
matches the old object.

Signed-off-by: Eduardo Barretto <ebarretto@linux.vnet.ibm.com>