### PR TITLE
Fix segfault when non-existing token object is deleted

### DIFF
--- a/usr/lib/common/obj_mgr.c
+++ b/usr/lib/common/obj_mgr.c
@@ -1751,6 +1751,12 @@ CK_RV object_mgr_set_attribute_values(STDLL_TokData_t *tokdata,
         save_token_object(tokdata, obj);
 
         if (priv_obj) {
+            if (tokdata->global_shm->num_priv_tok_obj == 0) {
+                TRACE_DEVEL("%s\n", ock_err(ERR_OBJECT_HANDLE_INVALID));
+                rc = CKR_OBJECT_HANDLE_INVALID;
+                XProcUnLock(tokdata);
+                goto done;
+            }
             rc = object_mgr_search_shm_for_obj(tokdata->global_shm->
                                                priv_tok_objs, 0,
                                                tokdata->global_shm->
@@ -1765,6 +1771,12 @@ CK_RV object_mgr_set_attribute_values(STDLL_TokData_t *tokdata,
 
             entry = &tokdata->global_shm->priv_tok_objs[index];
         } else {
+            if (tokdata->global_shm->num_publ_tok_obj == 0) {
+                TRACE_DEVEL("%s\n", ock_err(ERR_OBJECT_HANDLE_INVALID));
+                rc = CKR_OBJECT_HANDLE_INVALID;
+                XProcUnLock(tokdata);
+                goto done;
+            }
             rc = object_mgr_search_shm_for_obj(tokdata->global_shm->
                                                publ_tok_objs, 0,
                                                tokdata->global_shm->
@@ -1846,6 +1858,10 @@ CK_RV object_mgr_del_from_shm(OBJECT *obj, LW_SHM_TYPE *global_shm)
     priv = object_is_private(obj);
 
     if (priv) {
+        if (global_shm->num_priv_tok_obj == 0) {
+            TRACE_DEVEL("%s\n", ock_err(ERR_OBJECT_HANDLE_INVALID));
+            return CKR_OBJECT_HANDLE_INVALID;
+        }
         rc = object_mgr_search_shm_for_obj(global_shm->priv_tok_objs,
                                            0, global_shm->num_priv_tok_obj - 1,
                                            obj, &index);
@@ -1886,6 +1902,10 @@ CK_RV object_mgr_del_from_shm(OBJECT *obj, LW_SHM_TYPE *global_shm)
                    sizeof(TOK_OBJ_ENTRY));
         }
     } else {
+        if (global_shm->num_publ_tok_obj == 0) {
+            TRACE_DEVEL("%s\n", ock_err(ERR_OBJECT_HANDLE_INVALID));
+            return CKR_OBJECT_HANDLE_INVALID;
+        }
         rc = object_mgr_search_shm_for_obj(global_shm->publ_tok_objs,
                                            0, global_shm->num_publ_tok_obj - 1,
                                            obj, &index);


### PR DESCRIPTION
When a C_DestroyObject tries to delete a token object, that does no longer exist in the token directory and the shm, because another process has already deleted the object, and there are no further
token objects present in the token directory and shm, then function object_mgr_search_shm_for_obj() is called with an incorrect upper boundary of 0xffffffff (-1), which is higher than MAX_TOK_OBJS and
thus the for loop runs out of the array bounds causing a segfault.