### PR TITLE
TESTCASES: Skip test if CKM_RSA_PKCS is not available

### DIFF
--- a/testcases/crypto/aes_func.c
+++ b/testcases/crypto/aes_func.c
@@ -1277,6 +1277,14 @@ CK_RV do_WrapUnwrapRSA(struct generated_test_suite_info * tsuite)
                        (unsigned int) tsuite->mech.mechanism);
         goto testcase_cleanup;
     }
+    if (!mech_supported(slot_id, CKM_RSA_PKCS)) {
+        testsuite_skip(3,
+                       "Slot %u doesn't support %s (%u)",
+                       (unsigned int) slot_id,
+                       mech_to_str(CKM_RSA_PKCS),
+                       (unsigned int) CKM_RSA_PKCS);
+        goto testcase_cleanup;
+    }
 
     for (i = 0; i < 3; i++) {
 


### PR DESCRIPTION
The AES Wrap/Unwrap testcase uses mechanism CKM_RSA_PKCS to test if an unwrapped RSA key can be used for en/decryption. This fails if mechanism CKM_RSA_PKCS is not available (e.g. due to control point settings). Skip the whole testcase if CKM_RSA_PKCS is not available.