### PR TITLE
Fixes for potential vulnerabilities

### DIFF
--- a/usr/include/slotmgr.h
+++ b/usr/include/slotmgr.h
@@ -19,6 +19,8 @@
 #include <local_types.h>
 #include <pthread.h>
 #include <sys/mman.h>
+#include <stdarg.h>
+#include <stdio.h>
 
 #include "local_types.h"
 
@@ -246,5 +248,24 @@ typedef Slot_Info_t SLOT_INFO;
 #define LIB_MINOR_V 4
 
 #define RESTART_SYS_CALLS 1
+
+#if defined(__GNUC__) || defined(__clang__)
+__attribute__((__format__ (__printf__, 3, 4)))
+#endif
+static inline int ock_snprintf(char *buf, size_t buflen, const char *fmt, ...)
+{
+    va_list ap;
+    int n;
+
+    va_start(ap, fmt);
+    n = vsnprintf(buf, buflen, fmt, ap);
+    va_end(ap);
+
+    if (n < 0 || (size_t)n >= buflen)
+        return -1;
+
+    return 0;
+}
+
 
 #endif                          /* _SLOTMGR_H */

--- a/usr/lib/common/h_extern.h
+++ b/usr/lib/common/h_extern.h
@@ -430,7 +430,7 @@ CK_RV restore_private_token_object(STDLL_TokData_t *tokdata,
 CK_RV delete_token_object(STDLL_TokData_t *tokdata, OBJECT *ptr);
 CK_RV delete_token_data(STDLL_TokData_t *tokdata);
 
-char *get_pk_dir(STDLL_TokData_t *tokdata, char *);
+char *get_pk_dir(STDLL_TokData_t *tokdata, char *, size_t);
 
 CK_RV init_token_data(STDLL_TokData_t *, CK_SLOT_ID);
 CK_RV load_token_data(STDLL_TokData_t *, CK_SLOT_ID);
@@ -443,8 +443,8 @@ CK_RV save_masterkey_user(STDLL_TokData_t *tokdata);
 
 CK_RV generate_master_key(STDLL_TokData_t *tokdata, CK_BYTE *key);
 
-void init_data_store(STDLL_TokData_t *tokdata, char *directory,
-                     char *data_store);
+CK_RV init_data_store(STDLL_TokData_t *tokdata, char *directory,
+                      char *data_store, size_t len);
 void final_data_store(STDLL_TokData_t * tokdata);
 
 void copy_token_contents_sensibly(CK_TOKEN_INFO_PTR pInfo,

--- a/usr/lib/common/new_host.c
+++ b/usr/lib/common/new_host.c
@@ -115,13 +115,24 @@ CK_RV ST_Initialize(API_Slot_t *sltp, CK_SLOT_ID SlotNumber,
     bt_init(&sltp->TokData->publ_token_obj_btree, call_object_free);
 
     if (strlen(sinfp->tokname)) {
-        sprintf(abs_tokdir_name, "%s/%s", CONFIG_PATH, sinfp->tokname);
+        if (ock_snprintf(abs_tokdir_name, PATH_MAX, "%s/%s",
+                         CONFIG_PATH, sinfp->tokname) != 0) {
+            TRACE_ERROR("token directory path buffer overflow\n");
+            rc = CKR_FUNCTION_FAILED;
+            goto done;
+        }
         TRACE_DEVEL("Token directory: %s\n", abs_tokdir_name);
-        init_data_store(sltp->TokData, (char *) abs_tokdir_name,
-                        sltp->TokData->data_store);
+        rc = init_data_store(sltp->TokData, (char *) abs_tokdir_name,
+                             sltp->TokData->data_store,
+                             sizeof(sltp->TokData->data_store));
     } else {
-        init_data_store(sltp->TokData, (char *) PK_DIR,
-                        sltp->TokData->data_store);
+        rc = init_data_store(sltp->TokData, (char *) PK_DIR,
+                             sltp->TokData->data_store,
+                             sizeof(sltp->TokData->data_store));
+    }
+    if (rc != CKR_OK) {
+        TRACE_ERROR("init_data_store failed with buffer error.\n");
+        goto done;
     }
 
     sltp->TokData->version = sinfp->version;

--- a/usr/lib/common/p11util.c
+++ b/usr/lib/common/p11util.c
@@ -445,7 +445,7 @@ char *p11_ahex_dump(char **dst, CK_BYTE_PTR ptr, CK_ULONG len)
         return NULL;
     }
 
-    *dst = (char *) calloc(2 * len + 1, sizeof(char));
+    *dst = (char *) malloc(2 * len + 1);
     if (*dst == NULL) {
         return NULL;
     }

--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -13,6 +13,8 @@
      ==========
 ****************************************************************************/
 
+/* Declaration of secure_getenv requires _GNU_SOURCE */
+#define _GNU_SOURCE
 #include <pthread.h>
 #include <string.h>
 #include <stdlib.h>
@@ -1344,7 +1346,7 @@ static void *ep11_load_host_lib()
     char *ep11_lib_name;
     char *errstr;
 
-    ep11_lib_name = getenv(EP11SHAREDLIB_NAME);
+    ep11_lib_name = secure_getenv(EP11SHAREDLIB_NAME);
     if (ep11_lib_name != NULL) {
         lib_ep11 = dlopen(ep11_lib_name, DLOPEN_FLAGS);
 
@@ -7002,7 +7004,11 @@ static int read_adapter_config_file(STDLL_TokData_t * tokdata,
     int whitemode = 0;
     int anymode = 0;
     int apqn_i = 0;             /* how many APQN numbers */
-    char *conf_dir = getenv("OCK_EP11_TOKEN_DIR");
+    /* Since the ep11 token config contains the path to libica that
+     * will later be dlopen()ed, we cannot use a token config
+     * directory from an untrusted environment.
+     */
+    char *conf_dir = secure_getenv("OCK_EP11_TOKEN_DIR");
     char fname[PATH_MAX];
     int rc = 0;
     char *cfg_dir;

--- a/usr/lib/ep11_stdll/new_host.c
+++ b/usr/lib/ep11_stdll/new_host.c
@@ -106,13 +106,24 @@ CK_RV ST_Initialize(API_Slot_t *sltp, CK_SLOT_ID SlotNumber,
     bt_init(&sltp->TokData->publ_token_obj_btree, call_object_free);
 
     if (strlen(sinfp->tokname)) {
-        sprintf(abs_tokdir_name, "%s/%s", CONFIG_PATH, sinfp->tokname);
-        TRACE_DEVEL("Token directory: %s\n", abs_tokdir_name);
-        init_data_store(sltp->TokData, (char *) abs_tokdir_name,
-                        sltp->TokData->data_store);
+        if (ock_snprintf(abs_tokdir_name, PATH_MAX, "%s/%s",
+                            CONFIG_PATH, sinfp->tokname) != 0) {
+            TRACE_ERROR("abs_tokdir_name buffer overflow\n");
+            rc = CKR_FUNCTION_FAILED;
+        } else {
+            TRACE_DEVEL("Token directory: %s\n", abs_tokdir_name);
+            rc = init_data_store(sltp->TokData, (char *) abs_tokdir_name,
+                                 sltp->TokData->data_store,
+                                 sizeof(sltp->TokData->data_store));
+        }
     } else {
-        init_data_store(sltp->TokData, (char *) PK_DIR,
-                        sltp->TokData->data_store);
+        rc = init_data_store(sltp->TokData, (char *) PK_DIR,
+                             sltp->TokData->data_store,
+                             sizeof(sltp->TokData->data_store));
+    }
+    if (rc != CKR_OK) {
+        TRACE_ERROR("init_data_store failed with buffer error.\n");
+        goto done;
     }
 
     sltp->TokData->version = sinfp->version;

--- a/usr/lib/tpm_stdll/tpm_openssl.c
+++ b/usr/lib/tpm_stdll/tpm_openssl.c
@@ -170,7 +170,11 @@ int openssl_write_key(STDLL_TokData_t * tokdata, RSA * rsa, char *filename,
         return -1;
     }
 
-    sprintf(loc, "%s/%s/%s", tokdata->pk_dir, pw->pw_name, filename);
+    if (ock_snprintf(loc, PATH_MAX, "%s/%s/%s",
+                        tokdata->pk_dir, pw->pw_name, filename) != 0) {
+        TRACE_ERROR("key path too long\n");
+        return -1;
+    }
 
     b = BIO_new_file(loc, "w");
     if (!b) {
@@ -210,7 +214,11 @@ CK_RV openssl_read_key(STDLL_TokData_t * tokdata, char *filename,
         return CKR_FUNCTION_FAILED;
     }
 
-    sprintf(loc, "%s/%s/%s", tokdata->pk_dir, pw->pw_name, filename);
+    if (ock_snprintf(loc, PATH_MAX, "%s/%s/%s",
+                     tokdata->pk_dir, pw->pw_name, filename) != 0) {
+        TRACE_ERROR("key file name too long\n");
+        return CKR_FUNCTION_FAILED;
+    }
 
     /* we can't allow a pin of NULL here, since openssl will try to prompt
      * for a password in PEM_read_bio_RSAPrivateKey */

--- a/usr/sbin/p11sak/p11sak.c
+++ b/usr/sbin/p11sak/p11sak.c
@@ -39,7 +39,7 @@ static void load_pkcs11lib(void)
     const char *libname;
 
     /* check for environment variable PKCSLIB */
-    libname = getenv("PKCSLIB");
+    libname = secure_getenv("PKCSLIB");
     if (libname == NULL || strlen(libname) < 1)
         libname = default_pkcs11lib;
 

--- a/usr/sbin/pkcsep11_migrate/pkcsep11_migrate.c
+++ b/usr/sbin/pkcsep11_migrate/pkcsep11_migrate.c
@@ -386,7 +386,7 @@ static int do_GetFunctionList(void)
     char *evar;
     char *evar_default = "libopencryptoki.so";
 
-    evar = getenv("PKCSLIB");
+    evar = secure_getenv("PKCSLIB");
     if (evar == NULL) {
         evar = evar_default;
     }
@@ -486,7 +486,7 @@ static void *ep11_load_host_lib()
     char *ep11_lib_name;
     char *errstr;
 
-    ep11_lib_name = getenv(EP11SHAREDLIB_NAME);
+    ep11_lib_name = secure_getenv(EP11SHAREDLIB_NAME);
     if (ep11_lib_name != NULL) {
         lib_ep11 = dlopen(ep11_lib_name, DLOPEN_FLAGS);
 

--- a/usr/sbin/pkcsep11_session/pkcsep11_session.c
+++ b/usr/sbin/pkcsep11_session/pkcsep11_session.c
@@ -231,7 +231,7 @@ static int do_GetFunctionList(void)
     char *evar;
     char *evar_default = "libopencryptoki.so";
 
-    evar = getenv("PKCSLIB");
+    evar = secure_getenv("PKCSLIB");
     if (evar == NULL)
         evar = evar_default;
 
@@ -1003,7 +1003,7 @@ static void *ep11_load_host_lib()
     char *ep11_lib_name;
     char *errstr;
 
-    ep11_lib_name = getenv(EP11SHAREDLIB_NAME);
+    ep11_lib_name = secure_getenv(EP11SHAREDLIB_NAME);
     if (ep11_lib_name != NULL) {
         lib_ep11 = dlopen(ep11_lib_name, DLOPEN_FLAGS);
 


### PR DESCRIPTION
Don't use environment variables in all cases.  If running under setuid, we
should not trust the environment without additional sanitization.  Especially
for loading libraries, we cannot use input from untrusted environment
variables.

Some paths were written under some assumptions that paths never overflow.
Instead, we use a checked path creation.  If the path name overflows, the
function that tries to use the path name fails.

This commit only includes reworks on getenv and sprintf.  Further functions
should still be checked.

There are also some minor cosmetic fixes:
- Don't calloc if we anyway write all allocated bytes directly afterwards.
- Don't allocate paths larger than PATH_MAX.

Signed-off-by: Juergen Christ <jchrist@linux.ibm.com>