### PR TITLE
Fix GCC 10 compiler warning in pkcstok_migrate.c

### DIFF
--- a/testcases/common/common.c
+++ b/testcases/common/common.c
@@ -1004,8 +1004,8 @@ int get_user_pin(CK_BYTE * dest)
 
 void process_time(SYSTEMTIME t1, SYSTEMTIME t2)
 {
-    long ms = t2.millitm - t1.millitm;
-    long s = t2.time - t1.time;
+    long ms = (t2.tv_usec - t1.tv_usec) / 1000;
+    long s = t2.tv_sec - t1.tv_sec;
 
     while (ms < 0) {
         ms += 1000;

--- a/testcases/include/regress.h
+++ b/testcases/include/regress.h
@@ -30,9 +30,9 @@
 
 #define MIN(a, b)       ( (a) < (b) ? (a) : (b) )
 
-#include <sys/timeb.h>
-#define SYSTEMTIME   struct timeb
-#define GetSystemTime(x) ftime((x))
+#include <sys/time.h>
+#define SYSTEMTIME   struct timeval
+#define GetSystemTime(x) gettimeofday((x), NULL)
 
 #include <sys/time.h>
 

--- a/usr/sbin/pkcstok_migrate/pkcstok_migrate.c
+++ b/usr/sbin/pkcstok_migrate/pkcstok_migrate.c
@@ -564,11 +564,8 @@ static CK_RV read_object(const char *data_store, const char *name,
     *obj_len = 0;
 
     /* Open token object file */
-    snprintf((char *) fname, sizeof(fname), "%s/TOK_OBJ/", data_store);
-    strcat((char *) fname, (char *) name);
-    fp = fopen((char *) fname, "r");
+    fp = open_tokenobject(fname, sizeof(fname), data_store, "TOK_OBJ", name, "r");
     if (!fp) {
-        TRACE_ERROR("fopen(%s) failed, errno=%s\n", fname, strerror(errno));
         ret = CKR_FUNCTION_FAILED;
         goto done;
     }


### PR DESCRIPTION
GCC 10 complains about a snprintf.  The real problem is the strcat in the next
line.  However, the lines can easily be simplified to also remove the warning.

Signed-off-by: Juergen Christ <jchrist@linux.ibm.com>