### PR TITLE
TESTCASE: Fix obj_mgmt_lock testcase

### DIFF
--- a/testcases/misc_tests/obj_mgmt_lock.c
+++ b/testcases/misc_tests/obj_mgmt_lock.c
@@ -611,27 +611,29 @@ CK_RV do_FindObjects(void)
         goto destroy;
     }
 
-    rc = funcs->C_FindObjects(h_session, obj_list, 10, &find_count);
-    if (rc != CKR_OK) {
-        testcase_fail("C_FindObjects() rc = %s", p11_get_ckr(rc));
-        goto destroy;
-    }
+    do {
+        rc = funcs->C_FindObjects(h_session, obj_list, 10, &find_count);
+        if (rc != CKR_OK) {
+            testcase_fail("C_FindObjects() rc = %s", p11_get_ckr(rc));
+            goto destroy;
+        }
 
-    /* step through list and find our object handle */
-    for (i = 0; i < find_count; i++) {
-        if (obj_list[i] == h_cert2)
-            got_it++;
+        /* step through list and find our object handle */
+        for (i = 0; i < find_count; i++) {
+            if (obj_list[i] == h_cert2)
+                got_it++;
+        }
+    } while (got_it == 0 && find_count != 0);
+
+    rc = funcs->C_FindObjectsFinal(h_session);
+    if (rc != CKR_OK) {
+        testcase_fail("C_FindObjectsFinal() rc = %s", p11_get_ckr(rc));
+        goto destroy;
     }
 
     if (got_it == 0) {
         testcase_fail("could not find object handle");
         rc = -1;
-        goto destroy;
-    }
-
-    rc = funcs->C_FindObjectsFinal(h_session);
-    if (rc != CKR_OK) {
-        testcase_fail("C_FindObjectsFinal() rc = %s", p11_get_ckr(rc));
         goto destroy;
     }
 
@@ -648,15 +650,15 @@ CK_RV do_FindObjects(void)
         goto destroy;
     }
 
-    if (find_count != 0) {
-        testcase_fail("found %ld objects when none where expected", find_count);
-        rc = -1;
-        goto destroy;
-    }
-
     rc = funcs->C_FindObjectsFinal(h_session);
     if (rc != CKR_OK) {
         testcase_fail("C_FindObjectsFinal() rc = %s", p11_get_ckr(rc));
+        goto destroy;
+    }
+
+    if (find_count != 0) {
+        testcase_fail("found %ld objects when none where expected", find_count);
+        rc = -1;
         goto destroy;
     }
 
@@ -837,27 +839,29 @@ CK_RV do_CreateTokenObjects(void)
         goto destroy;
     }
 
-    rc = funcs->C_FindObjects(h_session, obj_list, 10, &find_count);
-    if (rc != CKR_OK) {
-        testcase_fail("C_FindObjects() rc = %s", p11_get_ckr(rc));
-        goto destroy;
-    }
+    do {
+        rc = funcs->C_FindObjects(h_session, obj_list, 10, &find_count);
+        if (rc != CKR_OK) {
+            testcase_fail("C_FindObjects() rc = %s", p11_get_ckr(rc));
+            goto destroy;
+        }
 
-    /* step through list and find 2nd object's handle */
-    for (i = 0; i < find_count; i++) {
-        if (obj_list[i] == h_cert2)
-            got_it++;
+        /* step through list and find 2nd object's handle */
+        for (i = 0; i < find_count; i++) {
+            if (obj_list[i] == h_cert2)
+                got_it++;
+        }
+    } while (got_it == 0 && find_count != 0);
+
+    rc = funcs->C_FindObjectsFinal(h_session);
+    if (rc != CKR_OK) {
+        testcase_fail("C_FindObjectsFinal() rc = %s", p11_get_ckr(rc));
+        goto destroy;
     }
 
     if (got_it == 0) {
         testcase_fail("could not find 2nd object's handle");
         rc = -1;
-        goto destroy;
-    }
-
-    rc = funcs->C_FindObjectsFinal(h_session);
-    if (rc != CKR_OK) {
-        testcase_fail("C_FindObjectsFinal() rc = %s", p11_get_ckr(rc));
         goto destroy;
     }
 
@@ -874,15 +878,15 @@ CK_RV do_CreateTokenObjects(void)
         goto destroy;
     }
 
-    if (find_count != 0) {
-        testcase_fail("found %ld objects when none where expected", find_count);
-        rc = -1;
-        goto destroy;
-    }
-
     rc = funcs->C_FindObjectsFinal(h_session);
     if (rc != CKR_OK) {
         testcase_fail("C_FindObjectsFinal() rc = %s", p11_get_ckr(rc));
+        goto destroy;
+    }
+
+    if (find_count != 0) {
+        testcase_fail("found %ld objects when none where expected", find_count);
+        rc = -1;
         goto destroy;
     }
 
