### PR TITLE
pkcsep11_session: Allow already closed sessions

### DIFF
--- a/usr/sbin/pkcsep11_session/pkcsep11_session.c
+++ b/usr/sbin/pkcsep11_session/pkcsep11_session.c
@@ -376,7 +376,7 @@ static CK_RV logout_handler(uint_32 adapter, uint_32 domain, void *handler_data)
     target.apqns[1] = domain;
 
     rc = dll_m_Logout(handler_data, XCP_PINBLOB_BYTES, (uint64_t) &target);
-    if (rc != CKR_OK) {
+    if (rc != CKR_OK && rc != CKR_SESSION_CLOSED) {
         fprintf(stderr,
                 "WARNING: Logout failed for adapter %02X.%04X: 0x%lx [%s]\n",
                 adapter, domain, rc, p11_get_ckr(rc));


### PR DESCRIPTION
When multiple VHSM-Session objects are left over to be logged out by the pkcsep11_session tool, it may happen that all or some of them contain the exact same session pin blob. Thus when logging out one of them, all others will receive CKR_SESSION_CLOSED when trying to log them out. This is not an error, since the session is already logged out in that case.
