### PR TITLE
CCA Token: Fix 8/72 failure on RSA sign destination buffer too big

### DIFF
--- a/usr/lib/pkcs11/cca_stdll/cca_specific.c
+++ b/usr/lib/pkcs11/cca_stdll/cca_specific.c
@@ -1064,6 +1064,12 @@ CK_RV token_specific_rsa_sign(STDLL_TokData_t * tokdata,
         return CKR_TEMPLATE_INCOMPLETE;
     }
 
+    /* The max value allowable by CCA for out_data_len is 512, so cap the
+     * incoming value if its too large. CCA will throw error 8, 72 otherwise.
+     */
+    if (*out_data_len > 512)
+        *out_data_len = 512;
+
     rule_array_count = 1;
     memcpy(rule_array, "PKCS-1.1", CCA_KEYWORD_SIZE);
 
@@ -1107,6 +1113,12 @@ CK_RV token_specific_rsa_verify(STDLL_TokData_t * tokdata,
         TRACE_ERROR("%s\n", ock_err(ERR_TEMPLATE_INCOMPLETE));
         return CKR_TEMPLATE_INCOMPLETE;
     }
+
+    /* The max value allowable by CCA for out_data_len is 512, so cap the
+     * incoming value if its too large. CCA will throw error 8, 72 otherwise.
+     */
+    if (out_data_len > 512)
+        out_data_len = 512;
 
     rule_array_count = 1;
     memcpy(rule_array, "PKCS-1.1", CCA_KEYWORD_SIZE);

--- a/usr/lib/pkcs11/cca_stdll/cca_specific.c
+++ b/usr/lib/pkcs11/cca_stdll/cca_specific.c
@@ -1478,7 +1478,7 @@ CK_RV token_specific_get_mechanism_info(STDLL_TokData_t * tokdata,
         }
     }
 
-    TRACE_ERROR("%s\n", ock_err(ERR_MECHANISM_INVALID));
+    TRACE_DEBUG("%s\n", ock_err(ERR_MECHANISM_INVALID));
 
     return CKR_MECHANISM_INVALID;
 }

--- a/usr/lib/pkcs11/ep11_stdll/ep11_specific.c
+++ b/usr/lib/pkcs11/ep11_stdll/ep11_specific.c
@@ -5715,7 +5715,7 @@ CK_RV ep11tok_get_mechanism_info(STDLL_TokData_t * tokdata,
 
     rc = ep11tok_is_mechanism_supported(tokdata, type);
     if (rc != CKR_OK) {
-        TRACE_ERROR("%s rc=0x%lx unsupported '%s'\n", __func__, rc,
+        TRACE_DEBUG("%s rc=0x%lx unsupported '%s'\n", __func__, rc,
                     ep11_get_ckm(type));
         return rc;
     }

--- a/usr/lib/pkcs11/ica_s390_stdll/ica_specific.c
+++ b/usr/lib/pkcs11/ica_s390_stdll/ica_specific.c
@@ -3314,7 +3314,7 @@ CK_RV ica_specific_get_mechanism_info(CK_MECHANISM_TYPE type,
         }
     }
 
-    TRACE_ERROR("%s\n", ock_err(ERR_MECHANISM_INVALID));
+    TRACE_DEBUG("%s\n", ock_err(ERR_MECHANISM_INVALID));
 
     return CKR_MECHANISM_INVALID;
 }


### PR DESCRIPTION
The CCA library does not like specifying a destination buffer
size > 512 bytes (4096 bits) for the signature target buffer
on RSA sign. This caused some testcases to fail as they specify
1024 bytes. Fixed by checking and rewriting the buffer size
parameter to be always <= 512 bytes.

Signed-off-by: Harald Freudenberger <freude@linux.ibm.com>