### PR TITLE
Fix log directory permission, owner and group

### DIFF
--- a/rpm/opencryptoki.spec
+++ b/rpm/opencryptoki.spec
@@ -262,7 +262,8 @@ exit 0
 %{_libdir}/pkcs11/libopencryptoki.so
 %{_libdir}/pkcs11/PKCS11_API.so
 %{_libdir}/pkcs11/stdll
-%{_localstatedir}/log/opencryptoki
+%dir %attr(770,root,pkcs11) %{_localstatedir}/log/opencryptoki
+
 
 %files devel
 %{_includedir}/%{name}/


### PR DESCRIPTION
We noticed that in internal building using the internal spec file,
/var/log/opencryptoki had the wrong permission, owner and group.