### PR TITLE
Fix memory leak in compute_sha()

### DIFF
--- a/usr/lib/pkcs11/common/utility.c
+++ b/usr/lib/pkcs11/common/utility.c
@@ -848,7 +848,10 @@ CK_RV compute_sha(STDLL_TokData_t *tokdata, CK_BYTE *data, CK_ULONG len,
         TRACE_DEBUG("failed to create digest.\n");
         return rv;
     }
-    return sha_hash(tokdata, NULL, FALSE, &ctx, data, len, hash, &hash_len);
+    rv = sha_hash(tokdata, NULL, FALSE, &ctx, data, len, hash, &hash_len);
+
+    digest_mgr_cleanup(&ctx);
+    return rv;
 }
 
 /* Compute SHA1 using software implementation */


### PR DESCRIPTION
compute_sha() leaks memory when using a token specific sha routine. The token specific sha init allocates a context, but leaves it to digest_mgr_cleanup() to free it. 

Usually the token specific sha routines are called by the digest manager, so digest manager also cares about freeing the context. Function compute_sha() does not use the digest manager, so it needs to free the context itself.

In general the token specific sha functions should free its context at end of token_specific_sha and token_specific_sha_final, but this is not how it is done in OCK. Also the token specific sign/verify and encrypt/decrypt routines do not free their contexts, but leave it to the sign/verify manager and the encrypt/decrypt manager to do so. So at least its consistent...


