### PR TITLE
Fix per-user data store option

### DIFF
--- a/usr/lib/common/loadsave.c
+++ b/usr/lib/common/loadsave.c
@@ -1651,6 +1651,7 @@ void init_data_store(char *directory, char *data_store)
         pk_dir = (char *) malloc(strlen(pkdir) + 1024);
         memset(pk_dir, 0, strlen(pkdir) + 1024);
         sprintf(pk_dir, "%s/%s", pkdir, SUB_DIR);
+        get_pk_dir(data_store);
         return;
     }
 
@@ -1658,13 +1659,12 @@ void init_data_store(char *directory, char *data_store)
         pk_dir = (char *) malloc(strlen(directory) + 25);
         memset(pk_dir, 0, strlen(directory) + 25);
         sprintf(pk_dir, "%s", directory);
-        memcpy(data_store, pk_dir, strlen(directory) + 25);
     } else {
         pk_dir = (char *) malloc(strlen(PK_DIR) + 25);
         memset(pk_dir, 0, strlen(PK_DIR) + 25);
         sprintf(pk_dir, "%s", PK_DIR);
-        memcpy(data_store, pk_dir, strlen(PK_DIR) + 25);
     }
+    get_pk_dir(data_store);
 
     return;
 }


### PR DESCRIPTION
Opencryptoki allows that a token uses a per-user data store. That is, the token directory then contains the user name, e.g. `/var/lib/opencryptoki/tpm/root`. Currently only the TPM token makes use of this, all other tokens share the data store across all, users.

Support for per-user data store got lost with commit 'MTI [PATCH 04/85]: Initialize token' https://github.com/opencryptoki/opencryptoki/commit/39a7685295a7fe3688dd66cbed687deefe06bee6.

Fixes: https://github.com/opencryptoki/opencryptoki/issues/242

**Note:** I can't test this with the TPM token, since I don't have a setup for testing the TPM token, but I simulated the per-user data store using the ICA token. Would be nice if someone with a TPM setup could test this....