### PR TITLE
Avoid mutex lock at bt_put_node_value()

### DIFF
--- a/usr/include/local_types.h
+++ b/usr/include/local_types.h
@@ -22,7 +22,11 @@ typedef unsigned int uint32;
 
 /* Each node value must start with struct bt_ref_hdr */
 struct bt_ref_hdr {
+#ifdef ENABLE_LOCKS
+    volatile unsigned long ref;
+#else
     unsigned long ref;
+#endif
 };
 
 #define BT_FLAG_FREE 1


### PR DESCRIPTION
Function bt_put_node_value() does not really modify the btree, but it decrements the node values reference count.

Do not use the btree's mutex to lock the reference count from being modified concurrently, but use the built-in functions for atomic memory access instead. This allows bt_put_node_value() to run lock-free.

That way, we can save one mutex-lock/unlock cycle per typical BTree access (bt_get_node_value()/bt_put_node_value()). 