### PR TITLE
Add pkcs11test as a git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "pkcs11test"]
+	path = pkcs11test
+	url = https://github.com/google/pkcs11test


### PR DESCRIPTION
.. for convenience. To fetch the pkcs11test suite, you can now either
```
 git clone --recurse-submodules <opencryptoki>
```
If you already cloned opencryptoki you can invoke
```
git submodule update --init
```
from the opencryptoki source directory