### PR TITLE
Fixes

### DIFF
--- a/misc/rsa_parser.pl
+++ b/misc/rsa_parser.pl
@@ -78,7 +78,7 @@ $begin_siglen = "\t\t.sig_len = ";
 
 # giant block of generated tests that I copy-pasted here.
 # this could be replaced with some functions that generate the data below
-# TODO: CKM_CDMF_KEY_GEN doesn't seem to be supported by ICA, CCA or SoftTok,
+# TODO: CKM_CDMF_KEY_GEN doesn't seem to be supported by ICA, CCA or Soft,
 # so those tests can be removed
 $defheader = "#include \"pkcs11types.h\"
 #define MAX_MODULUS_SIZE 256

--- a/testcases/common/common.c
+++ b/testcases/common/common.c
@@ -830,7 +830,7 @@ int is_icsf_token(CK_SLOT_ID slot_id)
     if ((strstr((const char *) tokinfo.model, "ICA") == NULL) &&
         (strstr((const char *) tokinfo.model, "EP11") == NULL) &&
         (strstr((const char *) tokinfo.model, "CCA") == NULL) &&
-        (strstr((const char *) tokinfo.model, "SoftTok") == NULL))
+        (strstr((const char *) tokinfo.model, "Soft") == NULL))
         return TRUE;
 
     return FALSE;
@@ -870,7 +870,7 @@ int is_cca_token(CK_SLOT_ID slot_id)
     return strstr((const char *) tokinfo.model, "CCA") != NULL;
 }
 
-/** Returns true if slot_id is a SoftTok Token **/
+/** Returns true if slot_id is a Soft Token **/
 int is_soft_token(CK_SLOT_ID slot_id)
 {
     CK_RV rc;
@@ -880,7 +880,7 @@ int is_soft_token(CK_SLOT_ID slot_id)
     if (rc != CKR_OK)
         return FALSE;
 
-    return strstr((const char *) tokinfo.model, "SoftTok") != NULL;
+    return strstr((const char *) tokinfo.model, "Soft") != NULL;
 }
 
 /** Returns true if slot_id is a TPM Token **/

--- a/testcases/ock_tests.sh.in
+++ b/testcases/ock_tests.sh.in
@@ -155,7 +155,7 @@ check_slot()
             echo "ICA Token type detected"
             TOKTYPE="ICA"
             ;;
-        *SoftTok*)
+        *Soft*)
             echo "Software Token type detected"
             TOKTYPE="Software"
             ;;

--- a/usr/lib/common/ec_defs.h
+++ b/usr/lib/common/ec_defs.h
@@ -11,7 +11,15 @@
 #ifndef _EC_DEFS
 #define _EC_DEFS
 
+#include <openssl/opensslv.h>
 #include "ec_curves.h"
+
+/* OpenSSL compat */
+#if OPENSSL_VERSION_NUMBER < 0x10101000L
+# define EC_POINT_get_affine_coordinates EC_POINT_get_affine_coordinates_GFp
+# define EC_POINT_set_compressed_coordinates \
+                                     EC_POINT_set_compressed_coordinates_GFp
+#endif
 
 // Elliptic Curve type
 //

--- a/usr/lib/common/mech_ec.c
+++ b/usr/lib/common/mech_ec.c
@@ -29,11 +29,6 @@
 #include "openssl/obj_mac.h"
 #include <openssl/ec.h>
 
