### PR TITLE
EP11: Add support for EP11 HSM simulation

### DIFF
--- a/usr/sbin/pkcsep11_migrate/pkcsep11_migrate.c
+++ b/usr/sbin/pkcsep11_migrate/pkcsep11_migrate.c
@@ -474,6 +474,12 @@ static int do_ParseArgs(int argc, char **argv)
     return 1;
 }
 
+#ifdef EP11_HSMSIM
+#define DLOPEN_FLAGS        RTLD_GLOBAL | RTLD_NOW | RTLD_DEEPBIND
+#else
+#define DLOPEN_FLAGS        RTLD_GLOBAL | RTLD_NOW
+#endif
+
 static void *ep11_load_host_lib()
 {
     void *lib_ep11;
@@ -482,7 +488,7 @@ static void *ep11_load_host_lib()
 
     ep11_lib_name = getenv(EP11SHAREDLIB_NAME);
     if (ep11_lib_name != NULL) {
-        lib_ep11 = dlopen(ep11_lib_name, RTLD_GLOBAL | RTLD_NOW);
+        lib_ep11 = dlopen(ep11_lib_name, DLOPEN_FLAGS);
 
         if (lib_ep11 == NULL) {
             errstr = dlerror();
@@ -494,24 +500,24 @@ static void *ep11_load_host_lib()
     }
 
     ep11_lib_name = EP11SHAREDLIB_V3;
-    lib_ep11 = dlopen(ep11_lib_name, RTLD_GLOBAL | RTLD_NOW);
+    lib_ep11 = dlopen(ep11_lib_name, DLOPEN_FLAGS);
 
     if (lib_ep11 == NULL) {
         /* Try version 2 instead */
         ep11_lib_name = EP11SHAREDLIB_V2;
-        lib_ep11 = dlopen(ep11_lib_name, RTLD_GLOBAL | RTLD_NOW);
+        lib_ep11 = dlopen(ep11_lib_name, DLOPEN_FLAGS);
     }
 
     if (lib_ep11 == NULL) {
         /* Try version 1 instead */
         ep11_lib_name = EP11SHAREDLIB_V1;
-        lib_ep11 = dlopen(ep11_lib_name, RTLD_GLOBAL | RTLD_NOW);
+        lib_ep11 = dlopen(ep11_lib_name, DLOPEN_FLAGS);
     }
 
     if (lib_ep11 == NULL) {
         /* Try unversioned library instead */
         ep11_lib_name = EP11SHAREDLIB;
-        lib_ep11 = dlopen(ep11_lib_name, RTLD_GLOBAL | RTLD_NOW);
+        lib_ep11 = dlopen(ep11_lib_name, DLOPEN_FLAGS);
     }
 
     if (lib_ep11 == NULL) {

--- a/usr/sbin/pkcsep11_session/pkcsep11_session.c
+++ b/usr/sbin/pkcsep11_session/pkcsep11_session.c
@@ -488,6 +488,10 @@ static CK_RV is_card_ep11_and_online(const char *name)
     CK_RV rc;
     unsigned long val;
 
+#ifdef EP11_HSMSIM
+    return CKR_OK;
+#endif
+
     sprintf(fname, "%s%s/online", SYSFS_DEVICES_AP, name);
     rc = file_fgets(fname, buf, sizeof(buf));
     if (rc != CKR_OK)
@@ -517,6 +521,10 @@ static CK_RV scan_for_card_domains(const char *name, adapter_handler_t handler,
     struct dirent *de;
     char *tok;
     uint_32 adapter, domain;
+
+#ifdef EP11_HSMSIM
+    return handler(0, 0, handler_data);
+#endif
 
     if (regcomp(&reg_buf, REGEX_SUB_CARD_PATTERN, REG_EXTENDED) != 0) {
         fprintf(stderr, "Failed to compile regular expression '%s'\n",
@@ -572,6 +580,10 @@ static CK_RV scan_for_ep11_cards(adapter_handler_t handler, void *handler_data)
 
     if (handler == NULL)
         return CKR_ARGUMENTS_BAD;
+
+#ifdef EP11_HSMSIM
+    return handler(0, 0, handler_data);
+#endif
 
     if (regcomp(&reg_buf, REGEX_CARD_PATTERN, REG_EXTENDED) != 0) {
         fprintf(stderr, "Failed to compile regular expression '%s'\n",
@@ -979,6 +991,12 @@ static CK_RV set_vhsmpin(CK_SESSION_HANDLE session)
     return CKR_OK;
 }
 
+#ifdef EP11_HSMSIM
+#define DLOPEN_FLAGS        RTLD_GLOBAL | RTLD_NOW | RTLD_DEEPBIND
+#else
+#define DLOPEN_FLAGS        RTLD_GLOBAL | RTLD_NOW
+#endif
+
 static void *ep11_load_host_lib()
 {
     void *lib_ep11;
@@ -987,7 +1005,7 @@ static void *ep11_load_host_lib()
 
     ep11_lib_name = getenv(EP11SHAREDLIB_NAME);
     if (ep11_lib_name != NULL) {
-        lib_ep11 = dlopen(ep11_lib_name, RTLD_GLOBAL | RTLD_NOW);
+        lib_ep11 = dlopen(ep11_lib_name, DLOPEN_FLAGS);
 
         if (lib_ep11 == NULL) {
             errstr = dlerror();
@@ -999,24 +1017,24 @@ static void *ep11_load_host_lib()
     }
 
     ep11_lib_name = EP11SHAREDLIB_V3;
-    lib_ep11 = dlopen(ep11_lib_name, RTLD_GLOBAL | RTLD_NOW);
+    lib_ep11 = dlopen(ep11_lib_name, DLOPEN_FLAGS);
 
     if (lib_ep11 == NULL) {
         /* Try version 2 instead */
         ep11_lib_name = EP11SHAREDLIB_V2;
-        lib_ep11 = dlopen(ep11_lib_name, RTLD_GLOBAL | RTLD_NOW);
+        lib_ep11 = dlopen(ep11_lib_name, DLOPEN_FLAGS);
     }
 
     if (lib_ep11 == NULL) {
         /* Try version 1 instead */
         ep11_lib_name = EP11SHAREDLIB_V1;
-        lib_ep11 = dlopen(ep11_lib_name, RTLD_GLOBAL | RTLD_NOW);
+        lib_ep11 = dlopen(ep11_lib_name, DLOPEN_FLAGS);
     }
 
     if (lib_ep11 == NULL) {
         /* Try unversioned library instead */
         ep11_lib_name = EP11SHAREDLIB;
-        lib_ep11 = dlopen(ep11_lib_name, RTLD_GLOBAL | RTLD_NOW);
+        lib_ep11 = dlopen(ep11_lib_name, DLOPEN_FLAGS);
     }
 
     if (lib_ep11 == NULL) {


### PR DESCRIPTION
To allow running with the EP11 HSM simulation, any sysfs related places in the code need to be changed to return configured values. Also load the EP11 host library with dlopen option RTLD_DEEPBIND to avoid a symbol name clash with the CCA host library.

To enable HSM simulation, configure with the following options: 'CFLAGS=-DEP11_HSMSIM -DEP11_HSMSIM_CARD_TYPE=7'

Symbol EP11_HSMSIM enables HSM simulation, EP11_HSMSIM_CARD_TYPE specifies the card type to simulate (e.g. 7 means it simulates a CEX7P card).

Use environment variable OCK_EP11_LIBRARY to specify the name and path of the EP11 Host Library for the simulation.