### PR TITLE
SOFT: C_SignFinal with NULL signature causes segfault

### DIFF
--- a/usr/lib/soft_stdll/soft_specific.c
+++ b/usr/lib/soft_stdll/soft_specific.c
@@ -2751,6 +2751,16 @@ static CK_RV softtok_hmac_final(SIGN_VERIFY_CONTEXT *ctx, CK_BYTE *signature,
         return CKR_MECHANISM_INVALID;
     }
 
+    if (signature == NULL) {
+        if (sign) {
+            if (general)
+                *sig_len = *(CK_ULONG *) ctx->mech.pParameter;
+            else
+                *sig_len = (CK_ULONG) mac_len;
+        }
+        return CKR_OK;
+    }
+
     mdctx = (EVP_MD_CTX *) ctx->context;
 
     rc = EVP_DigestSignFinal(mdctx, mac, &mac_len);


### PR DESCRIPTION
Multipart signing calling C_SignFinal the first time with a NULL
signature will cause a segfault.

Closes: https://github.com/opencryptoki/opencryptoki/pull/237

Signed-off-by: Hugo Géroux <hugo.geroux@gmail.com>
Signed-off-by: Ingo Franzki <ifranzki@linux.ibm.com>