### PR TITLE
EP11: Dilithium stage1, rename public key attribute "seed" to "rho"

### DIFF
--- a/usr/lib/common/key.c
+++ b/usr/lib/common/key.c
@@ -3190,7 +3190,7 @@ CK_BBOOL kea_priv_check_exportability(CK_ATTRIBUTE_TYPE type)
 CK_RV ibm_dilithium_publ_set_default_attributes(TEMPLATE *tmpl, CK_ULONG mode)
 {
     CK_ATTRIBUTE *type_attr = NULL;
-    CK_ATTRIBUTE *seed_attr = NULL;
+    CK_ATTRIBUTE *rho_attr = NULL;
     CK_ATTRIBUTE *t1_attr = NULL;
     CK_ATTRIBUTE *keyform_attr = NULL;
 
@@ -3198,14 +3198,14 @@ CK_RV ibm_dilithium_publ_set_default_attributes(TEMPLATE *tmpl, CK_ULONG mode)
 
     type_attr = (CK_ATTRIBUTE *) malloc(sizeof(CK_ATTRIBUTE) + sizeof(CK_KEY_TYPE));
     keyform_attr = (CK_ATTRIBUTE *) malloc(sizeof(CK_ATTRIBUTE) + sizeof(CK_ULONG));
-    seed_attr = (CK_ATTRIBUTE *) malloc(sizeof(CK_ATTRIBUTE));
+    rho_attr = (CK_ATTRIBUTE *) malloc(sizeof(CK_ATTRIBUTE));
     t1_attr = (CK_ATTRIBUTE *) malloc(sizeof(CK_ATTRIBUTE));
 
-    if (!type_attr || !seed_attr || !t1_attr || !keyform_attr) {
+    if (!type_attr || !rho_attr || !t1_attr || !keyform_attr) {
         if (type_attr)
             free(type_attr);
-        if (seed_attr)
-            free(seed_attr);
+        if (rho_attr)
+            free(rho_attr);
         if (t1_attr)
             free(t1_attr);
         if (keyform_attr)
@@ -3225,16 +3225,16 @@ CK_RV ibm_dilithium_publ_set_default_attributes(TEMPLATE *tmpl, CK_ULONG mode)
     keyform_attr->pValue = (CK_BYTE *) keyform_attr + sizeof(CK_ATTRIBUTE);
     *(CK_ULONG *) keyform_attr->pValue = 1;
 
-    seed_attr->type = CKA_IBM_DILITHIUM_SEED;
-    seed_attr->ulValueLen = 0;
-    seed_attr->pValue = NULL;
+    rho_attr->type = CKA_IBM_DILITHIUM_RHO;
+    rho_attr->ulValueLen = 0;
+    rho_attr->pValue = NULL;
 
     t1_attr->type = CKA_IBM_DILITHIUM_T1;
     t1_attr->ulValueLen = 0;
     t1_attr->pValue = NULL;
 
     template_update_attribute(tmpl, type_attr);
-    template_update_attribute(tmpl, seed_attr);
+    template_update_attribute(tmpl, rho_attr);
     template_update_attribute(tmpl, t1_attr);
     template_update_attribute(tmpl, keyform_attr);
 
@@ -3350,7 +3350,7 @@ CK_RV ibm_dilithium_publ_check_required_attributes(TEMPLATE *tmpl, CK_ULONG mode
     CK_ATTRIBUTE *attr = NULL;
     static CK_ULONG req_attrs[] = {
         CKA_IBM_DILITHIUM_KEYFORM,
-        CKA_IBM_DILITHIUM_SEED,
+        CKA_IBM_DILITHIUM_RHO,
         CKA_IBM_DILITHIUM_T1,
     };
     CK_ULONG i;
@@ -3411,7 +3411,7 @@ CK_RV ibm_dilithium_publ_validate_attribute(STDLL_TokData_t *tokdata,
                                             CK_ULONG mode)
 {
     switch (attr->type) {
-    case CKA_IBM_DILITHIUM_SEED:
+    case CKA_IBM_DILITHIUM_RHO:
     case CKA_IBM_DILITHIUM_T1:
         if (mode == MODE_CREATE)
             return CKR_OK;

--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -4630,7 +4630,7 @@ static CK_RV ibm_dilithium_generate_keypair(STDLL_TokData_t * tokdata,
     unsigned char *ep11_pin_blob = NULL;
     CK_ULONG ep11_pin_blob_len = 0;
     ep11_session_t *ep11_session = (ep11_session_t *) sess->private_data;
-    CK_BYTE *seed, *t1;
+    CK_BYTE *rho, *t1;
 
     UNUSED(h);
 
@@ -4753,30 +4753,30 @@ static CK_RV ibm_dilithium_generate_keypair(STDLL_TokData_t * tokdata,
         goto error;
     }
 
-    /* Public key must be a sequence holding two bit-strings: (seed, t1) */
+    /* Public key must be a sequence holding two bit-strings: (rho, t1) */
     rc = ber_decode_SEQUENCE(key, &data, &data_len, &field_len);
     if (rc != CKR_OK) {
         TRACE_ERROR("%s read sequence failed with rc=0x%lx\n", __func__, rc);
         goto error;
     }
 
-    /* Decode seed */
-    seed = key + field_len - data_len;
-    rc = ber_decode_BIT_STRING(seed, &data, &data_len, &field_len);
+    /* Decode rho */
+    rho = key + field_len - data_len;
+    rc = ber_decode_BIT_STRING(rho, &data, &data_len, &field_len);
     if (rc != CKR_OK) {
-        TRACE_ERROR("%s read seed failed with rc=0x%lx\n", __func__, rc);
+        TRACE_ERROR("%s read rho failed with rc=0x%lx\n", __func__, rc);
         goto error;
     }
     /* Remove leading unused-bits byte, returned by ber_decode_BIT_STRING */
     data++;
     data_len--;
 #ifdef DEBUG
-    TRACE_DEBUG("%s dilithium_generate_keypair (seed):\n", __func__);
+    TRACE_DEBUG("%s dilithium_generate_keypair (rho):\n", __func__);
     TRACE_DEBUG_DUMP(data, data_len);
 #endif
 
-    /* build and add CKA_IBM_DILITHIUM_SEED */
-    rc = build_attribute(CKA_IBM_DILITHIUM_SEED, data, data_len, &attr);
+    /* build and add CKA_IBM_DILITHIUM_RHO */
+    rc = build_attribute(CKA_IBM_DILITHIUM_RHO, data, data_len, &attr);
     if (rc != CKR_OK) {
         TRACE_ERROR("%s build_attribute failed with rc=0x%lx\n", __func__, rc);
         goto error;
@@ -4789,7 +4789,7 @@ static CK_RV ibm_dilithium_generate_keypair(STDLL_TokData_t * tokdata,
     }
 
     /* Decode t1 */
-    t1 = seed + field_len;
+    t1 = rho + field_len;
     rc = ber_decode_BIT_STRING(t1, &data, &data_len, &field_len);
     if (rc != CKR_OK) {
         TRACE_ERROR("%s read t failed with rc=0x%lx\n", __func__, rc);


### PR DESCRIPTION
The IBM implementation uses the "rho" value as the common attribute
between public and private key.

Signed-off-by: Joerg Schmidbauer <jschmidb@de.ibm.com>