### PR TITLE
CCA: store only public token in IBM_OPAQUE attribute

### DIFF
--- a/usr/lib/cca_stdll/cca_specific.c
+++ b/usr/lib/cca_stdll/cca_specific.c
@@ -238,6 +238,27 @@ static const MECH_LIST_ELEMENT cca_mech_list[] = {
 static const CK_ULONG cca_mech_list_len =
                         (sizeof(cca_mech_list) / sizeof(MECH_LIST_ELEMENT));
 
+
+/* Helper function: build attribute and update template */
+static CK_RV build_update_attribute(TEMPLATE * tmpl,
+                                    CK_ATTRIBUTE_TYPE type,
+                                    CK_BYTE * data, CK_ULONG data_len)
+{
+    CK_ATTRIBUTE *attr;
+    CK_RV rv;
+
+    if ((rv = build_attribute(type, data, data_len, &attr))) {
+        TRACE_DEVEL("Build attribute for type=%lu failed, rv=0x%lx\n", type, rv);
+        return rv;
+    }
+    if ((rv = template_update_attribute(tmpl, attr))) {
+	TRACE_DEVEL("Template update for type=%lu failed, rv=0x%lx\n", type, rv);
+        return rv;
+    }
+
+    return CKR_OK;
+}
+
 CK_RV token_specific_rng(STDLL_TokData_t * tokdata, CK_BYTE * output,
                          CK_ULONG bytes)
 {
@@ -715,7 +736,7 @@ CK_RV cca_inttok_privkey_get_n(CK_BYTE * tok, CK_ULONG * n_len, CK_BYTE * n)
 }
 
 /* Given a CCA internal token pubkey object, get the public exponent */
-CK_RV cca_inttok_pubkey_get_e(CK_BYTE * tok, CK_ULONG * e_len, CK_BYTE * e)
+static CK_RV cca_inttok_pubkey_get_e(CK_BYTE * tok, CK_ULONG * e_len, CK_BYTE * e)
 {
     uint16_t e_length;
 
@@ -733,14 +754,15 @@ CK_RV cca_inttok_pubkey_get_e(CK_BYTE * tok, CK_ULONG * e_len, CK_BYTE * e)
     return CKR_OK;
 }
 
-CK_RV token_create_keypair_object(TEMPLATE * tmpl, CK_ULONG tok_len,
-                                  CK_BYTE * tok)
+/* Pull n and e from RSA priv key token and add to template */
+static CK_RV add_n_and_e_to_rsa_key_template(TEMPLATE * tmpl,
+                                             CK_BYTE *cca_rsa_priv_key_token)
 {
     uint16_t privkey_len, pubkey_offset;
     CK_BYTE n[CCATOK_MAX_N_LEN], e[CCATOK_MAX_E_LEN];
     CK_ULONG n_len = CCATOK_MAX_N_LEN, e_len = CCATOK_MAX_E_LEN;
-    CK_ATTRIBUTE *modulus, *pub_exp, *opaque_key;
     CK_RV rv;
+    CK_BYTE *tok = cca_rsa_priv_key_token;
 
     privkey_len =
         cca_inttok_privkey_get_len(&tok[CCA_RSA_INTTOK_PRIVKEY_OFFSET]);
@@ -760,25 +782,18 @@ CK_RV token_create_keypair_object(TEMPLATE * tmpl, CK_ULONG tok_len,
     }
 
     /* Add n's value to the template */
-    if ((rv = build_attribute(CKA_MODULUS, n, n_len, &modulus))) {
-        TRACE_DEVEL("build_attribute for n failed. rv=0x%lx\n", rv);
+    rv = build_update_attribute(tmpl, CKA_MODULUS, n, n_len);
+    if (rv != CKR_OK) {
+        TRACE_DEVEL("add CKA_MODULUS attribute to template failed, rv=0x%lx\n", rv);
         return rv;
     }
-    template_update_attribute(tmpl, modulus);
 
     /* Add e's value to the template */
-    if ((rv = build_attribute(CKA_PUBLIC_EXPONENT, e, e_len, &pub_exp))) {
-        TRACE_DEVEL("build_attribute for e failed. rv=0x%lx\n", rv);
+    rv = build_update_attribute(tmpl, CKA_PUBLIC_EXPONENT, e, e_len);
+    if (rv != CKR_OK) {
+        TRACE_DEVEL("add CKA_PUBLIC_EXPONENT attribute to template failed, rv=0x%lx\n", rv);
         return rv;
     }
-    template_update_attribute(tmpl, pub_exp);
-
-    /* Add the opaque key object to the template */
-    if ((rv = build_attribute(CKA_IBM_OPAQUE, tok, tok_len, &opaque_key))) {
-        TRACE_DEVEL("build_attribute for opaque key failed. rv=0x%lx\n", rv);
-        return rv;
-    }
-    template_update_attribute(tmpl, opaque_key);
 
     return CKR_OK;
 }
@@ -833,10 +848,12 @@ CK_RV token_specific_rsa_generate_keypair(STDLL_TokData_t * tokdata,
     unsigned char private_key_name[CCA_PRIVATE_KEY_NAME_SIZE] = { 0, };
     unsigned char key_token[CCA_KEY_TOKEN_SIZE] = { 0, };
 
-    long regeneration_data_length, generated_key_token_length;
+    long regeneration_data_length;
+    long priv_key_token_length, publ_key_token_length;
     unsigned char regeneration_data[CCA_REGENERATION_DATA_SIZE] = { 0, };
     unsigned char transport_key_identifier[CCA_KEY_ID_SIZE] = { 0, };
-    unsigned char generated_key_token[CCA_KEY_TOKEN_SIZE] = { 0, };
+    unsigned char priv_key_token[CCA_KEY_TOKEN_SIZE] = { 0, };
+    unsigned char publ_key_token[CCA_KEY_TOKEN_SIZE] = { 0, };
 
     uint16_t size_of_e;
     uint16_t mod_bits;
@@ -907,25 +924,16 @@ CK_RV token_specific_rsa_generate_keypair(STDLL_TokData_t * tokdata,
 
     rule_array_count = 2;
     memcpy(rule_array, "RSA-AESCKEY-MGMT", (size_t) (CCA_KEYWORD_SIZE * 2));
-
     private_key_name_length = 0;
-
     key_token_length = CCA_KEY_TOKEN_SIZE;
 
-    dll_CSNDPKB(&return_code,
-                &reason_code,
-                NULL,
-                NULL,
-                &rule_array_count,
-                rule_array,
-                &key_value_structure_length,
-                key_value_structure,
-                &private_key_name_length,
-                private_key_name,
-                0,
-                NULL,
-                0,
-                NULL, 0, NULL, 0, NULL, 0, NULL, &key_token_length, key_token);
+    dll_CSNDPKB(&return_code, &reason_code,
+                NULL, NULL,
+                &rule_array_count, rule_array,
+                &key_value_structure_length, key_value_structure,
+                &private_key_name_length, private_key_name,
+                0, NULL, 0, NULL, 0, NULL, 0, NULL, 0, NULL,
+                &key_token_length, key_token);
 
     if (return_code != CCA_SUCCESS) {
         TRACE_ERROR("CSNDPKB (RSA KEY TOKEN BUILD) failed. return:%ld,"
@@ -936,23 +944,16 @@ CK_RV token_specific_rsa_generate_keypair(STDLL_TokData_t * tokdata,
     rule_array_count = 1;
     memset(rule_array, 0, sizeof(rule_array));
     memcpy(rule_array, "MASTER  ", (size_t) CCA_KEYWORD_SIZE);
-
-    generated_key_token_length = CCA_KEY_TOKEN_SIZE;
-
+    priv_key_token_length = CCA_KEY_TOKEN_SIZE;
     regeneration_data_length = 0;
 
-    dll_CSNDPKG(&return_code,
-                &reason_code,
-                NULL,
-                NULL,
-                &rule_array_count,
-                rule_array,
-                &regeneration_data_length,
-                regeneration_data,
-                &key_token_length,
-                key_token,
+    dll_CSNDPKG(&return_code, &reason_code,
+                NULL, NULL,
+                &rule_array_count, rule_array,
+                &regeneration_data_length, regeneration_data,
+                &key_token_length, key_token,
                 transport_key_identifier,
-                &generated_key_token_length, generated_key_token);
+                &priv_key_token_length, priv_key_token);
 
     if (return_code != CCA_SUCCESS) {
         TRACE_ERROR("CSNDPKG (RSA KEY GENERATE) failed. return:%ld,"
@@ -961,21 +962,55 @@ CK_RV token_specific_rsa_generate_keypair(STDLL_TokData_t * tokdata,
     }
 
     TRACE_DEVEL("RSA secure key token generated. size: %ld\n",
-                generated_key_token_length);
+                priv_key_token_length);
 
-    rv = token_create_keypair_object(publ_tmpl, generated_key_token_length,
-                                     generated_key_token);
+    rule_array_count = 0;
+    publ_key_token_length = CCA_KEY_TOKEN_SIZE;
+
+    dll_CSNDPKX(&return_code, &reason_code,
+                NULL, NULL,
+                &rule_array_count, rule_array,
+                &priv_key_token_length, priv_key_token,
+                &publ_key_token_length, publ_key_token);
+
+    if (return_code != CCA_SUCCESS) {
+        TRACE_ERROR("CSNDPKX (PUBLIC KEY TOKEN EXTRACT) failed. return:%ld,"
+                    " reason:%ld\n", return_code, reason_code);
+        return CKR_FUNCTION_FAILED;
+    }
+
+    TRACE_DEVEL("RSA public key token extracted. size: %ld\n",
+                publ_key_token_length);
+
+    /* update priv template, add n, e and ibm opaque attr with priv key token */
+    rv = add_n_and_e_to_rsa_key_template(priv_tmpl, priv_key_token);
     if (rv != CKR_OK) {
-        TRACE_DEVEL("token_create_keypair_object failed. rv:%lu\n", rv);
+        TRACE_DEVEL("add_n_and_e_to_rsa_key_template failed. rv:%lu\n", rv);
+        return rv;
+    }
+    rv = build_update_attribute(priv_tmpl, CKA_IBM_OPAQUE,
+                                priv_key_token,
+                                priv_key_token_length);
+    if (rv != CKR_OK) {
+        TRACE_DEVEL("add CKA_IBM_OPAQUE attribute to priv template failed, rv:%lu\n", rv);
         return rv;
     }
 
-    rv = token_create_keypair_object(priv_tmpl, generated_key_token_length,
-                                     generated_key_token);
-    if (rv != CKR_OK)
-        TRACE_DEVEL("token_create_keypair_object failed. rv:%lu\n", rv);
+    /* update pub template, add n, e and ibm opaque attr with pub key token */
+    rv = add_n_and_e_to_rsa_key_template(publ_tmpl, priv_key_token);
+    if (rv != CKR_OK) {
+        TRACE_DEVEL("add_n_and_e_to_rsa_key_template failed. rv:%lu\n", rv);
+        return rv;
+    }
+    rv = build_update_attribute(publ_tmpl, CKA_IBM_OPAQUE,
+                                publ_key_token,
+                                publ_key_token_length);
+    if (rv != CKR_OK) {
+        TRACE_DEVEL("add CKA_IBM_OPAQUE attribute to publ template failed, rv:%lu\n", rv);
+        return rv;
+    }
 
-    return rv;
+    return CKR_OK;
 }
 
 
@@ -2037,21 +2072,6 @@ CK_RV token_specific_get_mechanism_info(STDLL_TokData_t * tokdata,
     return ock_generic_get_mechanism_info(tokdata, type, pInfo);
 }
 
-CK_RV build_update_attribute(TEMPLATE * tmpl,
-                             CK_ATTRIBUTE_TYPE type,
-                             CK_BYTE * data, CK_ULONG data_len)
-{
-    CK_ATTRIBUTE *attr;
-    CK_RV rv;
-    if ((rv = build_attribute(type, data, data_len, &attr))) {
-        TRACE_DEVEL("Build attribute for type=%lu failed rv=0x%lx\n", type, rv);
-        return rv;
-    }
-    template_update_attribute(tmpl, attr);
-
-    return CKR_OK;
-}
-
 CK_BBOOL is_curve_error(long return_code, long reason_code)
 {
     if (return_code == 8) {
@@ -2136,7 +2156,8 @@ uint16_t cca_ec_publkey_offset(CK_BYTE * tok)
 
 CK_RV token_create_ec_keypair(TEMPLATE * publ_tmpl,
                               TEMPLATE * priv_tmpl,
-                              CK_ULONG tok_len, CK_BYTE * tok)
+                              CK_ULONG priv_tok_len, CK_BYTE *priv_tok,
+                              CK_ULONG publ_tok_len, CK_BYTE *publ_tok)
 {
     uint16_t pubkey_offset, qlen_offset, q_offset;
     CK_ULONG q_len;
@@ -2161,10 +2182,10 @@ CK_RV token_create_ec_keypair(TEMPLATE * publ_tmpl,
     /*
      * Get Q data for public key.
      */
-    pubkey_offset = cca_ec_publkey_offset(tok);
+    pubkey_offset = cca_ec_publkey_offset(priv_tok);
 
     qlen_offset = pubkey_offset + CCA_EC_INTTOK_PUBKEY_Q_LEN_OFFSET;
-    q_len = *(uint16_t *) & tok[qlen_offset];
+    q_len = *(uint16_t *) & priv_tok[qlen_offset];
     q_len = ntohs(q_len);
 
     if (q_len > CCATOK_EC_MAX_Q_LEN) {
@@ -2174,7 +2195,7 @@ CK_RV token_create_ec_keypair(TEMPLATE * publ_tmpl,
     }
 
     q_offset = pubkey_offset + CCA_EC_INTTOK_PUBKEY_Q_OFFSET;
-    memcpy(q, &tok[q_offset], (size_t) q_len);
+    memcpy(q, &priv_tok[q_offset], (size_t) q_len);
 
     rv = ber_encode_OCTET_STRING(FALSE, &ecpoint, &ecpoint_len, q, q_len);
     if (rv != CKR_OK) {
@@ -2203,18 +2224,17 @@ CK_RV token_create_ec_keypair(TEMPLATE * publ_tmpl,
         return rv;
     }
 
-    /*
-     * Save the CKA_IBM_OPAQUE for both keys.
-     */
-    if ((rv = build_update_attribute(publ_tmpl,
-                                     CKA_IBM_OPAQUE, tok, tok_len))) {
-        TRACE_DEVEL("build_update_attribute for tok failed rv=0x%lx\n", rv);
+    /* store publ key token into CKA_IBM_OPAQUE of the public key object */
+    if ((rv = build_update_attribute(publ_tmpl, CKA_IBM_OPAQUE,
+                                     publ_tok, publ_tok_len))) {
+        TRACE_DEVEL("build_update_attribute for publ_tok failed rv=0x%lx\n", rv);
         return rv;
     }
 
-    if ((rv = build_update_attribute(priv_tmpl,
-                                     CKA_IBM_OPAQUE, tok, tok_len))) {
-        TRACE_DEVEL("build_update_attribute for tok failed rv=0x%lx\n", rv);
+    /* store priv key token into CKA_IBM_OPAQUE of the private key object */
+    if ((rv = build_update_attribute(priv_tmpl, CKA_IBM_OPAQUE,
+                                     priv_tok, priv_tok_len))) {
+        TRACE_DEVEL("build_update_attribute for priv_tok failed rv=0x%lx\n", rv);
         return rv;
     }
 
@@ -2232,10 +2252,12 @@ CK_RV token_specific_ec_generate_keypair(STDLL_TokData_t * tokdata,
     unsigned char key_value_structure[CCA_EC_KEY_VALUE_STRUCT_SIZE] = { 0, };
     unsigned char private_key_name[CCA_PRIVATE_KEY_NAME_SIZE] = { 0, };
     unsigned char key_token[CCA_KEY_TOKEN_SIZE] = { 0, };
-    long regeneration_data_length, generated_key_token_length;
+    long regeneration_data_length;
+    long priv_key_token_length, publ_key_token_length;
     unsigned char regeneration_data[CCA_REGENERATION_DATA_SIZE] = { 0, };
     unsigned char transport_key_identifier[CCA_KEY_ID_SIZE] = { 0, };
-    unsigned char generated_key_token[CCA_KEY_TOKEN_SIZE] = { 0, };
+    unsigned char priv_key_token[CCA_KEY_TOKEN_SIZE] = { 0, };
+    unsigned char publ_key_token[CCA_KEY_TOKEN_SIZE] = { 0, };
     CK_RV rv;
     long param1 = 0;
     unsigned char *param2 = NULL;
@@ -2297,7 +2319,7 @@ CK_RV token_specific_ec_generate_keypair(STDLL_TokData_t * tokdata,
     memset(rule_array, 0, sizeof(rule_array));
     memcpy(rule_array, "MASTER  ", (size_t) CCA_KEYWORD_SIZE);
 
-    generated_key_token_length = CCA_KEY_TOKEN_SIZE;
+    priv_key_token_length = CCA_KEY_TOKEN_SIZE;
 
     regeneration_data_length = 0;
 
@@ -2312,7 +2334,7 @@ CK_RV token_specific_ec_generate_keypair(STDLL_TokData_t * tokdata,
                 &key_token_length,
                 key_token,
                 transport_key_identifier,
-                &generated_key_token_length, generated_key_token);
+                &priv_key_token_length, priv_key_token);
 
     if (return_code != CCA_SUCCESS) {
         TRACE_ERROR("CSNDPKG (EC KEY GENERATE) failed."
@@ -2322,12 +2344,30 @@ CK_RV token_specific_ec_generate_keypair(STDLL_TokData_t * tokdata,
         return CKR_FUNCTION_FAILED;
     }
 
-    TRACE_DEVEL("ECC secure key token generated. size: %ld\n",
-                generated_key_token_length);
+    TRACE_DEVEL("ECC secure private key token generated. size: %ld\n",
+                priv_key_token_length);
+
+    rule_array_count = 0;
+    publ_key_token_length = CCA_KEY_TOKEN_SIZE;
+
+    dll_CSNDPKX(&return_code, &reason_code,
+                NULL, NULL,
+                &rule_array_count, rule_array,
+                &priv_key_token_length, priv_key_token,
+                &publ_key_token_length, publ_key_token);
+
+    if (return_code != CCA_SUCCESS) {
+        TRACE_ERROR("CSNDPKX (PUBLIC KEY TOKEN EXTRACT) failed. return:%ld,"
+                    " reason:%ld\n", return_code, reason_code);
+        return CKR_FUNCTION_FAILED;
+    }
+
+    TRACE_DEVEL("ECC secure public key token generated. size: %ld\n",
+                publ_key_token_length);
 
     rv = token_create_ec_keypair(publ_tmpl, priv_tmpl,
-                                 generated_key_token_length,
-                                 generated_key_token);
+                                 priv_key_token_length, priv_key_token,
+                                 publ_key_token_length, publ_key_token);
     if (rv != CKR_OK) {
         TRACE_DEVEL("token_create_ec_keypair failed. rv: %lu\n", rv);
         return rv;

--- a/usr/lib/cca_stdll/cca_specific.c
+++ b/usr/lib/cca_stdll/cca_specific.c
@@ -874,7 +874,7 @@ CK_RV token_specific_rsa_generate_keypair(STDLL_TokData_t * tokdata,
         /* make pValue into CK_ULONG so we can compare */
         tmpexp = 0;
         memcpy((unsigned char *) &tmpexp + sizeof(CK_ULONG) - tmpsize,
-               ptr, tmpsize);	/* right align */
+               ptr, tmpsize);   /* right align */
 
         /* Check for one of the three allowed values */
         if ((tmpexp != 0) && (tmpexp != 3) && (tmpexp != 65537))
@@ -3155,7 +3155,7 @@ send:
     if (sign) {
         dll_CSNBHMG(&return_code, &reason_code, NULL, NULL,
                     &rule_array_count, rule_array,
-		    (long int *)&attr->ulValueLen, attr->pValue,
+                    (long int *)&attr->ulValueLen, attr->pValue,
                     use_buffer ? &buffer_len : (long int *) &in_data_len,
                     use_buffer ? buffer : in_data,
                     &cca_ctx->chain_vector_len, cca_ctx->chain_vector,
@@ -3807,9 +3807,10 @@ static CK_RV import_generic_secret_key(OBJECT * object)
 }
 
 static CK_RV build_private_EC_key_value_structure(CK_BYTE *privkey, CK_ULONG privlen,
-        CK_BYTE *pubkey, CK_ULONG publen,
-        uint8_t curve_type, uint16_t curve_bitlen,
-        unsigned char *key_value_structure, long *key_value_structure_length)
+                                                  CK_BYTE *pubkey, CK_ULONG publen,
+                                                  uint8_t curve_type, uint16_t curve_bitlen,
+                                                  unsigned char *key_value_structure,
+                                                  long *key_value_structure_length)
 {
     ECC_PAIR ecc_pair;
 
@@ -3860,8 +3861,9 @@ static unsigned int bitlen2bytelen(uint16_t bitlen)
 }
 
 static CK_RV build_public_EC_key_value_structure(CK_BYTE *pubkey, CK_ULONG publen,
-        uint8_t curve_type, uint16_t curve_bitlen,
-        unsigned char *key_value_structure, long *key_value_structure_length)
+                                                 uint8_t curve_type, uint16_t curve_bitlen,
+                                                 unsigned char *key_value_structure,
+                                                 long *key_value_structure_length)
 {
     ECC_PUBL ecc_publ;
 
@@ -4118,80 +4120,80 @@ static CK_RV ec_import_pubkey(TEMPLATE *pub_templ)
 
 CK_RV token_specific_object_add(STDLL_TokData_t *tokdata, SESSION *sess, OBJECT *object)
 {
-	CK_RV rc;
-	CK_ATTRIBUTE *attr = NULL;
-	CK_KEY_TYPE keytype;
-	CK_OBJECT_CLASS keyclass;
+    CK_RV rc;
+    CK_ATTRIBUTE *attr = NULL;
+    CK_KEY_TYPE keytype;
+    CK_OBJECT_CLASS keyclass;
 
-	UNUSED(tokdata);
-	UNUSED(sess);
+    UNUSED(tokdata);
+    UNUSED(sess);
 
-	if (!object) {
-		TRACE_ERROR("Invalid argument\n");
-		return CKR_FUNCTION_FAILED;
-	}
+    if (!object) {
+        TRACE_ERROR("Invalid argument\n");
+        return CKR_FUNCTION_FAILED;
+    }
 
-	rc = template_attribute_find(object->template, CKA_KEY_TYPE, &attr);
-	if (rc == FALSE) {
-		// not a key, so nothing to do. Just return.
-		TRACE_DEVEL("object not a key, no need to import.\n");
-		return CKR_OK;
-	}
+    rc = template_attribute_find(object->template, CKA_KEY_TYPE, &attr);
+    if (rc == FALSE) {
+        // not a key, so nothing to do. Just return.
+        TRACE_DEVEL("object not a key, no need to import.\n");
+        return CKR_OK;
+    }
 
-	keytype = *(CK_KEY_TYPE *)attr->pValue;
+    keytype = *(CK_KEY_TYPE *)attr->pValue;
 
-	switch (keytype) {
-	case CKK_RSA:
-		rc = template_attribute_find(object->template, CKA_CLASS, &attr);
-		if (rc == FALSE) {
-			TRACE_ERROR("%s\n", ock_err(ERR_TEMPLATE_INCOMPLETE));
-			return CKR_TEMPLATE_INCOMPLETE;
-		}
+    switch (keytype) {
+    case CKK_RSA:
+        rc = template_attribute_find(object->template, CKA_CLASS, &attr);
+        if (rc == FALSE) {
+            TRACE_ERROR("%s\n", ock_err(ERR_TEMPLATE_INCOMPLETE));
+            return CKR_TEMPLATE_INCOMPLETE;
+        }
 
         keyclass = *(CK_OBJECT_CLASS *)attr->pValue;
 
-		switch(keyclass) {
-		case CKO_PUBLIC_KEY:
-			// do import public key and create opaque object
-			rc = rsa_import_pubkey(object->template);
-			break;
-		case CKO_PRIVATE_KEY:
-			// do import keypair and create opaque object
-			rc = rsa_import_privkey_crt(object->template);
-			break;
-		default:
-			TRACE_ERROR("%s\n", ock_err(ERR_KEY_TYPE_INCONSISTENT));
-			return CKR_KEY_TYPE_INCONSISTENT;
-		}
+        switch(keyclass) {
+        case CKO_PUBLIC_KEY:
+            // do import public key and create opaque object
+            rc = rsa_import_pubkey(object->template);
+            break;
+        case CKO_PRIVATE_KEY:
+            // do import keypair and create opaque object
+            rc = rsa_import_privkey_crt(object->template);
+            break;
+        default:
+            TRACE_ERROR("%s\n", ock_err(ERR_KEY_TYPE_INCONSISTENT));
+            return CKR_KEY_TYPE_INCONSISTENT;
+        }
 
-		if (rc != CKR_OK) {
-			TRACE_DEVEL("rsa import failed\n");
-			return rc;
-		}
+        if (rc != CKR_OK) {
+            TRACE_DEVEL("rsa import failed\n");
+            return rc;
+        }
 
-		break;
-	case CKK_AES:
-	case CKK_DES:
-	case CKK_DES3:
-		rc = import_symmetric_key(object, keytype);
-		if (rc != CKR_OK) {
-			TRACE_DEVEL("Symmetric key import failed, rc=0x%lx\n",
-				     rc);
-			return rc;
-		}
-		TRACE_INFO("symmetric key with len=%ld successful imported\n",
-			    attr->ulValueLen);
-		break;
-	case CKK_GENERIC_SECRET:
-		rc = import_generic_secret_key(object);
-		if (rc != CKR_OK) {
-			TRACE_DEVEL("Generic Secret (HMAC) key import failed "
-				    " with rc=0x%lx\n", rc);
-			return rc;
-		}
-		TRACE_INFO("Generic Secret (HMAC) key with len=%ld successfully"
-			   " imported\n", attr->ulValueLen);
-		break;
+        break;
+    case CKK_AES:
+    case CKK_DES:
+    case CKK_DES3:
+        rc = import_symmetric_key(object, keytype);
+        if (rc != CKR_OK) {
+            TRACE_DEVEL("Symmetric key import failed, rc=0x%lx\n",
+                        rc);
+            return rc;
+        }
+        TRACE_INFO("symmetric key with len=%ld successful imported\n",
+                   attr->ulValueLen);
+        break;
+    case CKK_GENERIC_SECRET:
+        rc = import_generic_secret_key(object);
+        if (rc != CKR_OK) {
+            TRACE_DEVEL("Generic Secret (HMAC) key import failed "
+                        " with rc=0x%lx\n", rc);
+            return rc;
+        }
+        TRACE_INFO("Generic Secret (HMAC) key with len=%ld successfully"
+                   " imported\n", attr->ulValueLen);
+        break;
     case CKK_EC:
         rc = template_attribute_find(object->template, CKA_CLASS, &attr);
         if (rc == FALSE) {
@@ -4220,13 +4222,13 @@ CK_RV token_specific_object_add(STDLL_TokData_t *tokdata, SESSION *sess, OBJECT 
             return rc;
         }
         break;
-	default:
-		/* unknown/unsupported key type */
-		TRACE_ERROR("Unknown/unsupported key type 0x%lx\n", keytype);
-		return CKR_KEY_FUNCTION_NOT_PERMITTED;
-	}
+    default:
+        /* unknown/unsupported key type */
+        TRACE_ERROR("Unknown/unsupported key type 0x%lx\n", keytype);
+        return CKR_KEY_FUNCTION_NOT_PERMITTED;
+    }
 
-	return CKR_OK;
+    return CKR_OK;
 }
 
 CK_RV token_specific_generic_secret_key_gen(STDLL_TokData_t * tokdata,


### PR DESCRIPTION
Rework on RSA and EC keypair generate: Extract public cca token
part from private cca token and store only the public token
into CKA_IBM_OPAQUE attribute value of the public key object.

Signed-off-by: Harald Freudenberger <freude@linux.ibm.com>