-#if OPENSSL_VERSION_NUMBER < 0x10101000L
-# define EC_POINT_get_affine_coordinates EC_POINT_get_affine_coordinates_GFp
-# define EC_POINT_set_compressed_coordinates \
-                                     EC_POINT_set_compressed_coordinates_GFp
-#endif
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 /*
  * Older OpenSLL versions do not have BN_bn2binpad, so implement it here

--- a/usr/lib/common/mech_ec.c
+++ b/usr/lib/common/mech_ec.c
@@ -29,6 +29,11 @@
 #include "openssl/obj_mac.h"
 #include <openssl/ec.h>
 
+#if OPENSSL_VERSION_NUMBER < 0x10101000L
+# define EC_POINT_get_affine_coordinates EC_POINT_get_affine_coordinates_GFp
+# define EC_POINT_set_compressed_coordinates \
+                                     EC_POINT_set_compressed_coordinates_GFp
+#endif
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 /*
  * Older OpenSLL versions do not have BN_bn2binpad, so implement it here
@@ -1338,8 +1343,8 @@ CK_RV ec_uncompress_public_key(CK_BYTE *curve, CK_ULONG curve_len,
     bn_y = BN_new();
     ctx = BN_CTX_new();
 
-    if (!EC_POINT_set_compressed_coordinates_GFp(group,
-                                                 point, bn_x, y_bit, ctx)) {
+    if (!EC_POINT_set_compressed_coordinates(group,
+                                             point, bn_x, y_bit, ctx)) {
         rc = CKR_FUNCTION_FAILED;
         goto end;
     }
@@ -1349,7 +1354,7 @@ CK_RV ec_uncompress_public_key(CK_BYTE *curve, CK_ULONG curve_len,
         goto end;
     }
 
-    if (!EC_POINT_get_affine_coordinates_GFp(group, point, bn_x, bn_y, ctx)) {
+    if (!EC_POINT_get_affine_coordinates(group, point, bn_x, bn_y, ctx)) {
         rc = CKR_FUNCTION_FAILED;
         goto end;
     }

--- a/usr/lib/common/new_host.c
+++ b/usr/lib/common/new_host.c
@@ -988,7 +988,7 @@ CK_RV SC_SetPIN(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
     }
 
 done:
-    TRACE_INFO("C_SetPin: rc = 0x%08lx, session = %lu\n",
+    TRACE_INFO("C_SetPIN: rc = 0x%08lx, session = %lu\n",
                rc, sSession->sessionh);
 
     pthread_mutex_unlock(&tokdata->login_mutex);

--- a/usr/lib/common/object.c
+++ b/usr/lib/common/object.c
@@ -478,7 +478,8 @@ CK_RV object_get_attribute_values(OBJECT * obj,
         if (pTemplate[i].pValue == NULL) {
             pTemplate[i].ulValueLen = attr->ulValueLen;
         } else if (pTemplate[i].ulValueLen >= attr->ulValueLen) {
-            memcpy(pTemplate[i].pValue, attr->pValue, attr->ulValueLen);
+            if (attr->pValue != NULL)
+                memcpy(pTemplate[i].pValue, attr->pValue, attr->ulValueLen);
             pTemplate[i].ulValueLen = attr->ulValueLen;
         } else {
             TRACE_ERROR("%s\n", ock_err(ERR_BUFFER_TOO_SMALL));

--- a/usr/lib/ica_s390_stdll/ica_specific.c
+++ b/usr/lib/ica_s390_stdll/ica_specific.c
@@ -4058,8 +4058,8 @@ static CK_RV decompress_pubkey(unsigned int nid,
         goto end;
     }
 
-    if (!EC_POINT_set_compressed_coordinates_GFp(group,
-                                                 point, bn_x, y_bit, ctx)) {
+    if (!EC_POINT_set_compressed_coordinates(group,
+                                             point, bn_x, y_bit, ctx)) {
         ret = CKR_FUNCTION_FAILED;
         goto end;
     }
@@ -4069,7 +4069,7 @@ static CK_RV decompress_pubkey(unsigned int nid,
         goto end;
     }
 
-    if (!EC_POINT_get_affine_coordinates_GFp(group, point, bn_x, bn_y, ctx)) {
+    if (!EC_POINT_get_affine_coordinates(group, point, bn_x, bn_y, ctx)) {
         ret = CKR_FUNCTION_FAILED;
         goto end;
     }


### PR DESCRIPTION
icsf, tpm and ep11 still need to be tested.
ica, cca looking good.
soft: tdes hmac still fails.

Fixes https://github.com/opencryptoki/opencryptoki/issues/285.

I know its a lot of code duplication, but the <= OpenSSL 1.0.2 code could be removed, soon: https://github.com/opencryptoki/opencryptoki/issues/293