### PR TITLE
Make testcases-folder world writable for su tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -201,9 +201,12 @@ installcheck-local: all
 	killall -HUP pkcsslotd || true
 	@sbindir@/pkcsslotd
 	if test ! -z ${PKCS11_TEST_USER}; then				\
-		cd ${srcdir}/testcases && su ${PKCS11_TEST_USER} -c "PKCS11_SO_PIN=76543210 PKCS11_USER_PIN=01234567 PKCSLIB=@libdir@/opencryptoki/libopencryptoki.so sh ./ock_tests.sh"; \
+		chmod 777 ${srcdir}/testcases &&			\
+		cd ${srcdir}/testcases &&   				\
+		su ${PKCS11_TEST_USER} -c "PKCS11_SO_PIN=76543210 PKCS11_USER_PIN=01234567 PKCSLIB=@libdir@/opencryptoki/libopencryptoki.so sh ./ock_tests.sh"; \
 	else								\
-		cd ${srcdir}/testcases && PKCS11_SO_PIN=76543210 PKCS11_USER_PIN=01234567 PKCSLIB=@libdir@/opencryptoki/libopencryptoki.so sh ./ock_tests.sh; \
+		cd ${srcdir}/testcases && 				\
+		PKCS11_SO_PIN=76543210 PKCS11_USER_PIN=01234567 PKCSLIB=@libdir@/opencryptoki/libopencryptoki.so sh ./ock_tests.sh; \
 	fi
 	killall -HUP pkcsslotd
 endif


### PR DESCRIPTION
When running tests via "make installcheck" with "PKCS11_TEST_USER", that user
must be granted write access to the testcases folder since it will generate
the log-files in this folder.  Without this, ock_test.sh will not be able to
run successfully.

Signed-off-by: Juergen Christ <jchrist@linux.ibm.com>