### PR TITLE
TESTCASES: Stop the test after a testcase_error

### DIFF
--- a/testcases/crypto/rsa_func.c
+++ b/testcases/crypto/rsa_func.c
@@ -192,6 +192,7 @@ CK_RV do_EncryptDecryptRSA(struct GENERATED_TEST_SUITE_INFO *tsuite)
         rc = funcs->C_EncryptInit(session, &mech, publ_key);
         if (rc != CKR_OK) {
             testcase_error("C_EncryptInit, rc=%s", p11_get_ckr(rc));
+            goto error;
         }
         // do (public key) encryption
         rc = funcs->C_Encrypt(session,
@@ -457,6 +458,7 @@ CK_RV do_SignVerifyRSA(struct GENERATED_TEST_SUITE_INFO * tsuite,
         if (rc != CKR_OK) {
             testcase_error("C_Verify%sInit(), rc=%s",
                            recover_mode ? "Recover" : "", p11_get_ckr(rc));
+            goto error;
         }
         // do Verify
         if (recover_mode) {

--- a/testcases/crypto/rsaupdate_func.c
+++ b/testcases/crypto/rsaupdate_func.c
@@ -220,6 +220,7 @@ CK_RV do_SignVerifyUpdateRSA(struct GENERATED_TEST_SUITE_INFO *tsuite)
         rc = funcs->C_VerifyInit(session, &mech, publ_key);
         if (rc != CKR_OK) {
             testcase_error("C_VerifyInit(), rc=%s", p11_get_ckr(rc));
+            goto error;
         }
         // do VerifyUpdate
         len = message_len;
@@ -459,6 +460,7 @@ CK_RV do_SignVerifyUpdate_RSAPSS(struct GENERATED_TEST_SUITE_INFO * tsuite)
         rc = funcs->C_VerifyInit(session, &mech, publ_key);
         if (rc != CKR_OK) {
             testcase_error("C_VerifyInit(), rc=%s", p11_get_ckr(rc));
+            goto error;
         }
         // do VerifyUpdate
         data_done = 0;


### PR DESCRIPTION
Not all cases where a function has failed and testcase_error is called cause a stop of the test. This leads to follow on failures.