@@ -914,27 +918,30 @@ CK_RV do_CreateTokenObjects(void)
         goto destroy;
     }
 
-    rc = funcs->C_FindObjects(h_session, obj_list, 10, &find_count);
-    if (rc != CKR_OK) {
-        testcase_fail("C_FindObjects() rc = %s", p11_get_ckr(rc));
-        goto destroy;
-    }
+    do {
+        rc = funcs->C_FindObjects(h_session, obj_list, 10, &find_count);
+        if (rc != CKR_OK) {
+            testcase_fail("C_FindObjects() rc = %s", p11_get_ckr(rc));
+            goto destroy;
+        }
 
-    /* step through list and find 2nd object's handle */
-    for (i = 0; i < find_count; i++) {
-        if (obj_list[i] == h_cert2)
-            got_it++;
+        /* step through list and find 2nd object's handle */
+        got_it = 0;
+        for (i = 0; i < find_count; i++) {
+            if (obj_list[i] == h_cert2)
+                got_it++;
+        }
+    } while (got_it == 0 && find_count != 0);
+
+    rc = funcs->C_FindObjectsFinal(h_session);
+    if (rc != CKR_OK) {
+        testcase_fail("C_FindObjectsFinal() rc = %s", p11_get_ckr(rc));
+        goto destroy;
     }
 
     if (got_it == 0) {
         testcase_fail("could not find 2nd object's handle in new session");
         rc = -1;
-        goto destroy;
-    }
-
-    rc = funcs->C_FindObjectsFinal(h_session);
-    if (rc != CKR_OK) {
-        testcase_fail("C_FindObjectsFinal() rc = %s", p11_get_ckr(rc));
         goto destroy;
     }
 
@@ -1126,29 +1133,31 @@ CK_RV do_HWFeatureSearch(void)
         goto destroy;
     }
 
-    rc = funcs->C_FindObjects(h_session, obj_list, 10, &find_count);
-    if (rc != CKR_OK) {
-        testcase_fail("C_FindObjects() rc = %s", p11_get_ckr(rc));
-        goto destroy;
-    }
-
-    got_it = 0;
-    /* Make sure we got the right ones */
-    for (i = 0; i < find_count; i++) {
-        if (obj_list[i] == h_clock) {
-            got_it++;
+    do {
+        rc = funcs->C_FindObjects(h_session, obj_list, 10, &find_count);
+        if (rc != CKR_OK) {
+            testcase_fail("C_FindObjects() rc = %s", p11_get_ckr(rc));
+            goto destroy;
         }
+
+        got_it = 0;
+        /* Make sure we got the right ones */
+        for (i = 0; i < find_count; i++) {
+            if (obj_list[i] == h_clock) {
+                got_it++;
+            }
+        }
+    } while (got_it == 0 && find_count != 0);
+
+    rc = funcs->C_FindObjectsFinal(h_session);
+    if (rc != CKR_OK) {
+        testcase_fail("C_FindObjectsFinal() rc = %s", p11_get_ckr(rc));
     }
 
     if (got_it != 1) {
         testcase_fail("could not find the corect object handle");
         rc = -1;
         goto destroy;
-    }
-
-    rc = funcs->C_FindObjectsFinal(h_session);
-    if (rc != CKR_OK) {
-        testcase_fail("C_FindObjectsFinal() rc = %s", p11_get_ckr(rc));
     }
 
     testcase_pass("Looks okay...");


### PR DESCRIPTION
When spinlock_tests.sh is used with more than 10 concurrent processes, some child processes may fail with " TESTCASE do_FindObjects FAIL (testcases/misc_tests/obj_mgmt_lock.c:627) could not find object handle" or "TESTCASE do_CreateTokenObjects FAIL (testcases/misc_tests/ obj_mgmt_lock.c:853) could not find 2nd object's handle".

This is because each child process creates an object with the same ID attribute, and then performs a C_FindObjects for this ID and expects to find the object (i.e. the exact same handle). However, C_FindObjects is called with usMaxObjectCount of 10, limiting the number of find results to 10 per call to C_FindObjects. If the desired object handle is not found within the first 10 results, then the testcase fails. When more than 10 child processes are active, the find results may contain more then 10 objects, and thus the desired object might not be within the first 10 results.

This patch fixes this by obtaining further find results, until no more results are available, or the desired object has been found. Also call C_FindObjectsFinal before failing the testcase to do proper cleanup.

Fixes: https://github.com/opencryptoki/opencryptoki/issues/211

