### PR TITLE
Add more tests to be executed in ock_tests.sh

### DIFF
--- a/testcases/ock_tests.sh.in
+++ b/testcases/ock_tests.sh.in
@@ -48,6 +48,11 @@ NONEED_TOKEN_INIT=0
 # login/login MUST come last if it appears in this list
 #
 OCK_TESTS="crypto/*tests"
+OCK_TESTS+=" pkcs11/attribute pkcs11/copyobjects pkcs11/destroyobjects"
+OCK_TESTS+=" pkcs11/findobjects pkcs11/generate_keypair"
+OCK_TESTS+=" pkcs11/get_interface pkcs11/getobjectsize"
+OCK_TESTS+=" misc_tests/fork misc_tests/obj_mgmt_tests" 
+OCK_TESTS+=" misc_tests/obj_mgmt_lock_tests misc_tests/reencrypt"
 OCK_TEST=""
 OCK_BENCHS="pkcs11/*bench"
 


### PR DESCRIPTION
Add some of the tests in testcases/pkcs11/ and testcases/misc_tests/ to be executed in ock_tests.sh. This will execute these testcases also in Travis CI for the soft token, as well as other CIs that run 'make ci-installcheck' or 'make installcheck'.