### PR TITLE
Set sane defaults for library,slot and token information

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
         - name: "linux-x86-gcc-tm"
           os: linux
           compiler: gcc
-          env: CONFIG_OPTS="--enable-swtok --enable-icsftok --enable-ccatok --enable-tpmtok --enable-testcases" CFLAGS="-O3 -Wno-clobbered -Wextra -std=c99 -pedantic -Werror"
+          env: CONFIG_OPTS="--enable-swtok --enable-icsftok --enable-ccatok --enable-tpmtok --enable-testcases --disable-locks" CFLAGS="-O3 -Wno-clobbered -Wextra -std=c99 -pedantic -Werror"
         - name: "linux-ppc64le-clang-locks"
           os: linux-ppc64le
           compiler: clang
@@ -29,7 +29,7 @@ matrix:
         - name: "linux-ppc64le-gcc-tm"
           os: linux-ppc64le
           compiler: gcc
-          env: CONFIG_OPTS="--enable-swttok --enable-icsftok --enable-ccatok --enable-tpmtok --enable-testcases" CFLAGS="-O3 -Wextra -Wno-clobbered -std=c99 -pedantic -Werror -DDEBUG"
+          env: CONFIG_OPTS="--enable-swttok --enable-icsftok --enable-ccatok --enable-tpmtok --enable-testcases --disable-locks" CFLAGS="-O3 -Wno-clobbered -Wextra -std=c99 -pedantic -Werror -DDEBUG"
         - name: "linux-s390x-clang-locks"
           os: linux
           arch: s390x
@@ -39,7 +39,7 @@ matrix:
           os: linux
           arch: s390x
           compiler: gcc
-          env: CONFIG_OPTS="--enable-swttok --enable-icsftok --enable-ccatok --enable-tpmtok --enable-icatok --enable-ep11tok --enable-testcases" CFLAGS="-O3 -Wextra -Wno-clobbered -std=c99 -pedantic -Werror"
+          env: CONFIG_OPTS="--enable-swttok --enable-icsftok --enable-ccatok --enable-tpmtok --enable-icatok --enable-ep11tok --enable-testcases --disable-locks" CFLAGS="-O3 -Wno-clobbered -Wextra -std=c99 -pedantic -Werror"
         - name: "linux-arm64-clang-locks"
           os: linux
           arch: arm64
@@ -49,7 +49,7 @@ matrix:
           os: linux
           arch: arm64
           compiler: gcc
-          env: CONFIG_OPTS="--enable-swttok --enable-icsftok --enable-ccatok --enable-tpmtok --enable-testcases" CFLAGS="-O3 -Wextra -Wno-clobbered -std=c99 -pedantic -Werror -DDEBUG"
+          env: CONFIG_OPTS="--enable-swttok --enable-icsftok --enable-ccatok --enable-tpmtok --enable-testcases --disable-locks" CFLAGS="-O3 -Wno-clobbered -Wextra -std=c99 -pedantic -Werror -DDEBUG"
 
 before_script:
     - sudo groupadd pkcs11
@@ -60,10 +60,8 @@ script:
     - sudo make install
     - sudo ldconfig
     - sudo pkcsslotd
+    - sudo pkcsconf -i
+    - sudo pkcsconf -s
     - sudo pkcsconf -t
     - cd testcases
     - sudo PKCS11_SO_PIN=87654321 PKCS11_USER_PIN=01234567 PKCSLIB=/usr/local/lib/pkcs11/libopencryptoki.so ./ock_tests.sh -s 3
