### PR TITLE
Ensure the XProcLock is held when token object files are saved, read, or deleted.

### DIFF
--- a/usr/lib/common/loadsave.c
+++ b/usr/lib/common/loadsave.c
@@ -532,6 +532,7 @@ out_nolock:
 }
 
 //
+// Note: The token lock (XProcLock) must be held when calling this function.
 //
 CK_RV save_token_object(STDLL_TokData_t *tokdata, OBJECT *obj)
 {
@@ -582,6 +583,7 @@ CK_RV save_token_object(STDLL_TokData_t *tokdata, OBJECT *obj)
 
 // this is the same as the old version.  public token objects are stored in the
 // clear
+// Note: The token lock (XProcLock) must be held when calling this function.
 //
 CK_RV save_public_token_object(STDLL_TokData_t *tokdata, OBJECT * obj)
 {
@@ -629,6 +631,7 @@ error:
 }
 
 //
+// Note: The token lock (XProcLock) must be held when calling this function.
 //
 CK_RV save_private_token_object(STDLL_TokData_t *tokdata, OBJECT *obj)
 {
@@ -758,6 +761,7 @@ error:
 }
 
 //
+// Note: The token lock (XProcLock) must be held when calling this function.
 //
 CK_RV load_public_token_objects(STDLL_TokData_t *tokdata)
 {
@@ -837,6 +841,7 @@ CK_RV load_public_token_objects(STDLL_TokData_t *tokdata)
 }
 
 //
+// Note: The token lock (XProcLock) must be held when calling this function.
 //
 CK_RV load_private_token_objects(STDLL_TokData_t *tokdata)
 {
@@ -1499,6 +1504,7 @@ done:
 extern void set_perm(int);
 
 //
+// Note: The token lock (XProcLock) must be held when calling this function.
 //
 CK_RV delete_token_object(STDLL_TokData_t *tokdata, OBJECT *obj)
 {

--- a/usr/lib/common/new_host.c
+++ b/usr/lib/common/new_host.c
@@ -210,14 +210,14 @@ CK_RV ST_Initialize(API_Slot_t *sltp, CK_SLOT_ID SlotNumber,
         goto done;
     }
 
+    rc = XProcLock(sltp->TokData);
+    if (rc != CKR_OK)
+        goto done;
+
     /* no need to return error here, we load the token data we can
      * and syslog the rest
      */
     load_public_token_objects(sltp->TokData);
-
-    rc = XProcLock(sltp->TokData);
-    if (rc != CKR_OK)
-        goto done;
 
     sltp->TokData->global_shm->publ_loaded = TRUE;
 
@@ -1083,16 +1083,16 @@ CK_RV SC_Login(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
             goto done;
         }
 
-        /* no need to return error here, we load the token data
-         * we can and syslog the rest
-         */
-        load_private_token_objects(tokdata);
-
         rc = XProcLock(tokdata);
         if (rc != CKR_OK) {
             TRACE_ERROR("Failed to get process lock.\n");
             goto done;
         }
+
+        /* no need to return error here, we load the token data
+         * we can and syslog the rest
+         */
+        load_private_token_objects(tokdata);
 
         tokdata->global_shm->priv_loaded = TRUE;
 

--- a/usr/lib/ep11_stdll/new_host.c
+++ b/usr/lib/ep11_stdll/new_host.c
@@ -202,14 +202,14 @@ CK_RV ST_Initialize(API_Slot_t * sltp, CK_SLOT_ID SlotNumber,
         goto done;
     }
 
+    rc = XProcLock(sltp->TokData);
+    if (rc != CKR_OK)
+        goto done;
+
     /* no need to return error here, we load the token data we can
      * and syslog the rest
      */
     load_public_token_objects(sltp->TokData);
-
-    rc = XProcLock(sltp->TokData);
-    if (rc != CKR_OK)
-        goto done;
 
     sltp->TokData->global_shm->publ_loaded = TRUE;
     rc = XProcUnLock(sltp->TokData);
@@ -1059,16 +1059,16 @@ CK_RV SC_Login(STDLL_TokData_t * tokdata, ST_SESSION_HANDLE * sSession,
             goto done;
         }
 
-        /* no need to return error here, we load the token data
-         * we can and syslog the rest
-         */
-        load_private_token_objects(tokdata);
-
         rc = XProcLock(tokdata);
         if (rc != CKR_OK) {
             TRACE_ERROR("Failed to get process lock.\n");
             goto done;
         }
+
+        /* no need to return error here, we load the token data
+         * we can and syslog the rest
+         */
+        load_private_token_objects(tokdata);
 
         tokdata->global_shm->priv_loaded = TRUE;
 

--- a/usr/lib/icsf_stdll/new_host.c
+++ b/usr/lib/icsf_stdll/new_host.c
@@ -202,14 +202,14 @@ CK_RV ST_Initialize(API_Slot_t * sltp, CK_SLOT_ID SlotNumber,
         goto done;
     }
 
+    rc = XProcLock(sltp->TokData);
+    if (rc != CKR_OK)
+        goto done;
+
     /* no need to return error here, we load the token data we can
      * and syslog the rest
      */
     load_public_token_objects(sltp->TokData);
-
-    rc = XProcLock(sltp->TokData);
-    if (rc != CKR_OK)
-        goto done;
 
     sltp->TokData->global_shm->publ_loaded = TRUE;
 

--- a/usr/lib/tpm_stdll/tpm_specific.c
+++ b/usr/lib/tpm_stdll/tpm_specific.c
@@ -610,7 +610,21 @@ CK_RV token_wrap_key_object(STDLL_TokData_t * tokdata,
     /* if this is a token object, save it with the new attribute so that we
      * don't have to go down this path again */
     if (!object_is_session_object(obj)) {
+        rc = XProcLock(tokdata);
+        if (rc != CKR_OK) {
+            TRACE_ERROR("Failed to get process lock.\n");
+            return rc;
+        }
         rc = save_token_object(tokdata, obj);
+        if (rc != CKR_OK) {
+            XProcUnLock(tokdata);
+        } else {
+            rc = XProcUnLock(tokdata);
+            if (rc != CKR_OK) {
+                TRACE_ERROR("Failed to release process lock.\n");
+                return rc;
+            }
+        }
     }
 
     return rc;
@@ -1808,15 +1822,18 @@ CK_RV token_specific_login(STDLL_TokData_t * tokdata, SESSION * sess,
             return rc;
         }
 
-        rc = load_private_token_objects(tokdata);
-        if (rc != CKR_OK)
-            return rc;
-
         rc = XProcLock(tokdata);
         if (rc != CKR_OK) {
             TRACE_ERROR("Failed to get process lock.\n");
             return rc;
         }
+
+        rc = load_private_token_objects(tokdata);
+
+        if (rc != CKR_OK) {
+            XProcUnLock(tokdata);
+            return rc;
+        } 
 
         tokdata->global_shm->priv_loaded = TRUE;
 


### PR DESCRIPTION
This fixes a problem with message `usr/lib/common/loadsave.c Cannot read size.` on syslog when running multi threaded.

Note: This patch is on top of the "Check XProcLock return values" patch.
Since that other patch is not yet merged, it is also included in this PR. 
I may need to rebase my patch once the other one is merged.
