### PR TITLE
Fixes

### DIFF
--- a/testcases/crypto/aes_func.c
+++ b/testcases/crypto/aes_func.c
@@ -1572,20 +1572,27 @@ testcase_cleanup:
 CK_RV do_UnwrapRSA_Err(struct generated_test_suite_info * tsuite)
 {
     unsigned int i;
-    CK_BYTE wrapped_data[BIG_REQUEST + AES_BLOCK_SIZE];
-    CK_BYTE user_pin[PKCS11_MAX_PIN_LEN];
+    CK_BYTE wrapped_data[BIG_REQUEST + AES_BLOCK_SIZE] = {0};
+    CK_BYTE user_pin[PKCS11_MAX_PIN_LEN] = {0};
     CK_BYTE pub_exp[] = { 0x01, 0x00, 0x01 };
     CK_MECHANISM mech, mech1, mech2;
     CK_MECHANISM_INFO mech_info;
-    CK_OBJECT_HANDLE publ_key, priv_key, w_key, uw_key;
+    CK_OBJECT_HANDLE publ_key = CK_INVALID_HANDLE,
+        priv_key = CK_INVALID_HANDLE, w_key = CK_INVALID_HANDLE,
+        uw_key = CK_INVALID_HANDLE;
     CK_ULONG bits = 1024;
-    CK_ULONG wrapped_data_len, user_pin_len, key_size;
+    CK_ULONG wrapped_data_len = 0, user_pin_len = 0, key_size = 0;
     CK_RV rc = CKR_OK;
-    CK_FLAGS flags;
-    CK_SESSION_HANDLE session;
+    CK_FLAGS flags = 0;
+    CK_SESSION_HANDLE session = CK_INVALID_HANDLE;
     CK_OBJECT_CLASS keyclass = CKO_PRIVATE_KEY;
     CK_KEY_TYPE keytype = CKK_RSA;
     CK_SLOT_ID slot_id = SLOT_ID;
+
+    memset(&mech, 0, sizeof(mech));
+    memset(&mech1, 0, sizeof(mech1));
+    memset(&mech2, 0, sizeof(mech2));
+    memset(&mech_info, 0, sizeof(mech_info));
 
     CK_ATTRIBUTE pub_tmpl[] = {
         {CKA_MODULUS_BITS, &bits, sizeof(bits)}

--- a/testcases/misc_tests/obj_mgmt.c
+++ b/testcases/misc_tests/obj_mgmt.c
@@ -1172,15 +1172,15 @@ CK_RV do_HWFeatureSearch(void)
     CK_BBOOL false = FALSE;
     CK_BBOOL true = TRUE;
 
-    CK_SESSION_HANDLE h_session;
-    CK_BYTE user_pin[PKCS11_MAX_PIN_LEN];
-    CK_ULONG user_pin_len;
+    CK_SESSION_HANDLE h_session = CK_INVALID_HANDLE;
+    CK_BYTE user_pin[PKCS11_MAX_PIN_LEN] = {0};
+    CK_ULONG user_pin_len = 0;
 
     /* A counter object */
     CK_OBJECT_CLASS counter1_class = CKO_HW_FEATURE;
     CK_HW_FEATURE_TYPE feature1_type = CKH_MONOTONIC_COUNTER;
     CK_UTF8CHAR counter1_label[] = "Monotonic counter";
-    CK_CHAR counter1_value[16];
+    CK_CHAR counter1_value[16] = {0};
     CK_ATTRIBUTE counter1_template[] = {
         {CKA_CLASS, &counter1_class, sizeof(counter1_class)},
         {CKA_HW_FEATURE_TYPE, &feature1_type, sizeof(feature1_type)},
@@ -1194,7 +1194,7 @@ CK_RV do_HWFeatureSearch(void)
     CK_OBJECT_CLASS clock_class = CKO_HW_FEATURE;
     CK_HW_FEATURE_TYPE clock_type = CKH_CLOCK;
     CK_UTF8CHAR clock_label[] = "Clock";
-    CK_CHAR clock_value[16];
+    CK_CHAR clock_value[16] = {0};
     CK_ATTRIBUTE clock_template[] = {
         {CKA_CLASS, &clock_class, sizeof(clock_class)},
         {CKA_HW_FEATURE_TYPE, &clock_type, sizeof(clock_type)},
@@ -1217,7 +1217,7 @@ CK_RV do_HWFeatureSearch(void)
     CK_OBJECT_CLASS obj2_class = CKO_SECRET_KEY;
     CK_KEY_TYPE obj2_type = CKK_AES;
     CK_UTF8CHAR obj2_label[] = "Object 2";
-    CK_BYTE obj2_data[AES_KEY_SIZE_128];
+    CK_BYTE obj2_data[AES_KEY_SIZE_128] = {0};
     CK_ATTRIBUTE obj2_template[] = {
         {CKA_CLASS, &obj2_class, sizeof(obj2_class)},
         {CKA_TOKEN, &true, sizeof(true)},
@@ -1226,7 +1226,8 @@ CK_RV do_HWFeatureSearch(void)
         {CKA_VALUE, obj2_data, sizeof(obj2_data)}
     };
 
-    CK_OBJECT_HANDLE h_counter1, h_clock, h_obj1, h_obj2, obj_list[10];
+    CK_OBJECT_HANDLE h_counter1 = 0, h_clock = 0, h_obj1 = 0, h_obj2 = 0,
+        obj_list[10] = {0};
 
     CK_ATTRIBUTE find_tmpl[] = {
         {CKA_CLASS, &counter1_class, sizeof(counter1_class)}

--- a/testcases/misc_tests/obj_mgmt_lock.c
+++ b/testcases/misc_tests/obj_mgmt_lock.c
@@ -1015,9 +1015,9 @@ CK_RV do_HWFeatureSearch(void)
     CK_BBOOL false = FALSE;
     CK_BBOOL true = TRUE;
 
-    CK_SESSION_HANDLE h_session;
-    CK_BYTE user_pin[PKCS11_MAX_PIN_LEN];
-    CK_ULONG user_pin_len;
+    CK_SESSION_HANDLE h_session = 0;
+    CK_BYTE user_pin[PKCS11_MAX_PIN_LEN] = {0};
+    CK_ULONG user_pin_len = 0;
 
     /* A counter object */
     CK_OBJECT_CLASS counter1_class = CKO_HW_FEATURE;
@@ -1037,7 +1037,7 @@ CK_RV do_HWFeatureSearch(void)
     CK_OBJECT_CLASS clock_class = CKO_HW_FEATURE;
     CK_HW_FEATURE_TYPE clock_type = CKH_CLOCK;
     CK_UTF8CHAR clock_label[] = "Clock";
-    CK_CHAR clock_value[16];
+    CK_CHAR clock_value[16] = {0};
     CK_ATTRIBUTE clock_template[] = {
         {CKA_CLASS, &clock_class, sizeof(clock_class)},
         {CKA_HW_FEATURE_TYPE, &clock_type, sizeof(clock_type)},
@@ -1060,7 +1060,7 @@ CK_RV do_HWFeatureSearch(void)
     CK_OBJECT_CLASS obj2_class = CKO_SECRET_KEY;
     CK_KEY_TYPE obj2_type = CKK_AES;
     CK_UTF8CHAR obj2_label[] = "Object 2";
-    CK_BYTE obj2_data[AES_KEY_SIZE_128];
+    CK_BYTE obj2_data[AES_KEY_SIZE_128] = {0};
     CK_ATTRIBUTE obj2_template[] = {
         {CKA_CLASS, &obj2_class, sizeof(obj2_class)},
         {CKA_TOKEN, &true, sizeof(true)},
@@ -1069,7 +1069,8 @@ CK_RV do_HWFeatureSearch(void)
         {CKA_VALUE, obj2_data, sizeof(obj2_data)}
     };
 
-    CK_OBJECT_HANDLE h_counter1, h_clock, h_obj1, h_obj2, obj_list[10];
+    CK_OBJECT_HANDLE h_counter1 = 0, h_clock = 0, h_obj1 = 0, h_obj2 = 0,
+        obj_list[10] = {0};
     CK_ATTRIBUTE find_tmpl[] = {
         {CKA_CLASS, &counter1_class, sizeof(counter1_class)}
     };

--- a/testcases/misc_tests/tok_rsa.c
+++ b/testcases/misc_tests/tok_rsa.c
@@ -31,9 +31,9 @@ CK_FUNCTION_LIST *funcs;
 CK_RV do_Cleanup(CK_SESSION_HANDLE sess)
 {
     CK_RV rv;
-    CK_ULONG count;
-    CK_OBJECT_HANDLE handle;
-    CK_CHAR label[128];
+    CK_ULONG count = 0;
+    CK_OBJECT_HANDLE handle = 0;
+    CK_CHAR label[128] = {0};
     CK_ATTRIBUTE tlabel = { CKA_LABEL, label, sizeof(label) };
 
     rv = funcs->C_FindObjectsInit(sess, NULL, 0);

--- a/testcases/pkcs11/gen_purpose.c
+++ b/testcases/pkcs11/gen_purpose.c
@@ -211,13 +211,13 @@ testcase_cleanup:
 
 CK_RV do_GetMechanismList(void)
 {
-    CK_FLAGS flags;
-    CK_SESSION_HANDLE session;
+    CK_FLAGS flags = 0;
+    CK_SESSION_HANDLE session = 0;
     CK_RV rc = 0;
-    CK_BYTE user_pin[PKCS11_MAX_PIN_LEN];
-    CK_ULONG user_pin_len;
+    CK_BYTE user_pin[PKCS11_MAX_PIN_LEN] = {0};
+    CK_ULONG user_pin_len = 0;
     CK_SLOT_ID slot_id = SLOT_ID;
-    CK_ULONG count;
+    CK_ULONG count = 0;
     CK_MECHANISM_TYPE *mech_list = NULL;
 
     testcase_begin("testing C_GetMechanismList");
@@ -245,7 +245,7 @@ CK_RV do_GetMechanismList(void)
         testcase_fail("C_GetMechanismList did not not return "
                       "mechanism count.");
 
-    mech_list = (CK_MECHANISM_TYPE *) malloc(count * sizeof(CK_MECHANISM_TYPE));
+    mech_list = (CK_MECHANISM_TYPE *) calloc(1, count * sizeof(CK_MECHANISM_TYPE));
     if (!mech_list) {
         testcase_fail();
         rc = CKR_HOST_MEMORY;
@@ -290,15 +290,17 @@ testcase_cleanup:
 
 CK_RV do_GetMechanismInfo(void)
 {
-    CK_FLAGS flags;
-    CK_SESSION_HANDLE session;
+    CK_FLAGS flags = 0;
+    CK_SESSION_HANDLE session = 0;
     CK_RV rc = 0;
-    CK_BYTE user_pin[PKCS11_MAX_PIN_LEN];
-    CK_ULONG user_pin_len;
+    CK_BYTE user_pin[PKCS11_MAX_PIN_LEN] = {0};
+    CK_ULONG user_pin_len = 0;
     CK_SLOT_ID slot_id = SLOT_ID;
     CK_MECHANISM_INFO info;
-    CK_ULONG i, count;
+    CK_ULONG i = 0, count = 0;
     CK_MECHANISM_TYPE *mech_list = NULL;
+
+    memset(&info, 0, sizeof(info));
 
     testcase_begin("testing C_GetMechanismInfo");
     testcase_rw_session();
@@ -312,7 +314,7 @@ CK_RV do_GetMechanismInfo(void)
         return rc;
     }
 
-    mech_list = (CK_MECHANISM_TYPE *) malloc(count * sizeof(CK_MECHANISM_TYPE));
+    mech_list = (CK_MECHANISM_TYPE *) calloc(1, count * sizeof(CK_MECHANISM_TYPE));
     if (!mech_list) {
         rc = CKR_HOST_MEMORY;
         goto testcase_cleanup;
@@ -359,9 +361,9 @@ testcase_cleanup:
 
 CK_RV do_InitToken(void)
 {
-    CK_BYTE label[32];
-    int len;
-    CK_CHAR so_pin[PKCS11_MAX_PIN_LEN];
+    CK_BYTE label[32] = {0};
+    int len = 0;
+    CK_CHAR so_pin[PKCS11_MAX_PIN_LEN] = {0};
     CK_RV rc = 0;
 
     testcase_begin("testing C_InitToken");

--- a/testcases/pkcs11/hw_fn.c
+++ b/testcases/pkcs11/hw_fn.c
@@ -54,9 +54,9 @@ CK_SESSION_HANDLE sess;
  */
 int do_HW_Feature_Search(void)
 {
-    unsigned int i;
-    CK_RV rc;
-    CK_ULONG find_count;
+    unsigned int i = 0;
+    CK_RV rc = 0;
+    CK_ULONG find_count = 0;
 
     CK_BBOOL false = FALSE;
     CK_BBOOL true = TRUE;
@@ -65,7 +65,7 @@ int do_HW_Feature_Search(void)
     CK_OBJECT_CLASS counter1_class = CKO_HW_FEATURE;
     CK_HW_FEATURE_TYPE feature1_type = CKH_MONOTONIC_COUNTER;
     CK_UTF8CHAR counter1_label[] = "Monotonic counter";
-    CK_CHAR counter1_value[16];
+    CK_CHAR counter1_value[16] = {0};
     CK_ATTRIBUTE counter1_template[] = {
         {CKA_CLASS, &counter1_class, sizeof(counter1_class)},
         {CKA_HW_FEATURE_TYPE, &feature1_type, sizeof(feature1_type)},
@@ -79,7 +79,7 @@ int do_HW_Feature_Search(void)
     CK_OBJECT_CLASS counter2_class = CKO_HW_FEATURE;
     CK_HW_FEATURE_TYPE feature2_type = CKH_MONOTONIC_COUNTER;
     CK_UTF8CHAR counter2_label[] = "Monotonic counter";
-    CK_CHAR counter2_value[16];
+    CK_CHAR counter2_value[16] = {0};
     CK_ATTRIBUTE counter2_template[] = {
         {CKA_CLASS, &counter2_class, sizeof(counter2_class)},
         {CKA_HW_FEATURE_TYPE, &feature2_type, sizeof(feature2_type)},
@@ -93,7 +93,7 @@ int do_HW_Feature_Search(void)
     CK_OBJECT_CLASS clock_class = CKO_HW_FEATURE;
     CK_HW_FEATURE_TYPE clock_type = CKH_CLOCK;
     CK_UTF8CHAR clock_label[] = "Clock";
-    CK_CHAR clock_value[16];
+    CK_CHAR clock_value[16] = {0};
     CK_ATTRIBUTE clock_template[] = {
         {CKA_CLASS, &clock_class, sizeof(clock_class)},
         {CKA_HW_FEATURE_TYPE, &clock_type, sizeof(clock_type)},
@@ -116,7 +116,7 @@ int do_HW_Feature_Search(void)
     CK_OBJECT_CLASS obj2_class = CKO_SECRET_KEY;
     CK_KEY_TYPE obj2_type = CKK_AES;
     CK_UTF8CHAR obj2_label[] = "Object 2";
-    CK_BYTE obj2_data[AES_KEY_SIZE_128];
+    CK_BYTE obj2_data[AES_KEY_SIZE_128] = {0};
     CK_ATTRIBUTE obj2_template[] = {
         {CKA_CLASS, &obj2_class, sizeof(obj2_class)},
         {CKA_TOKEN, &true, sizeof(true)},
@@ -125,8 +125,9 @@ int do_HW_Feature_Search(void)
         {CKA_VALUE, obj2_data, sizeof(obj2_data)}
     };
 
-    CK_OBJECT_HANDLE h_counter1,
-        h_counter2, h_clock, h_obj1, h_obj2, obj_list[10];
+    CK_OBJECT_HANDLE h_counter1 = 0,
+        h_counter2 = 0, h_clock = 0, h_obj1 = 0, h_obj2 = 0,
+        obj_list[10] = {0};
 
     CK_ATTRIBUTE find_tmpl[] = {
         {CKA_CLASS, &counter1_class, sizeof(counter1_class)}

--- a/usr/lib/common/new_host.c
+++ b/usr/lib/common/new_host.c
@@ -272,6 +272,14 @@ CK_RV SC_Finalize(STDLL_TokData_t *tokdata, CK_SLOT_ID sid, SLOT_INFO *sinfp)
 
     session_mgr_close_all_sessions();
     object_mgr_purge_token_objects(tokdata);
+
+    /* Finally free the nodes on free list. */
+    bt_destroy(&sess_btree, NULL);
+    bt_destroy(&sess_obj_btree, NULL);
+    bt_destroy(&object_map_btree, NULL);
+    bt_destroy(&priv_token_obj_btree, NULL);
+    bt_destroy(&publ_token_obj_btree, NULL);
+
     detach_shm(tokdata);
     /* close spin lock file */
     CloseXProcLock(tokdata);

--- a/usr/lib/ep11_stdll/new_host.c
+++ b/usr/lib/ep11_stdll/new_host.c
@@ -267,6 +267,14 @@ CK_RV SC_Finalize(STDLL_TokData_t * tokdata, CK_SLOT_ID sid, SLOT_INFO * sinfp)
 
     session_mgr_close_all_sessions();
     object_mgr_purge_token_objects(tokdata);
+
+    /* Finally free the nodes on free list. */
+    bt_destroy(&sess_btree, NULL);
+    bt_destroy(&sess_obj_btree, NULL);
+    bt_destroy(&object_map_btree, NULL);
+    bt_destroy(&priv_token_obj_btree, NULL);
+    bt_destroy(&publ_token_obj_btree, NULL);
+
     detach_shm(tokdata);
     /* close spin lock file */
     CloseXProcLock(tokdata);

--- a/usr/lib/icsf_stdll/new_host.c
+++ b/usr/lib/icsf_stdll/new_host.c
@@ -269,6 +269,14 @@ CK_RV SC_Finalize(STDLL_TokData_t * tokdata, CK_SLOT_ID sid, SLOT_INFO * sinfp)
 
     session_mgr_close_all_sessions();
     object_mgr_purge_token_objects(tokdata);
+
+    /* Finally free the nodes on free list. */
+    bt_destroy(&sess_btree, NULL);
+    bt_destroy(&sess_obj_btree, NULL);
+    bt_destroy(&object_map_btree, NULL);
+    bt_destroy(&priv_token_obj_btree, NULL);
+    bt_destroy(&publ_token_obj_btree, NULL);
+
     detach_shm(tokdata);
     /* close spin lock file */
     CloseXProcLock(tokdata);


### PR DESCRIPTION
First patch:
Fix conditional jump or move depending on uninitialised value(s)

Valgrind complaints about some uninitialized local variables.

Second patch:
Fix C_Finalize memleak of binary trees' nodes with BT_FLAG_FREE set.

C_Finalize uses bt_for_each_node to free the btrees' nodes which
in turn calls bt_get_node for each node in the tree. However,
bt_get_node returns NULL if a node has the BT_FLAG_FREE set
such that bt_for_each_node ignores those nodes, so they are
never actually freed.
Call bt_destroy in C_Finalize to also cleanup those nodes.

Fixes https://github.com/opencryptoki/opencryptoki/issues/166 .
