### PR TITLE
Remove ep11 configuration on uninstall

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -165,6 +165,8 @@ if ENABLE_EP11TOK
 	if test -d $(DESTDIR)$(libdir)/opencryptoki/stdll; then \
 		cd $(DESTDIR)$(libdir)/opencryptoki/stdll && \
 		rm -f PKCS11_EP11.so; fi
+	rm -f $(DESTDIR)$(sysconfdir)/opencryptoki/ep11tok.conf 
+	rm -f $(DESTDIR)$(sysconfdir)/opencryptoki/ep11cpfilter.conf
 endif
 if ENABLE_ICATOK
 	if test -d $(DESTDIR)$(libdir)/opencryptoki/stdll; then \


### PR DESCRIPTION
The uninstall targets leaves ep11tok.conf and ep11cpfilter.conf in the
configuration directories.  Remove these two to have a clean uninstall.

Signed-off-by: Juergen Christ <jchrist@linux.ibm.com>