### PR TITLE
Correct Sign/VerifyRecover attribute checking

### DIFF
--- a/testcases/common/common.c
+++ b/testcases/common/common.c
@@ -38,6 +38,21 @@ int mech_supported(CK_SLOT_ID slot_id, CK_ULONG mechanism)
     return (rc == CKR_OK);
 }
 
+int mech_supported_flags(CK_SLOT_ID slot_id, CK_ULONG mechanism, CK_FLAGS flags)
+{
+    CK_MECHANISM_INFO mech_info;
+    int rc;
+
+    rc = funcs->C_GetMechanismInfo(slot_id, mechanism, &mech_info);
+    if (rc != CKR_OK)
+        return FALSE;
+
+    if (mech_info.flags & flags)
+        return TRUE;
+
+    return FALSE;
+}
+
 int check_supp_keysize(CK_SLOT_ID slot_id, CK_ULONG mechanism, CK_ULONG keylen)
 {
     CK_MECHANISM_INFO mech_info;

--- a/usr/lib/pkcs11/common/verify_mgr.c
+++ b/usr/lib/pkcs11/common/verify_mgr.c
@@ -61,20 +61,30 @@ CK_RV verify_mgr_init(STDLL_TokData_t *tokdata,
         else
             return rc;
     }
-    // is key allowed to verify signatures?
-    //
-    rc = template_attribute_find(key_obj->template, CKA_VERIFY, &attr);
-    if (rc == FALSE) {
-        TRACE_ERROR("Could not find CKA_VERIFY for the key.\n");
-        return CKR_KEY_FUNCTION_NOT_PERMITTED;
+
+    if (recover_mode) {
+        // is key allowed to verify signatures where the data can be
+        // recovered from the signature?
+        rc = template_attribute_find(key_obj->template, CKA_VERIFY_RECOVER,
+                                     &attr);
+        if (rc == FALSE) {
+            TRACE_ERROR("Could not find CKA_VERIFY_RECOVER for the key.\n");
+            return CKR_KEY_FUNCTION_NOT_PERMITTED;
+        }
     } else {
-        flag = *(CK_BBOOL *) attr->pValue;
-        if (flag != TRUE) {
-            TRACE_ERROR("%s\n", ock_err(ERR_KEY_FUNCTION_NOT_PERMITTED));
+        // is key allowed to verify signatures where the signature is an
+        // appendix to the data?
+        rc = template_attribute_find(key_obj->template, CKA_VERIFY, &attr);
+        if (rc == FALSE) {
+            TRACE_ERROR("Could not find CKA_VERIFY for the key.\n");
             return CKR_KEY_FUNCTION_NOT_PERMITTED;
         }
     }
-
+    flag = *(CK_BBOOL *) attr->pValue;
+    if (flag != TRUE) {
+        TRACE_ERROR("%s\n", ock_err(ERR_KEY_FUNCTION_NOT_PERMITTED));
+        return CKR_KEY_FUNCTION_NOT_PERMITTED;
+    }
 
     // is the mechanism supported?  is the key type correct?  is a
     // parameter present if required?  is the key size allowed?


### PR DESCRIPTION
C_SignRecoverInit and C_VerifyRecoverInit must check for key attributes CKA_SIGN_RECOVER and CKA_VERIFY_RECOVER instead of CKA_SIGN and CKA_VERIFY being TRUE, otherwise the operations must fail with CKR_KEY_FUNCTION_NOT_PERMITTED.