### PR TITLE
Add ci-installcheck make target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -199,17 +199,23 @@ endif
 
 
 if ENABLE_TESTCASES
+PKCS11_SO_PIN ?= 76543210
+PKCS11_USER_PIN ?= 01234567
+
 installcheck-local: all
 	killall -HUP pkcsslotd || true
 	@sbindir@/pkcsslotd
 	if test ! -z ${PKCS11_TEST_USER}; then				\
 		chmod 777 ${srcdir}/testcases &&			\
-		cd ${srcdir}/testcases &&   				\
-		su ${PKCS11_TEST_USER} -c "PKCS11_SO_PIN=76543210 PKCS11_USER_PIN=01234567 PKCSLIB=@libdir@/opencryptoki/libopencryptoki.so sh ./ock_tests.sh"; \
+		cd ${srcdir}/testcases &&                               \
+		su ${PKCS11_TEST_USER} -s /bin/bash -c "PKCS11_SO_PIN=$(PKCS11_SO_PIN) PKCS11_USER_PIN=$(PKCS11_USER_PIN) PKCSLIB=@libdir@/opencryptoki/libopencryptoki.so sh ./ock_tests.sh"; \
 	else								\
 		cd ${srcdir}/testcases && 				\
-		PKCS11_SO_PIN=76543210 PKCS11_USER_PIN=01234567 PKCSLIB=@libdir@/opencryptoki/libopencryptoki.so sh ./ock_tests.sh; \
+		PKCS11_SO_PIN=$(PKCS11_SO_PIN) PKCS11_USER_PIN=$(PKCS11_USER_PIN) PKCSLIB=@libdir@/opencryptoki/libopencryptoki.so sh ./ock_tests.sh; \
 	fi
 	killall -HUP pkcsslotd
+
+ci-installcheck: installcheck
+	@echo "done"
 endif
 


### PR DESCRIPTION
This target is supposed to contain all checks that should only run in the CI
but not on a "make installcheck".  Examples include token pin changes and
master key changes.

Signed-off-by: Juergen Christ <jchrist@linux.ibm.com>