### PR TITLE
pkcstok_migrate: Fix NVTOK.DAT conversion on little endian platforms

### DIFF
--- a/usr/sbin/pkcstok_migrate/pkcstok_migrate.c
+++ b/usr/sbin/pkcstok_migrate/pkcstok_migrate.c
@@ -239,7 +239,7 @@ static CK_RV make_OBJECT_PRIV_312(unsigned char **obj_new, unsigned int *obj_new
 
     /* Setup header */
     memset(&header, 0, sizeof(header));
-    header.tokversion = 0x0003000C;
+    header.tokversion = htobe32(0x0003000C);
     header.private_flag = 0x01;
     ret = aes_256_wrap(header.key_wrapped, obj_key, masterkey);
     if (ret != CKR_OK) {
@@ -252,7 +252,7 @@ static CK_RV make_OBJECT_PRIV_312(unsigned char **obj_new, unsigned int *obj_new
     header.iv[9] = 0;
     header.iv[10] = 0;
     header.iv[11] = 1;
-    header.object_len = clear_len;
+    header.object_len = htobe32(clear_len);
     memcpy(object, &header, HEADER_LEN);
 
     /* Encrypt body */

--- a/usr/sbin/pkcstok_migrate/pkcstok_migrate.c
+++ b/usr/sbin/pkcstok_migrate/pkcstok_migrate.c
@@ -103,9 +103,9 @@ static CK_RV make_OBJECT_PUB_312(char **obj_new, unsigned int *obj_new_len,
 
     /* Setup object */
     memset(&header, 0, sizeof(header));
-    header.tokversion = 0x0003000C;
+    header.tokversion = htobe32(0x0003000C);
     header.private_flag = 0x00;
-    header.object_len = clear_len;
+    header.object_len = htobe32(clear_len);
     memcpy(object, &header, sizeof(header));
     memcpy(object + sizeof(header), clear, clear_len);
 

--- a/usr/sbin/pkcstok_migrate/pkcstok_migrate.mk
+++ b/usr/sbin/pkcstok_migrate/pkcstok_migrate.mk
@@ -6,7 +6,7 @@ noinst_HEADERS += usr/include/local_types.h
 noinst_HEADERS += usr/lib/common/h_extern.h
 noinst_HEADERS += usr/lib/common/pkcs_utils.h
 
-usr_sbin_pkcstok_migrate_pkcstok_migrate_LDFLAGS = -lcrypto -ldl
+usr_sbin_pkcstok_migrate_pkcstok_migrate_LDFLAGS = -lcrypto -ldl -lrt
 
 usr_sbin_pkcstok_migrate_pkcstok_migrate_CFLAGS  =		\
 	-DSTDLL_NAME=\"pkcstok_migrate\"			\


### PR DESCRIPTION
The new format stores all numeric fields in big endian, while the old format uses the platform endianness. So convert the fields to big endian during conversion.

@p-steuer: As discussed, please test this on x86 Linux, thanks.