### PR TITLE
Dont print backspace delete ^ H in pkcsconf -m output

### DIFF
--- a/usr/sbin/pkcsconf/pkcsconf.c
+++ b/usr/sbin/pkcsconf/pkcsconf.c
@@ -565,21 +565,21 @@ void display_mechanism_name(CK_MECHANISM_TYPE mech)
 void display_mechanism_flags(CK_FLAGS flags)
 {
     CK_ULONG i, firsties = 1;
+    CK_CHAR_PTR tok = "(";
 
     for (i = 0; pkcs11_mech_flags[i].name; i++) {
         if (pkcs11_mech_flags[i].flag & flags) {
+            printf("%s%s", tok, pkcs11_mech_flags[i].name);
+
             if (firsties) {
-                printf("(");
+                tok = "|";
                 firsties = 0;
             }
-
-            printf("%s|", pkcs11_mech_flags[i].name);
         }
     }
 
-    if (!firsties) {
-        printf(")");
-    }
+    if (!firsties)
+        printf(")");
 }
 
 CK_RV print_mech_info(int slot_id)


### PR DESCRIPTION
pkcsconf -m prints the backspace delete character ^ H to delete a trailing | when printing a mechanism's flag list:

This is working when printing to terminal, e.g.:
```
Mechanism #60
	Mechanism: 0x2107 (CKM_AES_CFB128)
	Key Size: 16-32
	Flags: 0x60300 (CKF_ENCRYPT|CKF_DECRYPT|CKF_WRAP|CKF_UNWRAP)
```

When tool output is redirected to a file it looks like:
```
Mechanism #60
        Mechanism: 0x2107 (CKM_AES_CFB128)
        Key Size: 16-32
        Flags: 0x60300 (CKF_ENCRYPT|CKF_DECRYPT|CKF_WRAP|CKF_UNWRAP|^H)


```

This PR has the fix.