### PR TITLE
Fix the pkcsep11_migrate tool

### DIFF
--- a/usr/sbin/pkcsep11_migrate/ep11adm.h
+++ b/usr/sbin/pkcsep11_migrate/ep11adm.h
@@ -22,24 +22,24 @@
 
 // these numbers apply to current version, subject to change
 //
-#if !defined(EP11_SERIALNR_CHARS)
-#define  EP11_SERIALNR_CHARS        8
+#if !defined(XCP_SERIALNR_CHARS)
+#define  XCP_SERIALNR_CHARS        8
 #endif
 
-#if !defined(EP11_KEYCSUM_BYTES)
-#define  EP11_KEYCSUM_BYTES         (256/8) /* full size of verific. pattern */
+#if !defined(XCP_KEYCSUM_BYTES)
+#define  XCP_KEYCSUM_BYTES         (256/8) /* full size of verific. pattern */
 #endif
 
-#if !defined(EP11_ADMCTR_BYTES)
-#define  EP11_ADMCTR_BYTES          (128/8) /* admin transaction ctrs */
+#if !defined(XCP_ADMCTR_BYTES)
+#define  XCP_ADMCTR_BYTES          (128/8) /* admin transaction ctrs */
 #endif
 
-#if !defined(EP11_ADM_REENCRYPT)
-#define  EP11_ADM_REENCRYPT         25      /* transform blobs to next WK */
+#if !defined(XCP_ADM_REENCRYPT)
+#define  XCP_ADM_REENCRYPT         25      /* transform blobs to next WK */
 #endif
 
-#if !defined(CK_IBM_EP11Q_DOMAIN)
-#define  CK_IBM_EP11Q_DOMAIN        3       /* list domain's WK hashes */
+#if !defined(CK_IBM_XCPQ_DOMAIN)
+#define  CK_IBM_XCPQ_DOMAIN        3       /* list domain's WK hashes */
 #endif
 
 #if !defined(CK_IBM_DOM_COMMITTED_NWK)
@@ -47,17 +47,17 @@
 #endif
 
 
-typedef struct ep11_admresp {
+typedef struct XCPadmresp {
     uint32_t fn;
     uint32_t domain;
     uint32_t domainInst;
 
     /* module ID || module instance */
-    unsigned char module[EP11_SERIALNR_CHARS + EP11_SERIALNR_CHARS];
-    unsigned char modNr[EP11_SERIALNR_CHARS];
-    unsigned char modInst[EP11_SERIALNR_CHARS];
+    unsigned char module[XCP_SERIALNR_CHARS + XCP_SERIALNR_CHARS];
+    unsigned char modNr[XCP_SERIALNR_CHARS];
+    unsigned char modInst[XCP_SERIALNR_CHARS];
 
-    unsigned char tctr[EP11_ADMCTR_BYTES];      /* transaction counter */
+    unsigned char tctr[XCP_ADMCTR_BYTES];     /* transaction counter */
 
     CK_RV rv;
     uint32_t reason;
@@ -67,14 +67,14 @@ typedef struct ep11_admresp {
     //
     const unsigned char *payload;
     size_t pllen;
-} *ep11_admresp_t;
+} *XCPadmresp_t;
 
 
 #if !defined(__XCP_H__)
 typedef struct CK_IBM_DOMAIN_INFO {
     CK_ULONG domain;
-    CK_BYTE wk[EP11_KEYCSUM_BYTES];
-    CK_BYTE nextwk[EP11_KEYCSUM_BYTES];
+    CK_BYTE wk[XCP_KEYCSUM_BYTES];
+    CK_BYTE nextwk[XCP_KEYCSUM_BYTES];
     CK_ULONG flags;
     CK_BYTE mode[8];
 } CK_IBM_DOMAIN_INFO;
@@ -82,30 +82,30 @@ typedef struct CK_IBM_DOMAIN_INFO {
 
 
 /*----------------------------------------------------------------------
- *  build a command block to (blk,blen), querying 'fn'
- *  (payload,plen) copied to query block if non-NULL
+ * build a query block to (blk,blen), querying 'fn'
+ * (payload,plen) copied to query block if non-NULL
  *
- *  returns written bytecount; size query if blk is NULL
- *   *minf used for module ID and transaction counter
- *  ignored for commands where those fields are ignored
+ * returns written bytecount; size query if blk is NULL
+ *
+ * *minf used for module ID and transaction counter
+ *       ignored for commands where those fields are ignored
  */
-long ep11a_cmdblock(unsigned char *blk,
-                    size_t blen,
-                    unsigned int fn,
-                    const struct ep11_admresp *minf,
-                    const unsigned char *tctr,       /* EP11_ADMCTR_BYTES */
-                    const unsigned char *payload, size_t plen);
+long xcpa_cmdblock(unsigned char *blk, 
+                   size_t blen,
+                   unsigned int fn,
+                   const struct XCPadmresp *minf,
+                   const unsigned char *tctr,    /* XCP_ADMCTR_BYTES */
+                   const unsigned char *payload, size_t plen) ;
 
 
 /*----------------------------------------------------------------------
- *  returns <0 if response is malformed, or contents invalid
+ * returns <0 if response is malformed, or contents invalid
  *
- *  parse embedded return value from response, writes to *rv if non-NULL
- *  (outside envelope always reports CKR_OK, unless infrastructure
- *  failed)
+ * parse embedded return value from response, writes to *rv if non-NULL
+ * (outside envelope always reports CKR_OK, unless infrastructure failed)
  */
-long ep11a_internal_rv(const unsigned char *rsp, size_t rlen,
-                       struct ep11_admresp *rspblk, CK_RV *rv);
+long xcpa_internal_rv(const unsigned char *rsp,   size_t rlen,
+                      struct XCPadmresp *rspblk, CK_RV *rv) ;
 
 
 /*----------------------------------------------------------------------
@@ -116,9 +116,9 @@ long ep11a_internal_rv(const unsigned char *rsp, size_t rlen,
  *  list therefore, infbytes is ignored by other types (we still check
  *  if present)
  */
-CK_RV m_get_ep11_info(CK_VOID_PTR pinfo, CK_ULONG_PTR infbytes,
-                      unsigned int query,
-                      unsigned int subquery, uint64_t target);
+CK_RV m_get_xcp_info (CK_VOID_PTR pinfo, CK_ULONG_PTR infbytes,
+                     unsigned int query,
+                     unsigned int subquery, target_t target) ;
 
 
 #endif                          /* !defined(__EP11ADM_H__) */


### PR DESCRIPTION
Since commit 2668e8f347ca2514b4274daccf71defce0e2313f the contents of attribute CKA_IBM_OPAQUE has been changed to contain the raw EP11 blob directly, no longer wrapped into struct ep11_opaque.

Since then, the pkcsep11_migrate tool could not have worked to re-encrypt EP11 key blobs stored in token objects.

Correct the tool and while at it also replace some older, now deprecated EP11 host library functions with ist newer equivalents.