### PR TITLE
Handle early error cases in C_Initialize

### DIFF
--- a/usr/lib/api/api_interface.c
+++ b/usr/lib/api/api_interface.c
@@ -2557,6 +2557,11 @@ CK_RV C_Initialize(CK_VOID_PTR pVoid)
     // Clear out the load list
     memset(slot_loaded, 0, sizeof(int) * NUMBER_SLOTS_MANAGED);
 
+    // Zero out API_Proc_Struct
+    // This must be done prior to all goto error calls, else bt_destroy()
+    // will fail because it accesses uninitialized memory when t->size > 0.
+    memset(Anchor, 0, sizeof(API_Proc_Struct_t));
+
     TRACE_DEBUG("Anchor allocated at %s\n", (char *) Anchor);
 
     // Validation of the parameters passed
@@ -2653,12 +2658,10 @@ CK_RV C_Initialize(CK_VOID_PTR pVoid)
         rc = CKR_FUNCTION_FAILED;
         goto error;
     }
-    //Zero out API_Proc_Struct
     //Map Shared Memory Region
     //if ( Shared Memory Mapped not Successful )
     //                Free allocated Memory
     //                Return CKR_HOST_MEMORY
-    memset((char *) Anchor, 0, sizeof(API_Proc_Struct_t));
     bt_init(&Anchor->sess_btree, free);
     Anchor->Pid = getpid();
 


### PR DESCRIPTION
When `C_Initialize` errors prior to the `bt_init` call, `bt_destroy` will be
called on garbage memory because `Anchor` hasn't yet been zeroed. This
gives a stack trace such as:

    Stack trace of thread 27740:
    #0  0x00007fce91552b05 raise (libc.so.6 + 0x3cb05)
    #1  0x00007fce9153b8a4 abort (libc.so.6 + 0x258a4)
    #2  0x00007fce908db2e1 _ZN2os5abortEb.cold (libjvm.so + 0x20f2e1)
    #3  0x00007fce911f76c2 _ZN7VMError14report_and_dieEv (libjvm.so + 0xb2b6c2)
    #4  0x00007fce90fe7a24 JVM_handle_linux_signal (libjvm.so + 0x91ba24)
    #5  0x00007fce90fdaa9c _Z13signalHandleriP9siginfo_tPv (libjvm.so + 0x90ea9c)
    #6  0x00007fce91552b90 __restore_rt (libc.so.6 + 0x3cb90)
    #7  0x00007fce7a262550 bt_destroy (libopencryptoki.so + 0x11550)
    #8  0x00007fce7a2600d6 C_Initialize (libopencryptoki.so + 0xf0d6)
    #9  0x00007fce7a6c8234 initialize_module_inlock_reentrant (p11-kit-proxy.so + 0x2d234)
    #10 0x00007fce7a6c8383 managed_C_Initialize (p11-kit-proxy.so + 0x2d383)
    #11 0x00007fce7a6cabe0 p11_kit_modules_initialize (p11-kit-proxy.so + 0x2fbe0)
    #12 0x00007fce7a6cea97 proxy_C_Initialize (p11-kit-proxy.so + 0x33a97)
    #13 0x00007fce7aaaa6f2 secmod_ModuleInit (libnss3.so + 0x486f2)
    #14 0x00007fce7aaaae4a secmod_LoadPKCS11Module (libnss3.so + 0x48e4a)
    #15 0x00007fce7aab800d SECMOD_LoadModule (libnss3.so + 0x5600d)
    #16 0x00007fce7aab8148 SECMOD_LoadModule (libnss3.so + 0x56148)
    #17 0x00007fce7aa80dc1 nss_Init (libnss3.so + 0x1edc1)
    #18 0x00007fce7aa8124d NSS_InitReadWrite (libnss3.so + 0x1f24d)
    #19 0x00007fce7ac47a29 Java_org_mozilla_jss_CryptoManager_initializeAllNative2 (libjss4.so + 0x15a29)
    #20 0x00007fce7c8133c7 n/a (n/a + 0x0)
    #21 0x00007fce7c802ffd n/a (n/a + 0x0)
    #22 0x00007fce7c802ffd n/a (n/a + 0x0)
    #23 0x00007fce7c802ffd n/a (n/a + 0x0)
    #24 0x00007fce7c802ffd n/a (n/a + 0x0)
    #25 0x00007fce7c802ffd n/a (n/a + 0x0)
    #26 0x00007fce7c802ffd n/a (n/a + 0x0)
    #27 0x00007fce7c802ffd n/a (n/a + 0x0)
    #28 0x00007fce7c802ffd n/a (n/a + 0x0)
    #29 0x00007fce7c802ffd n/a (n/a + 0x0)
    #30 0x00007fce7c7fb4e7 n/a (n/a + 0x0)
    #31 0x00007fce90d60e45 _ZN9JavaCalls11call_helperEP9JavaValueP12methodHandleP17JavaCallArgumentsP6Thread (libjvm.so + 0x694e45)
    #32 0x00007fce90d8488d _ZL17jni_invoke_staticP7JNIEnv_P9JavaValueP8_jobject11JNICallTypeP10_jmethodIDP18JNI_ArgumentPusherP6Thread.constprop.1 (libjvm.so + 0x6b888d)
    #33 0x00007fce90d87996 jni_CallStaticVoidMethod (libjvm.so + 0x6bb996)
    #34 0x00007fce916ee877 JavaMain (libjli.so + 0x4877)
    #35 0x00007fce914dc3f9 start_thread (libpthread.so.0 + 0x93f9)
    #36 0x00007fce916183b3 __clone (libc.so.6 + 0x1023b3)

Fixing this requires zeroing `Anchor` earlier, making `t->size` 0 and
allowing `bt_destroy` to exit with accessing uninitialized memory.

Resolves: #304

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`