### PR TITLE
Fix CCA version migration tool

### DIFF
--- a/usr/lib/pkcs11/common/object.c
+++ b/usr/lib/pkcs11/common/object.c
@@ -308,6 +308,7 @@ CK_RV object_flatten(OBJECT * obj, CK_BYTE ** data, CK_ULONG * len)
     CK_ULONG tmpl_len, total_len;
     CK_ULONG offset;
     CK_ULONG_32 count;
+    CK_OBJECT_CLASS_32 class32;
     long rc;
 
     if (!obj) {
@@ -329,7 +330,8 @@ CK_RV object_flatten(OBJECT * obj, CK_BYTE ** data, CK_ULONG * len)
 
     offset = 0;
 
-    memcpy(buf + offset, &obj->class, sizeof(CK_OBJECT_CLASS_32));
+    class32 = obj->class;
+    memcpy(buf + offset, &class32, sizeof(CK_OBJECT_CLASS_32));
     offset += sizeof(CK_OBJECT_CLASS_32);
 
     memcpy(buf + offset, &count, sizeof(CK_ULONG_32));
@@ -626,6 +628,7 @@ CK_RV object_restore_withSize(CK_BYTE * data, OBJECT ** new_obj,
     CK_ULONG offset = 0;
     CK_ULONG_32 count = 0;
     CK_RV rc;
+    CK_OBJECT_CLASS_32 class32;
 
     if (!data || !new_obj) {
         TRACE_ERROR("Invalid function arguments.\n");
@@ -641,7 +644,8 @@ CK_RV object_restore_withSize(CK_BYTE * data, OBJECT ** new_obj,
 
     memset(obj, 0x0, sizeof(OBJECT));
 
-    memcpy(&obj->class, data + offset, sizeof(CK_OBJECT_CLASS_32));
+    memcpy(&class32, data + offset, sizeof(CK_OBJECT_CLASS_32));
+    obj->class = class32;
     offset += sizeof(CK_OBJECT_CLASS_32);
 
     memcpy(&count, data + offset, sizeof(CK_ULONG_32));

--- a/usr/sbin/pkcscca/pkcscca.h
+++ b/usr/sbin/pkcscca/pkcscca.h
@@ -137,4 +137,46 @@ struct key_count {
     int rsa;
 };
 
+typedef struct _DL_NODE
+{
+    struct _DL_NODE   *next;
+    struct _DL_NODE   *prev;
+    void              *data;
+} DL_NODE;
+
+typedef struct _TEMPLATE
+{
+    DL_NODE  *attribute_list;
+} TEMPLATE;
+
+typedef void *SESSION;
+
+typedef struct _OBJECT
+{
+    CK_OBJECT_CLASS   class;
+    CK_BYTE           name[8];   // for token objects
+
+    SESSION          *session;   // creator; only for session objects
+    TEMPLATE         *template;
+    CK_ULONG          count_hi;  // only significant for token objects
+    CK_ULONG          count_lo;  // only significant for token objects
+    CK_ULONG      index;  // SAB  Index into the SHM
+    CK_OBJECT_HANDLE  map_handle;
+} OBJECT;
+
+struct secaeskeytoken {
+    unsigned char  type;     /* 0x01 for internal key token */
+    unsigned char  res0[3];
+    unsigned char  version;  /* should be 0x04 */
+    unsigned char  res1[1];
+    unsigned char  flag;     /* key flags */
+    unsigned char  res2[1];
+    unsigned long  mkvp;     /* master key verification pattern */
+    unsigned char  key[32];  /* key value (encrypted) */
+    unsigned char  cv[8];    /* control vector */
+    unsigned short bitsize;  /* key bit size */
+    unsigned short keysize;  /* key byte size */
+    unsigned char  tvv[4];   /* token validation value */
+} __packed;
+
 #endif


### PR DESCRIPTION
This fix was triggered by a customer problem. They reported problems when migrating the CCA token objects from OCK version 2 to version 3. The CCA migration tool pkcscca ended successfully, but AES keys stored in token objects were not usable afterwards.