### PR TITLE
ica_token: Fix compile problem with older libica without ECC support

### DIFF
--- a/usr/lib/pkcs11/ica_s390_stdll/ica_specific.c
+++ b/usr/lib/pkcs11/ica_s390_stdll/ica_specific.c
@@ -31,10 +31,17 @@
 #include "h_extern.h"
 #include "trace.h"
 
+#include <ica_api.h>
+
+#ifndef EC_DH
+#define NO_EC
+#warning "Your Libica does not provide ECC support, use Libica 3.3.0 or newer for ECC."
+#endif
+
 #include "tok_specific.h"
 #include "tok_struct.h"
 #include "ica_specific.h"
-#include "ica_api.h"
+
 #ifndef NO_EC
 #include "ec_defs.h"
 #include "openssl/obj_mac.h"
@@ -152,7 +159,9 @@ token_specific_init(STDLL_TokData_t *tokdata, CK_SLOT_ID  SlotNumber,
 {
 	CK_ULONG rc = CKR_OK;
 
+#ifndef NO_EC
     ica_ec_support_available = ecc_support_in_libica_available();
+#endif
 
 	rc = mech_list_ica_initialize();
 	if (rc != CKR_OK) {

--- a/usr/lib/pkcs11/ica_s390_stdll/tok_struct.h
+++ b/usr/lib/pkcs11/ica_s390_stdll/tok_struct.h
@@ -77,11 +77,18 @@ token_spec_t token_specific = {
 	&token_specific_rsa_pss_sign,
 	&token_specific_rsa_pss_verify,
 	&token_specific_rsa_generate_keypair,
-	// Elliptic Curve
+#ifndef NO_EC
+    // Elliptic Curve
     &token_specific_ec_sign,
     &token_specific_ec_verify,
     &token_specific_ec_generate_keypair,
     &token_specific_ecdh_pkcs_derive,
+#else
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+#endif
 #ifndef NODH
 	// DH
 	&token_specific_dh_pkcs_derive,


### PR DESCRIPTION
Signed-off-by: Joerg Schmidbauer <jschmidb@de.ibm.com>