### PR TITLE
Fix C_DigestKey return code for secure keys

### DIFF
--- a/usr/lib/pkcs11/common/dig_mgr.c
+++ b/usr/lib/pkcs11/common/dig_mgr.c
@@ -322,8 +322,8 @@ CK_RV digest_mgr_digest_key(STDLL_TokData_t *tokdata,
     */
     if (token_specific.token_keysize > 0) {
         TRACE_ERROR("%s because its a secure key token\n",
-                    ock_err(CKR_FUNCTION_NOT_SUPPORTED));
-        rc = CKR_FUNCTION_NOT_SUPPORTED;
+                    ock_err(CKR_KEY_INDIGESTIBLE));
+        rc = CKR_KEY_INDIGESTIBLE;
         goto out;
     }
 


### PR DESCRIPTION
"CKR_KEY_INDIGESTIBLE: This error code can only be returned by
C_DigestKey. It indicates that the value of the specified key
cannot be digested for some reason (perhaps the key isn’t a
secret key, or perhaps the token simply can’t digest this kind
of key)."