### PR TITLE
CCA/EP11: Cleanse clear key after importing keys 

### DIFF
--- a/usr/lib/pkcs11/common/attributes.h
+++ b/usr/lib/pkcs11/common/attributes.h
@@ -21,6 +21,9 @@
 
 void free_attribute_array(CK_ATTRIBUTE_PTR attrs, CK_ULONG attrs_len);
 
+void cleanse_and_free_attribute_array(CK_ATTRIBUTE_PTR attrs,
+                                      CK_ULONG attrs_len);
+
 CK_RV dup_attribute_array(CK_ATTRIBUTE_PTR orig, CK_ULONG orig_len,
                           CK_ATTRIBUTE_PTR *p_dest, CK_ULONG *p_dest_len);
 


### PR DESCRIPTION
The CCA and EP11 tokens uses secure keys. When importing a clear key the secure key blob is stored in attribute CKA_IBM_OPAQUE. The other attributes containing clear key material must be cleansed, but kept in their original length.

This fixes https://github.com/opencryptoki/opencryptoki/issues/153

Question: Should we really cleanse the public key parts also? The CCA token did so already for EC keys.....
