### PR TITLE
EP11: Support key usage restrictions for public keys

### DIFF
--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -3908,7 +3908,8 @@ static CK_RV dh_generate_keypair(STDLL_TokData_t * tokdata,
     dh_pgs.pg = malloc(p_len * 2);
     if (!dh_pgs.pg) {
         TRACE_ERROR("%s Memory allocation failed\n", __func__);
-        return CKR_HOST_MEMORY;
+        rc = CKR_HOST_MEMORY;
+        goto dh_generate_keypair_end;
     }
     memset(dh_pgs.pg, 0, p_len * 2);
     memcpy(dh_pgs.pg, prime_attr->pValue, p_len);     /* copy CKA_PRIME value */
@@ -4168,8 +4169,10 @@ static CK_RV dsa_generate_keypair(STDLL_TokData_t * tokdata,
         }
     }
 
-    if (prime_attr == NULL || sub_prime_attr == NULL || base_attr == NULL)
-        return CKR_TEMPLATE_INCOMPLETE;
+    if (prime_attr == NULL || sub_prime_attr == NULL || base_attr == NULL) {
+        rc = CKR_TEMPLATE_INCOMPLETE;
+        goto dsa_generate_keypair_end;
+    }
 
     /* copy CKA_PRIME/CKA_BASE/CKA_SUBPRIME to private template */
     rc = build_attribute(CKA_PRIME, prime_attr->pValue,
@@ -4221,7 +4224,8 @@ static CK_RV dsa_generate_keypair(STDLL_TokData_t * tokdata,
     dsa_pqgs.pqg = malloc(p_len * 3);
     if (!dsa_pqgs.pqg) {
         TRACE_ERROR("%s Memory allocation failed\n", __func__);
-        return CKR_HOST_MEMORY;
+        rc = CKR_HOST_MEMORY;
+        goto dsa_generate_keypair_end;
     }
     memset(dsa_pqgs.pqg, 0, p_len * 3);
     memcpy(dsa_pqgs.pqg, prime_attr->pValue, p_len);
@@ -4255,7 +4259,7 @@ static CK_RV dsa_generate_keypair(STDLL_TokData_t * tokdata,
     if (rc != CKR_OK) {
         TRACE_ERROR("%s RSA/EC check public key attributes failed with "
                     "rc=0x%lx\n", __func__, rc);
-        return rc;
+        goto dsa_generate_keypair_end;
     }
 
     rc = check_key_attributes(tokdata, CKK_DSA, CKO_PRIVATE_KEY,
@@ -4265,7 +4269,7 @@ static CK_RV dsa_generate_keypair(STDLL_TokData_t * tokdata,
     if (rc != CKR_OK) {
         TRACE_ERROR("%s RSA/EC check private key attributes failed with "
                     "rc=0x%lx\n", __func__, rc);
-        return rc;
+        goto dsa_generate_keypair_end;
     }
 
     rc = override_key_attributes(tokdata, CKK_DSA, CKO_PUBLIC_KEY,


### PR DESCRIPTION
EP11 does not allow to restrict a public RSA, EC, or DSA keys using CKA_VERIFY=FALSE or CKA_ENCRYPT=FALSE, because it can not be technically enforced since the public key material is available in clear (refer to chapter 2.2.6 of the EP11 structure document). Thus, generating a key pair using C_GenerateKeyPair fails with CKR_TEMPLATE_INCONSISTENT when the public key template contains CKA_VERIFY=FALSE or CKA_ENCRYPT=FALSE.

With this change, the EP11 token allows to restrict public keys with CKA_VERIFY=FALSE or CKA_ENCRYPT=FALSE. When specified, these attributes are overridden with TRUE when passing the key generate request to the EP11 library, but the original attribute values are stored in the object. The key usage restriction in regards of SIGN and ENCRYPT are enforced by the EP11 token, before the sign or encrypt request is passed to the EP11 library.