-
-notifications:
-  slack:
-    secure: dcaiPQdCGfoMNc8Hr4Mjg31cB2kY4XAE/ed2VNNZVGrbEdHLHzUKa55bGvRpxLgREWG6zly2izDpTS0lskO0WD7XS1ybLNT5AZITgN2Sa+yG87qHSMgFQybz5sgZtOzd6KFUH+Ft3OBbvRMMS+bUsd6GIoqguHV5eRUYZoa+3Gc7g0Hvo/2C4s5mGL4DrWHou8WnGI1nplvLgsadCjZdJ8y/yoX6ua3h1KNDpv9Mbe2SFb6b/t244p58+JwvVXyP8PEqzRtjuYE9PXLYTqwz0pYJlBmcLDCUXNeI9vdJ/+523A7YuaMq2spIKd0hLMqmJ2+CiC/iLM0dX9Are7f/BTsSfkcAYhjF0tmlHRUFuqLwRvEDjyNifMaGsTNuRDMAhEc2F77gIyvLA03EHKBhdVGlPT3+dwzpze0nDUP+ThneSgZplG7kuvBZ+ZdN0kaDZxzyPAXhCLxIg8vhJ9cPeI07dfoyOeGIoYSThk+MpOBKZUVmVF7APAM/ytALZ1Oycvvh2ApOdxl0or1ezTEFFArMoMNQOaIK6DNElsdYDyQopjtLq8ZOXhtNcaqOpZ0B95/qj4iPnoyk9sG592PYu3wzoVbXXuEWa7XCp+jiky5AUMOkxF9dpAmXkzkGyD+jFjhZ35VvGqshK3RmlNL81VNmA9Tm8LbkvQ4Tl1mvS1s=

--- a/usr/include/slotmgr.h
+++ b/usr/include/slotmgr.h
@@ -228,7 +228,7 @@ typedef Slot_Info_t SLOT_INFO;
 //  Call to populate the shared memory
 #define STR "01234567890123456789012345678901"
 #define MFG "IBM                             "
-#define LIB "Meta PKCS11 LIBRARY             "
+#define LIB "openCryptoki                    "
 
 
 #define MAJOR_V   1

--- a/usr/lib/cca_stdll/cca_specific.c
+++ b/usr/lib/cca_stdll/cca_specific.c
@@ -64,10 +64,10 @@
 #define POINT_CONVERSION_HYBRID          0x06
 
 
-const char manuf[] = "IBM Corp.";
-const char model[] = "IBM CCA Token";
-const char descr[] = "IBM PKCS#11 CCA Token";
-const char label[] = "IBM PKCS#11 for CCA";
+const char manuf[] = "IBM";
+const char model[] = "CCA";
+const char descr[] = "IBM CCA Token";
+const char label[] = "ccatok";
 
 #define CCASHAREDLIB "libcsulcca.so"
 

--- a/usr/lib/common/utility.c
+++ b/usr/lib/common/utility.c
@@ -474,9 +474,8 @@ void init_tokenInfo(TOKEN_DATA *nv_token_data)
     memcpy(token_info->manufacturerID, manuf, strlen(manuf));
     memcpy(token_info->model, model, strlen(model));
 
-    // use the 41-xxxxx serial number from the coprocessor
-    //
-    memcpy(token_info->serialNumber, "123", 3);
+    // Unused
+    // memcpy(token_info->serialNumber, "123", 3);
 
     // I don't see any API support for changing the clock so
     // we will use the system clock for the token's clock.
@@ -507,9 +506,9 @@ void init_tokenInfo(TOKEN_DATA *nv_token_data)
     token_info->ulTotalPrivateMemory = (CK_ULONG_32) CK_UNAVAILABLE_INFORMATION;
     token_info->ulFreePrivateMemory = (CK_ULONG_32) CK_UNAVAILABLE_INFORMATION;
 
-    token_info->hardwareVersion.major = 1;
+    token_info->hardwareVersion.major = 0;
     token_info->hardwareVersion.minor = 0;
-    token_info->firmwareVersion.major = 1;
+    token_info->firmwareVersion.major = 0;
     token_info->firmwareVersion.minor = 0;
 }
 

--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -169,10 +169,10 @@ static inline void hexdump(void *buf, size_t buflen)
 
 #endif                          /* DEBUG */
 
-const char manuf[] = "IBM Corp.";
-const char model[] = "IBM EP11Tok ";
-const char descr[] = "IBM PKCS#11 EP11 token";
-const char label[] = "IBM OS PKCS#11   ";
+const char manuf[] = "IBM";
+const char model[] = "EP11";
+const char descr[] = "IBM EP11 token";
+const char label[] = "ep11tok";
 
 /* largest blobsize ever seen is about 5k (for 4096 mod bits RSA keys) */
 #define MAX_BLOBSIZE 8192

