### PR TITLE
ICSF: replace PBKDF implementation by libcrypto call

### DIFF
--- a/usr/lib/icsf_stdll/pbkdf.h
+++ b/usr/lib/icsf_stdll/pbkdf.h
@@ -22,6 +22,11 @@
 #define DKEYLEN  32      // 256 bytes is max key size to be derived
 #define PIN_SIZE 80      // samedefine in pkcsconf
 #define ENCRYPT_SIZE 96      // PIN_SIZE + AES_BLOCK_SIZE (for padding)
+/*
+ * SP 800-132 recommends a minimum iteration count of 1000.
+ * so lets try that for now...
+ */
+#define ITERATIONS 1000
 
 #define ICSF_CONFIG_PATH CONFIG_PATH "/icsf"
 #define RACFFILE ICSF_CONFIG_PATH "/RACF"


### PR DESCRIPTION
We want to replace all of openCryptoki's SW implementations
by calling to libcrypto. Moreover, the HMAC interface used
by openCryptoki's PBKDF implementation is deprecated in
OpenSSL master.

Edit: It looks like there may be a difference between OCK's old PBKDF implementation and what OpenSSL implements, so this one is not working yet. Not planning to include this one in the october release.