### PR TITLE
Ensure obj-map and obj-btrees are in sync when deleting objects

### DIFF
--- a/usr/lib/common/obj_mgr.c
+++ b/usr/lib/common/obj_mgr.c
@@ -1976,7 +1976,8 @@ void delete_objs_from_btree_cb(STDLL_TokData_t *tokdata, void *node,
         }
     }
 
-    /* didn't find it in SHM, delete it from its btree */
+    /* didn't find it in SHM, delete it from its btree and the object map */
+    bt_node_free(&object_map_btree, obj->map_handle, free);
     bt_node_free(ua->t, obj_handle, call_free);
 }
 


### PR DESCRIPTION
During C_FindObjectsInit() function object_mgr_update_from_shm() is called to synchronize the objects in the local btrees with the shared memory (SHM). Any objects that are only in the SHM (because other processes have added them in the meantime) are added to the local btrees, and any objects that are no longer in the SHM (because other processes have deleted them in the meantime) are removed from the local btrees.

This patch ensure that the objects are not only removed from the btrees (publ_token_obj_btree, priv_token_obj_btree), but also from the object-map (object_map_btree).

Leaving the removed object in the object-map causes that the left-over map entry points to a non-existing object. Later, when new objects are added, an object with the same btree-index may be created, and thus the left-over map entry now points to that object. Thus you now have 2 map entries (and thus 2 handles) pointing to the same object. This may lead to the fact that C_FindObjects is finding that object
under another handle than it was created. This causes the testcase spinlock_test.sh to fail with `TESTCASE do_CreateTokenObjects FAIL (testcases/misc_tests/obj_mgmt_lock.c:865) could not find 2nd object's handle` when running with many concurrent processes.
