### PR TITLE
configure.ac: add locks status message, and improve configure --help

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -181,9 +181,7 @@ AC_ARG_ENABLE([pkcsep11_session],
 
 dnl --- locking support
 AC_ARG_ENABLE([locks],
-	AS_HELP_STRING([--enable-locks],[build opencryptoki with locks instead of transactional memory @<:@default=enabled@:>@]),
-	[],
-	[enable_locks=check])
+	AS_HELP_STRING([--disable-locks],[build opencryptoki with transactional memory instead of locks]))
 
 dnl ---
 dnl --- Check for external software
@@ -629,6 +627,7 @@ echo "	Testcases:		$enable_testcases"
 echo "	Daemon build:		$enable_daemon"
 echo "	Library build:		$enable_library"
 echo "	Systemd service:	$enable_systemd"
+echo "	Build with locks:	$enable_locks"
 echo
 echo "Enabled token types:"
 echo "	ICA token:		$enable_icatok"


### PR DESCRIPTION
Tested all combinations of:

```
./configure
./configure --enable-locks
./configure --enable-locks=no
./configure --disable-locks
```

Normally, the opposite of default is listed in the `./configure --help` output (i.e. `--disable` for things that are enabled by default), and this variable seems important enough to show, given that default has recently changed.

Also note that prior to v3.13 the locks flag behavior was buggy, and `--disable-locks` actually enabled using locks, instead of transactional memory.