--- a/usr/lib/ica_s390_stdll/ica_specific.c
+++ b/usr/lib/ica_s390_stdll/ica_specific.c
@@ -61,10 +61,10 @@ typedef struct {
 
 #define MAX_GENERIC_KEY_SIZE 256
 
-const char manuf[] = "IBM Corp.";
-const char model[] = "IBM ICA     ";
-const char descr[] = "IBM PKCS#11 ICA token ";
-const char label[] = "IBM ICA  PKCS #11";
+const char manuf[] = "IBM";
+const char model[] = "ICA";
+const char descr[] = "IBM ICA token";
+const char label[] = "icatok";
 
 static pthread_mutex_t rngmtx = PTHREAD_MUTEX_INITIALIZER;
 

--- a/usr/lib/icsf_stdll/icsf_specific.c
+++ b/usr/lib/icsf_stdll/icsf_specific.c
@@ -46,10 +46,10 @@
 #include "slotmgr.h"
 
 /* Default token attributes */
-const char manuf[] = "IBM Corp.";
-const char model[] = "IBM ICSFTok ";
-const char descr[] = "IBM PKCS#11 ICSF token";
-const char label[] = "IBM OS PKCS#11   ";
+const char manuf[] = "IBM";
+const char model[] = "ICSF";
+const char descr[] = "IBM ICSF token";
+const char label[] = "icsftok";
 
 /* mechanisms provided by this token */
 static const MECH_LIST_ELEMENT icsf_mech_list[] = {

--- a/usr/lib/soft_stdll/soft_specific.c
+++ b/usr/lib/soft_stdll/soft_specific.c
@@ -59,10 +59,10 @@
 
 #define MAX_GENERIC_KEY_SIZE 256
 
-const char manuf[] = "IBM Corp.";
-const char model[] = "IBM SoftTok ";
-const char descr[] = "IBM PKCS#11 Soft token";
-const char label[] = "IBM OS PKCS#11   ";
+const char manuf[] = "IBM";
+const char model[] = "Soft";
+const char descr[] = "IBM Soft token";
+const char label[] = "softtok";
 
 static const MECH_LIST_ELEMENT soft_mech_list[] = {
     {CKM_RSA_PKCS_KEY_PAIR_GEN, {512, 4096, CKF_GENERATE_KEY_PAIR}},

--- a/usr/lib/tpm_stdll/tpm_specific.c
+++ b/usr/lib/tpm_stdll/tpm_specific.c
@@ -93,10 +93,10 @@ typedef struct {
 TSS_RESULT util_set_public_modulus(TSS_HCONTEXT tspContext, TSS_HKEY,
                                   unsigned long, unsigned char *);
 
-const char manuf[] = "IBM Corp.";
-const char model[] = "TPM v1.1 Token";
-const char descr[] = "Token for the Trusted Platform Module";
-const char label[] = "IBM PKCS#11 TPM Token";
+const char manuf[] = "IBM";
+const char model[] = "TPM";
+const char descr[] = "IBM TPM v1.1 token";
+const char label[] = "tpmtok";
 
 static const MECH_LIST_ELEMENT tpm_mech_list[] = {
     {CKM_RSA_PKCS_KEY_PAIR_GEN, {512, 2048, CKF_GENERATE_KEY_PAIR}},

--- a/usr/sbin/pkcsconf/pkcsconf.c
+++ b/usr/sbin/pkcsconf/pkcsconf.c
@@ -575,7 +575,7 @@ CK_RV display_pkcs11_info(void)
     printf("\tManufacturer: %.32s \n", CryptokiInfo.manufacturerID);
     printf("\tFlags: 0x%lX  \n", CryptokiInfo.flags);
     printf("\tLibrary Description: %.32s \n", CryptokiInfo.libraryDescription);
-    printf("\tLibrary Version %d.%d \n", CryptokiInfo.libraryVersion.major,
+    printf("\tLibrary Version: %d.%d \n", CryptokiInfo.libraryVersion.major,
            CryptokiInfo.libraryVersion.minor);
 
     return rc;


### PR DESCRIPTION
See only the last 2 commits (on top of ingo's PR).

- unify library,slot and token info
- use 0 or empty values for fields that have no meaning, instead of using dummy values
- update travis.yml