### PR TITLE
error: 'uint32_t' undeclared

### DIFF
--- a/usr/sbin/pkcsslotd/lexer.l
+++ b/usr/sbin/pkcsslotd/lexer.l
@@ -13,6 +13,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 
 #include "parser.h"
 


### PR DESCRIPTION
opencryptoki-3.12.0 cannot be built on rhel-7, it breaks with the following error:
---
usr/sbin/pkcsslotd/lexer.l: In function 'yylex':
usr/sbin/pkcsslotd/lexer.l:60:20: error: 'uint32_t' undeclared (first use in this function)
      yylval.num = (uint32_t)major << 16 | (uint32_t)minor;
---
this type is defined in the C header <stdint.h>, adding include <stdint.h> into lexer.l resolves this issue.

I have opened a pull request for this.