### PR TITLE
Fix coverty scan findings for stat/open

### DIFF
--- a/usr/lib/api/apiutil.c
+++ b/usr/lib/api/apiutil.c
@@ -51,15 +51,12 @@ extern API_Proc_Struct_t *Anchor;
 
 CK_RV CreateProcLock(void)
 {
-    struct stat statbuf;
-
     if (xplfd == -1) {
 
         /* The slot mgr daemon should have already created lock,
          * so just open it so we can get a lock...
          */
-        if (stat(OCK_API_LOCK_FILE, &statbuf) == 0)
-            xplfd = open(OCK_API_LOCK_FILE, O_RDONLY);
+        xplfd = open(OCK_API_LOCK_FILE, O_RDONLY);
 
         if (xplfd == -1) {
             OCK_SYSLOG(LOG_ERR, "Could not open %s\n", OCK_API_LOCK_FILE);

--- a/usr/sbin/pkcsslotd/mutex.c
+++ b/usr/sbin/pkcsslotd/mutex.c
@@ -26,37 +26,31 @@ int CreateXProcLock(void)
 {
     struct group *grp;
     mode_t mode = (S_IRUSR | S_IRGRP);
-    struct stat statbuf;
 
     if (xplfd == -1) {
-        if (stat(OCK_API_LOCK_FILE, &statbuf) == 0) {
-            xplfd = open(OCK_API_LOCK_FILE, O_RDONLY, mode);
-        } else {
-            xplfd = open(OCK_API_LOCK_FILE, O_CREAT | O_RDONLY, mode);
+        xplfd = open(OCK_API_LOCK_FILE, O_CREAT | O_RDONLY, mode);
 
-            if (xplfd != -1) {
-                if (fchmod(xplfd, mode) == -1) {
-                    DbgLog(DL0, "%s:fchmod(%s):%s\n",
-                           __func__, OCK_API_LOCK_FILE, strerror(errno));
-                    goto error;
-                }
-
-                grp = getgrnam("pkcs11");
-                if (grp != NULL) {
-                    if (fchown(xplfd, -1, grp->gr_gid) == -1) {
-                        DbgLog(DL0, "%s:fchown(%s):%s\n",
-                               __func__,
-                               OCK_API_LOCK_FILE, strerror(errno));
-                        goto error;
-                    }
-                } else {
-                    DbgLog(DL0, "%s:getgrnam():%s\n",
-                           __func__, strerror(errno));
-                    goto error;
-                }
+        if (xplfd != -1) {
+            if (fchmod(xplfd, mode) == -1) {
+                DbgLog(DL0, "%s:fchmod(%s):%s\n",
+                       __func__, OCK_API_LOCK_FILE, strerror(errno));
+                goto error;
             }
-        }
-        if (xplfd == -1) {
+
+            grp = getgrnam("pkcs11");
+            if (grp != NULL) {
+                if (fchown(xplfd, -1, grp->gr_gid) == -1) {
+                    DbgLog(DL0, "%s:fchown(%s):%s\n",
+                           __func__,
+                           OCK_API_LOCK_FILE, strerror(errno));
+                    goto error;
+                }
+            } else {
+                DbgLog(DL0, "%s:getgrnam():%s\n",
+                       __func__, strerror(errno));
+                goto error;
+            }
+        } else  {
             DbgLog(DL0, "open(%s): %s\n", OCK_API_LOCK_FILE, strerror(errno));
             return FALSE;
         }


### PR DESCRIPTION
A stat() before open() is not required and can cause timing ralted errors. The code can directly react on the result of open(). Flag O_CREAT will create the file only if it is not existent, so we don't need to know upfront if the file exists already or not.

**For discussion:** 
The only difference in usr/sbin/pkcsslotd/mutex.c is that now the code always uses fchmod() and fchown() on the lock file when the lock file was successfully opened, so also when it was already existent, not only when it was newly created. This happens once when pkcsslotd starts, so IMHO this does not hurt.