### PR TITLE
CCA: Support import of CCA secure key token objects

### DIFF
--- a/testcases/common/common.c
+++ b/testcases/common/common.c
@@ -149,6 +149,9 @@ int create_AESKey(CK_SESSION_HANDLE session,
     };
 
     rc = funcs->C_CreateObject(session, keyTemplate, 5, h_key);
+    if (rc != CKR_OK) {
+        testcase_error("C_CreateObject rc=%s", p11_get_ckr(rc));
+    }
 
     return rc;
 }
@@ -167,6 +170,9 @@ int generate_AESKey(CK_SESSION_HANDLE session,
                                     key_gen_tmpl,
                                     1,
                                     h_key);
+    if (rc != CKR_OK) {
+	testcase_error("C_GenerateKey rc=%s", p11_get_ckr(rc));
+    }
 
     return rc;
 }

--- a/testcases/misc_tests/cca_export_import_test.c
+++ b/testcases/misc_tests/cca_export_import_test.c
@@ -1,0 +1,1451 @@
+/*
+ * import/export test for the CCA token
+ * by Harald Freudenberger <freude@de.ibm.com>
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <memory.h>
+#include <stdint.h>
+
+#include "pkcs11types.h"
+#include "ec_curves.h"
+
+#include "regress.h"
+#include "common.c"
+
+static CK_RV export_ibm_opaque(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE handle,
+			       CK_BYTE **buf, CK_ULONG *buflen)
+{
+    CK_RV rc;
+    CK_ULONG len;
+    CK_ATTRIBUTE a_opaque = { CKA_IBM_OPAQUE, NULL_PTR, 0 };
+
+    rc = funcs->C_GetAttributeValue(session, handle, &a_opaque, 1);
+    if (rc != CKR_OK) {
+	testcase_error("C_GetAttributeValue() rc=%s", p11_get_ckr(rc));
+	return rc;
+    }
+    len = a_opaque.ulValueLen;
+    if (!len) {
+	testcase_error("opaque attribute len is 0");
+	return CKR_ATTRIBUTE_VALUE_INVALID;
+    }
+    a_opaque.pValue = malloc(len);
+    if (!a_opaque.pValue) {
+	testcase_error("malloc(%lu) failed", len);
+	return CKR_HOST_MEMORY;
+    }
+    rc = funcs->C_GetAttributeValue(session, handle, &a_opaque, 1);
+    if (rc != CKR_OK) {
+	testcase_error("C_GetAttributeValue() rc=%s", p11_get_ckr(rc));
+	return rc;
+    }
+
+    *buf = a_opaque.pValue;
+    *buflen = len;
+
+    return CKR_OK;
+}
+
+static CK_RV import_cca_des_key(CK_SESSION_HANDLE session,
+				const char *label,
+				CK_BYTE *ccatoken, CK_ULONG tokenlen,
+				CK_OBJECT_HANDLE *handle)
+{
+    CK_RV rc;
+    CK_OBJECT_CLASS keyClass = CKO_SECRET_KEY;
+    CK_KEY_TYPE keyType = CKK_DES;
+    CK_BYTE value[8];
+    CK_BBOOL true = TRUE;
+    CK_BBOOL false = FALSE;
+    CK_ATTRIBUTE template[] = {
+	{CKA_CLASS, &keyClass, sizeof(keyClass)},
+	{CKA_KEY_TYPE, &keyType, sizeof(keyType)},
+	{CKA_LABEL, (char *) label, strlen(label) + 1},
+	{CKA_ENCRYPT, &true, sizeof(true)},
+	{CKA_TOKEN, &false, sizeof(false)},
+	{CKA_VALUE, value, sizeof(value)},
+	{CKA_IBM_OPAQUE, ccatoken, tokenlen}
+    };
+
+    memset(value, 0, sizeof(value));
+
+    rc = funcs->C_CreateObject(session, template, 7, handle);
+    if (rc != CKR_OK) {
+	testcase_error("C_CreateObject() rc=%s", p11_get_ckr(rc));
+    }
+
+    return rc;
+}
+
+static CK_RV import_cca_des3_key(CK_SESSION_HANDLE session,
+				 const char *label,
+				 CK_BYTE *ccatoken, CK_ULONG tokenlen,
+				 CK_OBJECT_HANDLE *handle)
+{
+    CK_RV rc;
+    CK_OBJECT_CLASS keyClass = CKO_SECRET_KEY;
+    CK_KEY_TYPE keyType = CKK_DES3;
+    CK_BYTE value[24];
+    CK_BBOOL true = TRUE;
+    CK_BBOOL false = FALSE;
+    CK_ATTRIBUTE template[] = {
+	{CKA_CLASS, &keyClass, sizeof(keyClass)},
+	{CKA_KEY_TYPE, &keyType, sizeof(keyType)},
+	{CKA_LABEL, (char *) label, strlen(label) + 1},
+	{CKA_ENCRYPT, &true, sizeof(true)},
+	{CKA_TOKEN, &false, sizeof(false)},
+	{CKA_VALUE, value, sizeof(value)},
+	{CKA_IBM_OPAQUE, ccatoken, tokenlen}
+    };
+
+    memset(value, 0, sizeof(value));
+
+    rc = funcs->C_CreateObject(session, template, 7, handle);
+    if (rc != CKR_OK) {
+	testcase_error("C_CreateObject() rc=%s", p11_get_ckr(rc));
+    }
+
+    return rc;
+}
+
+static CK_RV import_cca_aes_key(CK_SESSION_HANDLE session,
+				const char *label,
+				CK_BYTE *ccatoken, CK_ULONG tokenlen,
+				CK_OBJECT_HANDLE *handle)
+{
+    CK_RV rc;
+    CK_OBJECT_CLASS keyClass = CKO_SECRET_KEY;
+    CK_KEY_TYPE keyType = CKK_AES;
+    CK_BYTE value[32];
+    CK_BBOOL true = TRUE;
+    CK_BBOOL false = FALSE;
+    CK_ATTRIBUTE template[] = {
+	{CKA_CLASS, &keyClass, sizeof(keyClass)},
+	{CKA_KEY_TYPE, &keyType, sizeof(keyType)},
+	{CKA_LABEL, (char *) label, strlen(label) + 1},
+	{CKA_ENCRYPT, &true, sizeof(true)},
+	{CKA_TOKEN, &false, sizeof(false)},
+	{CKA_VALUE, value, sizeof(value)},
+	{CKA_IBM_OPAQUE, ccatoken, tokenlen}
+    };
+    unsigned keybitsize;
+
+    memset(value, 0, sizeof(value));
+
+    keybitsize = *((uint16_t *)(ccatoken + 56));
+    switch (keybitsize) {
+    case 128:
+	template[5].ulValueLen = 16;
+	break;
+    case 192:
+	template[5].ulValueLen = 24;
+	break;
+    case 256:
+	template[5].ulValueLen = 32;
+	break;
+    default:
+	testcase_error("invalid aes key bit size %u in ccatoken");
+	return CKR_ATTRIBUTE_VALUE_INVALID;
+    }
+
+    rc = funcs->C_CreateObject(session, template, 7, handle);
+    if (rc != CKR_OK) {
+	testcase_error("C_CreateObject() rc=%s", p11_get_ckr(rc));
+    }
+
+    return rc;
+}
+
+static CK_RV import_cca_aes_cipher_key(CK_SESSION_HANDLE session,
+				       const char *label,
+				       CK_BYTE *ccatoken, CK_ULONG tokenlen,
+				       unsigned int keybitsize,
+				       CK_OBJECT_HANDLE *handle)
+{
+    CK_RV rc;
+    CK_OBJECT_CLASS keyClass = CKO_SECRET_KEY;
+    CK_KEY_TYPE keyType = CKK_AES;
+    CK_BYTE value[32];
+    CK_BBOOL true = TRUE;
+    CK_BBOOL false = FALSE;
+    CK_ATTRIBUTE template[] = {
+	{CKA_CLASS, &keyClass, sizeof(keyClass)},
+	{CKA_KEY_TYPE, &keyType, sizeof(keyType)},
+	{CKA_LABEL, (char *) label, strlen(label) + 1},
+	{CKA_ENCRYPT, &true, sizeof(true)},
+	{CKA_TOKEN, &false, sizeof(false)},
+	{CKA_VALUE, value, sizeof(value)},
+	{CKA_IBM_OPAQUE, ccatoken, tokenlen}
+    };
+
+    memset(value, 0, sizeof(value));
+    template[5].ulValueLen = keybitsize / 8;
+
+    rc = funcs->C_CreateObject(session, template, 7, handle);
+    if (rc != CKR_OK) {
+	testcase_error("C_CreateObject() rc=%s", p11_get_ckr(rc));
+    }
+
+    return rc;
+}
+
+static CK_RV import_cca_gen_sec_key(CK_SESSION_HANDLE session,
+				    const char *label,
+				    CK_BYTE *ccatoken, CK_ULONG tokenlen,
+				    unsigned int keybitsize,
+				    CK_OBJECT_HANDLE *handle)
+{
+    CK_RV rc;
+    CK_OBJECT_CLASS keyClass = CKO_SECRET_KEY;
+    CK_KEY_TYPE keyType = CKK_GENERIC_SECRET;
+    CK_BYTE value[512];
+    CK_BBOOL true = TRUE;
+    CK_BBOOL false = FALSE;
+    CK_ATTRIBUTE template[] = {
+	{CKA_CLASS, &keyClass, sizeof(keyClass)},
+	{CKA_KEY_TYPE, &keyType, sizeof(keyType)},
+	{CKA_LABEL, (char *) label, strlen(label) + 1},
+	{CKA_SIGN, &true, sizeof(true)},
+	{CKA_VERIFY, &true, sizeof(true)},
+	{CKA_TOKEN, &false, sizeof(false)},
+	{CKA_VALUE, value, sizeof(value)},
+	{CKA_IBM_OPAQUE, ccatoken, tokenlen}
+    };
+    unsigned pl, calc_pl;
+
+    memset(value, 0, sizeof(value));
+
+    // cca only supports hmac key in range 80...2048
+    if (keybitsize < 80 || keybitsize > 2048) {
+	testcase_error("invalid keybitsize %u", keybitsize);
+	return CKR_ATTRIBUTE_VALUE_INVALID;
+    }
+
+    // calculate expected payloadbitsize based on keybitsize
+    calc_pl = (((keybitsize + 32) + 63) & (~63)) + 320;
+    // pull payloadbitsize from the cca hmac token
+    pl = *((uint16_t *)(ccatoken + 38));
+    if (calc_pl != pl) {
+	testcase_error("mismatch keybitsize %u - expected pl bitsize %u / cca pl bitsize %hu",
+		       keybitsize, calc_pl, pl);
+	return CKR_ATTRIBUTE_VALUE_INVALID;
+    }
+
+    template[6].ulValueLen = (keybitsize + 7) / 8;
+
+    rc = funcs->C_CreateObject(session, template, 7, handle);
+    if (rc != CKR_OK) {
+	testcase_error("C_CreateObject() rc=%s", p11_get_ckr(rc));
+    }
+
+    return rc;
+}
+
+static CK_RV import_rsa_priv_key(CK_SESSION_HANDLE session,
+				 const char *label,
+				 CK_BYTE *ccatoken, CK_ULONG tokenlen,
+				 CK_OBJECT_HANDLE *handle)
+{
+    CK_RV rc;
+    CK_OBJECT_CLASS keyClass = CKO_PRIVATE_KEY;
+    CK_KEY_TYPE keyType = CKK_RSA;
+    CK_BBOOL true = TRUE;
+    CK_BBOOL false = FALSE;
+    CK_ATTRIBUTE template[] = {
+	{CKA_CLASS, &keyClass, sizeof(keyClass)},
+	{CKA_KEY_TYPE, &keyType, sizeof(keyType)},
+	{CKA_LABEL, (char *) label, strlen(label) + 1},
+	{CKA_SIGN, &true, sizeof(true)},
+	{CKA_DECRYPT, &true, sizeof(true)},
+	{CKA_TOKEN, &false, sizeof(false)},
+	{CKA_IBM_OPAQUE, ccatoken, tokenlen}
+    };
+
+    rc = funcs->C_CreateObject(session, template, 7, handle);
+    if (rc != CKR_OK) {
+	testcase_error("C_CreateObject() rc=%s", p11_get_ckr(rc));
+    }
+
+    return rc;
+}
+
+static CK_RV import_rsa_publ_key(CK_SESSION_HANDLE session,
+				 const char *label,
+				 CK_BYTE *ccatoken, CK_ULONG tokenlen,
+				 CK_OBJECT_HANDLE *handle)
+{
+    CK_RV rc;
+    CK_OBJECT_CLASS keyClass = CKO_PUBLIC_KEY;
+    CK_KEY_TYPE keyType = CKK_RSA;
+    CK_BBOOL true = TRUE;
+    CK_BBOOL false = FALSE;
+    CK_ATTRIBUTE template[] = {
+	{CKA_CLASS, &keyClass, sizeof(keyClass)},
+	{CKA_KEY_TYPE, &keyType, sizeof(keyType)},
+	{CKA_LABEL, (char *) label, strlen(label) + 1},
+	{CKA_VERIFY, &true, sizeof(true)},
+	{CKA_ENCRYPT, &true, sizeof(true)},
+	{CKA_TOKEN, &false, sizeof(false)},
+	{CKA_IBM_OPAQUE, ccatoken, tokenlen}
+    };
+
+    rc = funcs->C_CreateObject(session, template, 7, handle);
+    if (rc != CKR_OK) {
+	testcase_error("C_CreateObject() rc=%s", p11_get_ckr(rc));
+    }
+
+    return rc;
+}
+
+static CK_RV import_ecc_priv_key(CK_SESSION_HANDLE session,
+				 const char *label,
+				 CK_BYTE *ccatoken, CK_ULONG tokenlen,
+				 CK_OBJECT_HANDLE *handle)
+{
+    CK_RV rc;
+    CK_OBJECT_CLASS keyClass = CKO_PRIVATE_KEY;
+    CK_KEY_TYPE keyType = CKK_EC;
+    CK_BBOOL true = TRUE;
+    CK_BBOOL false = FALSE;
+    CK_ATTRIBUTE template[] = {
+	{CKA_CLASS, &keyClass, sizeof(keyClass)},
+	{CKA_KEY_TYPE, &keyType, sizeof(keyType)},
+	{CKA_LABEL, (char *) label, strlen(label) + 1},
+	{CKA_SIGN, &true, sizeof(true)},
+	{CKA_TOKEN, &false, sizeof(false)},
+	{CKA_IBM_OPAQUE, ccatoken, tokenlen}
+    };
+
+    rc = funcs->C_CreateObject(session, template, 6, handle);
+    if (rc != CKR_OK) {
+	testcase_error("C_CreateObject() rc=%s", p11_get_ckr(rc));
+    }
+
+    return rc;
+}
+
+static CK_RV import_ecc_publ_key(CK_SESSION_HANDLE session,
+				 const char *label,
+				 CK_BYTE *ccatoken, CK_ULONG tokenlen,
+				 CK_OBJECT_HANDLE *handle)
+{
+    CK_RV rc;
+    CK_OBJECT_CLASS keyClass = CKO_PUBLIC_KEY;
+    CK_KEY_TYPE keyType = CKK_EC;
+    CK_BBOOL true = TRUE;
+    CK_BBOOL false = FALSE;
+    CK_ATTRIBUTE template[] = {
+	{CKA_CLASS, &keyClass, sizeof(keyClass)},
+	{CKA_KEY_TYPE, &keyType, sizeof(keyType)},
+	{CKA_LABEL, (char *) label, strlen(label) + 1},
+	{CKA_VERIFY, &true, sizeof(true)},
+	{CKA_TOKEN, &false, sizeof(false)},
+	{CKA_IBM_OPAQUE, ccatoken, tokenlen}
+    };
+
+    rc = funcs->C_CreateObject(session, template, 6, handle);
+    if (rc != CKR_OK) {
+	testcase_error("C_CreateObject() rc=%s", p11_get_ckr(rc));
+    }
+
+    return rc;
+}
+
+static CK_RV cca_des_data_export_import_tests(void)
+{
+    const char *tstr = "CCA export/import test with DES data key";
+    CK_RV rc = CKR_OK;
+    CK_FLAGS flags;
+    CK_SESSION_HANDLE session;
+    CK_BYTE user_pin[PKCS11_MAX_PIN_LEN];
+    CK_ULONG user_pin_len;
+    CK_BYTE key[] = { 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef };
+    CK_BYTE iv[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+    CK_MECHANISM mech = { CKM_DES_CBC, iv, sizeof(iv) };
+    CK_OBJECT_HANDLE hkey, hikey;
+    CK_BYTE data[80], encdata1[80], encdata2[80];
+    CK_ULONG ilen, len;
+    CK_BYTE *opaquekey = NULL;
+    CK_ULONG opaquekeylen;
+    char label[80];
+
+    testcase_begin("%s", tstr);
+
+    if (!is_cca_token(SLOT_ID)) {
+	testcase_skip("%s: this slot is not a CCA token", tstr);
+	goto out;
+    }
+
+    testcase_rw_session();
+    testcase_user_login();
+
+    // create ock des key
+
+    rc = create_DESKey(session, key, sizeof(key), &hkey);
+    if (rc != CKR_OK) {
+	testcase_error("create_DESKey() rc=%s", p11_get_ckr(rc));
+	goto testcase_cleanup;
+    }
+
+    // encrypt some data with this key
+
+    rc = funcs->C_EncryptInit(session, &mech, hkey);
+    if (rc != CKR_OK) {
+	testcase_error("C_EncryptInit rc=%s", p11_get_ckr(rc));
+	goto testcase_cleanup;
+    }
+    ilen = len = sizeof(data);
+    rc = funcs->C_Encrypt(session, data, ilen, encdata1, &len);
+    if (rc != CKR_OK) {
+	testcase_error("C_Encrypt rc=%s", p11_get_ckr(rc));
+	goto testcase_cleanup;
+    }
+    if (ilen != len) {
+	testcase_fail("plain and encrypted data len does not match");
+	goto testcase_cleanup;
+    }
+
+    testcase_new_assertion();
+
+    // export this key's cca token
+
+    rc = export_ibm_opaque(session, hkey, &opaquekey, &opaquekeylen);
+    if (rc != CKR_OK) {
+	testcase_fail("export_ibm_opaque rc=%s", p11_get_ckr(rc));
+	goto testcase_cleanup;
+    }
+
+    // re-import this cca token as a new key object
+
+    snprintf(label, sizeof(label), "re-imported_des_key");
+    rc = import_cca_des_key(session, label, opaquekey, opaquekeylen, &hikey);
+    if (rc != CKR_OK) {
+	testcase_fail("import_cca_des_key rc=%s", p11_get_ckr(rc));
+	goto testcase_cleanup;
+    }
+
+    // encrypt same data with this re-imported key
+
+    rc = funcs->C_EncryptInit(session, &mech, hikey);
+    if (rc != CKR_OK) {
+	testcase_error("C_EncryptInit rc=%s", p11_get_ckr(rc));
+	goto testcase_cleanup;
+    }
+    ilen = len = sizeof(data);
+    rc = funcs->C_Encrypt(session, data, ilen, encdata2, &len);
+    if (rc != CKR_OK) {
+	testcase_error("C_Encrypt rc=%s", p11_get_ckr(rc));
+	goto testcase_cleanup;
+    }
+    if (ilen != len) {
+	testcase_fail("plain and encrypted data len does not match");
+	goto testcase_cleanup;
+    }
+
+    // and check the encrypted data to be equal
+
+    if (memcmp(encdata1, encdata2, len) != 0) {
+	testcase_fail("encrypted data from original and exported/imported key is NOT the same");
+	goto testcase_cleanup;
+    }
+
+    testcase_pass("%s: ok", tstr);
+
+testcase_cleanup:
+    testcase_close_session();
+    free(opaquekey);
+out:
+    return rc;
+}
+
+static CK_RV cca_des3_data_export_import_tests(void)
+{
+    const char *tstr = "CCA export/import test with DES3 data key";
+    CK_RV rc = CKR_OK;
+    CK_FLAGS flags;
+    CK_SESSION_HANDLE session;
+    CK_BYTE user_pin[PKCS11_MAX_PIN_LEN];
+    CK_ULONG user_pin_len;
+    CK_BYTE key[] = { 0xe9, 0x7c, 0x83, 0x13, 0xba, 0x26, 0x5d, 0x43,
+		      0x25, 0x4c, 0xbf, 0x9e, 0x8f, 0x7c, 0x2a, 0xa8,
+		      0xa7, 0x54, 0xd6, 0x5e, 0x8a, 0xe9, 0x97, 0xe3 };
+    CK_BYTE iv[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+    CK_MECHANISM mech = { CKM_DES3_CBC, iv, sizeof(iv) };
+    CK_OBJECT_HANDLE hkey, hikey;
+    CK_BYTE data[80], encdata1[80], encdata2[80];
+    CK_ULONG ilen, len;
+    CK_BYTE *opaquekey = NULL;
+    CK_ULONG opaquekeylen;
+    char label[80];
+
+    testcase_begin("%s", tstr);
+
+    if (!is_cca_token(SLOT_ID)) {
+	testcase_skip("%s: this slot is not a CCA token", tstr);
+	goto out;
+    }
+
+    testcase_rw_session();
+    testcase_user_login();
+
+    // create ock 3des key
+
+    rc = create_DES3Key(session, key, sizeof(key), &hkey);
+    if (rc != CKR_OK) {
+	testcase_error("create_DES3Key() rc=%s", p11_get_ckr(rc));
+	goto testcase_cleanup;
+    }
+
+    // encrypt some data with this key
+
+    rc = funcs->C_EncryptInit(session, &mech, hkey);
+    if (rc != CKR_OK) {
+	testcase_error("C_EncryptInit rc=%s", p11_get_ckr(rc));
+	goto testcase_cleanup;
+    }
+    ilen = len = sizeof(data);
+    rc = funcs->C_Encrypt(session, data, ilen, encdata1, &len);
+    if (rc != CKR_OK) {
+	testcase_error("C_Encrypt rc=%s", p11_get_ckr(rc));
+	goto testcase_cleanup;
+    }
+    if (ilen != len) {
+	testcase_fail("plain and encrypted data len does not match");
+	goto testcase_cleanup;
+    }
+
+    testcase_new_assertion();
+
+    // export this key's cca token
+
+    rc = export_ibm_opaque(session, hkey, &opaquekey, &opaquekeylen);
+    if (rc != CKR_OK) {
+	testcase_fail("export_ibm_opaque rc=%s", p11_get_ckr(rc));
+	goto testcase_cleanup;
+    }
+
+    // re-import this cca token as a new key object
+
+    snprintf(label, sizeof(label), "re-imported_des3_key");
+    rc = import_cca_des3_key(session, label, opaquekey, opaquekeylen, &hikey);
+    if (rc != CKR_OK) {
+	testcase_fail("import_cca_des3_key rc=%s", p11_get_ckr(rc));
+	goto testcase_cleanup;
+    }
+
+    // encrypt same data with this re-imported key
+
+    rc = funcs->C_EncryptInit(session, &mech, hikey);
+    if (rc != CKR_OK) {
+	testcase_error("C_EncryptInit rc=%s", p11_get_ckr(rc));
+	goto testcase_cleanup;
+    }
+    ilen = len = sizeof(data);
+    rc = funcs->C_Encrypt(session, data, ilen, encdata2, &len);
+    if (rc != CKR_OK) {
+	testcase_error("C_Encrypt rc=%s", p11_get_ckr(rc));
+	goto testcase_cleanup;
+    }
+    if (ilen != len) {
+	testcase_fail("plain and encrypted data len does not match");
+	goto testcase_cleanup;
+    }
+
+    // and check the encrypted data to be equal
+
+    if (memcmp(encdata1, encdata2, len) != 0) {
+	testcase_fail("encrypted data from original and exported/imported key is NOT the same");
+	goto testcase_cleanup;
+    }
+
+    testcase_pass("%s: ok", tstr);
+
+testcase_cleanup:
+    testcase_close_session();
+    free(opaquekey);
+out:
+    return rc;
+}
+
+static CK_RV cca_aes_data_export_import_tests(void)
+{
+    CK_RV rc = CKR_OK;
+    CK_FLAGS flags;
+    CK_SESSION_HANDLE session;
+    CK_BYTE user_pin[PKCS11_MAX_PIN_LEN];
+    CK_ULONG user_pin_len;
+    CK_BYTE key[] = { 0x60, 0x3d, 0xeb, 0x10, 0x15, 0xca, 0x71, 0xbe,
+		      0x2b, 0x73, 0xae, 0xf0, 0x85, 0x7d, 0x77, 0x81,
+		      0x1f, 0x35, 0x2c, 0x07, 0x3b, 0x61, 0x08, 0xd7,
+		      0x2d, 0x98, 0x10, 0xa3, 0x09, 0x14, 0xdf, 0xf4 };
+    CK_BYTE iv[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+		     0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f };
+    CK_MECHANISM mech = { CKM_AES_CBC, iv, sizeof(iv) };
+    CK_OBJECT_HANDLE hkey, hikey;
+    CK_BYTE data[160], encdata1[160], encdata2[160];
+    CK_ULONG ilen, len;
+    CK_BYTE *opaquekey = NULL;
+    CK_ULONG opaquekeylen;
+    unsigned int keylen;
+    char label[80];
+
+    testcase_rw_session();
+    testcase_user_login();
+
+    for (keylen = 16; keylen <= 32; keylen += 8) {
+
+	testcase_begin("CCA export/import test with AES%d data key", 8 * keylen);
+
+	if (!is_cca_token(SLOT_ID)) {
+	    testcase_skip("this slot is not a CCA token");
+	    goto out;
+	}
+
+	// create ock aes key
+
+	rc = create_AESKey(session, key, keylen, &hkey);
+	if (rc != CKR_OK) {
+	    testcase_error("create_AESKey() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// encrypt some data with this key
+
+	rc = funcs->C_EncryptInit(session, &mech, hkey);
+	if (rc != CKR_OK) {
+	    testcase_error("C_EncryptInit rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+	ilen = len = sizeof(data);
+	rc = funcs->C_Encrypt(session, data, ilen, encdata1, &len);
+	if (rc != CKR_OK) {
+	    testcase_error("C_Encrypt rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+	if (ilen != len) {
+	    testcase_fail("plain and encrypted data len does not match");
+	    goto error;
+	}
+
+	testcase_new_assertion();
+
+	// export this key's cca token
+
+	rc = export_ibm_opaque(session, hkey, &opaquekey, &opaquekeylen);
+	if (rc != CKR_OK) {
+	    testcase_fail("export_ibm_opaque rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// re-import this cca token as a new key object
+
+	snprintf(label, sizeof(label), "re-imported_aes%u_key", 8 * keylen);
+	rc = import_cca_aes_key(session, label, opaquekey, opaquekeylen, &hikey);
+	if (rc != CKR_OK) {
+	    testcase_fail("import_cca_aes_key rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// encrypt same data with this re-imported key
+
+	rc = funcs->C_EncryptInit(session, &mech, hikey);
+	if (rc != CKR_OK) {
+	    testcase_error("C_EncryptInit rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+	ilen = len = sizeof(data);
+	rc = funcs->C_Encrypt(session, data, ilen, encdata2, &len);
+	if (rc != CKR_OK) {
+	    testcase_error("C_Encrypt rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+	if (ilen != len) {
+	    testcase_fail("plain and encrypted data len does not match");
+	    goto error;
+	}
+
+	// and check the encrypted data to be equal
+
+	if (memcmp(encdata1, encdata2, len) != 0) {
+	    testcase_fail("encrypted data from original and exported/imported key is NOT the same");
+	    goto error;
+	}
+
+	testcase_pass("CCA export/import test with AES%d data key: ok", 8 * keylen);
+
+error:
+	free(opaquekey);
+	opaquekey = NULL;
+    }
+
+testcase_cleanup:
+    testcase_close_session();
+out:
+    return rc;
+}
+
+static CK_RV cca_aes_cipher_import_tests(void)
+{
+    CK_RV rc = CKR_OK;
+    CK_FLAGS flags;
+    CK_SESSION_HANDLE session;
+    CK_BYTE user_pin[PKCS11_MAX_PIN_LEN];
+    CK_ULONG user_pin_len;
+    CK_BYTE key[1024] = { 0 };
+    CK_BYTE iv[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+		     0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f };
+    CK_MECHANISM mech = { CKM_AES_CBC, iv, sizeof(iv) };
+    CK_OBJECT_HANDLE hkey;;
+    CK_BYTE data[160], encdata[160];
+    CK_ULONG ilen, len, keylen;
+    unsigned int i, keybitlen[] = { 128, 192, 256, 0 };
+    char filename[256], label[80];
+    FILE *f;
+
+    testcase_rw_session();
+    testcase_user_login();
+
+    for (i = 0; keybitlen[i]; i++) {
+
+	testcase_begin("CCA import test with AES%d cipher key", keybitlen[i]);
+
+	if (!is_cca_token(SLOT_ID)) {
+	    testcase_skip("this slot is not a CCA token");
+	    goto out;
+	}
+
+	// Opencryptoki can't create CCA AES cipher keys.
+	// So let's read a raw CCA AES cipher key from the pkey sysfs api
+
+	sprintf(filename, "/sys/devices/virtual/misc/pkey/ccacipher/ccacipher_aes_%u", keybitlen[i]);
+	f = fopen(filename, "r");
+	if (!f) {
+	    testcase_error("Can't open file '%s'", filename);
+	    goto error;
+	}
+	keylen = fread(key, 1, sizeof(key), f);
+	if (ferror(f) || keylen < 1) {
+	    testcase_error("Can't read cipher key from file '%s'", filename);
+	    fclose(f);
+	    goto error;
+	}
+	fclose(f);
+
+	testcase_new_assertion();
+
+	// import this key into Opencryptoki as an AES key object :-)
+
+	snprintf(label, sizeof(label), "imported_aes%u_cipher_key", keybitlen[i]);
+	rc = import_cca_aes_cipher_key(session, label, key, keylen, keybitlen[i], &hkey);
+	if (rc != CKR_OK) {
+	    testcase_fail("import_cca_aes_cipher_key rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// encrypt same data with this key just to make sure it is working
+
+	rc = funcs->C_EncryptInit(session, &mech, hkey);
+	if (rc != CKR_OK) {
+	    testcase_error("C_EncryptInit rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+	ilen = len = sizeof(data);
+	rc = funcs->C_Encrypt(session, data, ilen, encdata, &len);
+	if (rc != CKR_OK) {
+	    testcase_error("C_Encrypt rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+	if (ilen != len) {
+	    testcase_fail("plain and encrypted data len does not match");
+	    goto error;
+	}
+
+	// that's it here
+
+	testcase_pass("CCA import test with AES%d cipher key: ok", keybitlen[i]);
+
+error:
+	;
+    }
+
+testcase_cleanup:
+    testcase_close_session();
+out:
+    return rc;
+}
+
+static CK_RV cca_hmac_data_export_import_tests(void)
+{
+    CK_RV rc = CKR_OK;
+    CK_FLAGS flags;
+    CK_SESSION_HANDLE session;
+    CK_BYTE user_pin[PKCS11_MAX_PIN_LEN];
+    CK_ULONG user_pin_len;
+    CK_BYTE key[512] = { 0x00 };
+    CK_OBJECT_HANDLE hkey, hikey;
+    CK_MECHANISM mech = { CKM_SHA_1_HMAC, 0, 0 };
+    CK_BYTE data[4096], mac1[4096], mac2[4096];
+    CK_BYTE *opaquekey = NULL;
+    CK_ULONG mac1len, mac2len, opaquekeylen;
+    unsigned int i, keybits[] = { 80, 160, 320, 640, 1024, 2048, 0 };
+    char label[80];
+
+    testcase_rw_session();
+    testcase_user_login();
+
+    for (i = 0; keybits[i]; i++) {
+
+	testcase_begin("CCA export/import test with generic secret key %u", keybits[i]);
+
+	if (!is_cca_token(SLOT_ID)) {
+	    testcase_skip("this slot is not a CCA token");
+	    goto out;
+	}
+
+	// create hmac key
+
+	rc = create_GenericSecretKey(session, key, keybits[i] / 8, &hkey);
+	if (rc != CKR_OK) {
+	    testcase_error("create_GenericSecretKey() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// sign data with original hmac key
+
+	rc = funcs->C_SignInit(session, &mech, hkey);
+	if (rc != CKR_OK) {
+	    testcase_error("C_SignInit rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+	mac1len = sizeof(mac1);
+	rc = funcs->C_Sign(session, data, sizeof(data), mac1, &mac1len);
+	if (rc != CKR_OK) {
+	    testcase_error("C_Sign rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+
+	testcase_new_assertion();
+
+	// export this key's cca token
+
+	rc = export_ibm_opaque(session, hkey, &opaquekey, &opaquekeylen);
+	if (rc != CKR_OK) {
+	    testcase_fail("export_ibm_opaque rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+
+#if 0
+	printf("cca hmac key token (%lu bytes):\n", opaquekeylen);
+	print_hex(opaquekey, opaquekeylen);
+#endif
+
+	// re-import this cca token as a new key object
+
+	snprintf(label, sizeof(label), "re-imported_hmac%u_key", keybits[i]);
+	rc = import_cca_gen_sec_key(session, label,
+				    opaquekey, opaquekeylen, keybits[i],
+				    &hikey);
+	if (rc != CKR_OK) {
+	    testcase_fail("import_cca_gen_sec_key rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// sign data with re-imported hmac key
+
+	rc = funcs->C_SignInit(session, &mech, hikey);
+	if (rc != CKR_OK) {
+	    testcase_error("C_SignInit with re-imported key failed, rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+	mac2len = sizeof(mac2);
+	rc = funcs->C_Sign(session, data, sizeof(data), mac2, &mac2len);
+	if (rc != CKR_OK) {
+	    testcase_error("C_Sign with re-imported key failed, rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// compare the two signatures
+
+	if (mac1len != mac2len) {
+	    testcase_fail("mac len with orig key %lu differs from mac len with re-imported key %lu",
+			  mac1len, mac2len);
+	    goto error;
+	}
+	if (memcmp(mac1, mac2, mac1len) != 0) {
+	    testcase_fail("signature with orig key differs from signature with re-imported key");
+	    goto error;
+	}
+
+	testcase_pass("CCA export/import test with generic secret key %u: ok", keybits[i]);
+
+error:
+	free(opaquekey);
+	opaquekey = NULL;
+    }
+
+testcase_cleanup:
+    testcase_close_session();
+out:
+    return rc;
+}
+
+static CK_RV cca_rsa_export_import_tests(void)
+{
+    CK_RV rc = CKR_OK;
+    CK_FLAGS flags;
+    CK_SESSION_HANDLE session;
+    CK_BYTE user_pin[PKCS11_MAX_PIN_LEN];
+    CK_ULONG user_pin_len;
+    CK_BYTE exp[] = { 0x01, 0x00, 0x01 };
+    CK_OBJECT_HANDLE publ_key, priv_key;
+    CK_OBJECT_HANDLE imp_priv_key, imp_publ_key;
+    CK_BYTE msg[512], sig[512];
+    CK_ULONG msglen, siglen;
+    CK_MECHANISM mech = {CKM_RSA_PKCS, 0, 0};
+    unsigned int keybitlen;
+    CK_BYTE *priv_opaquekey = NULL, *publ_opaquekey = NULL;
+    CK_ULONG priv_opaquekeylen, publ_opaquekeylen;
+    char label[80];
+
+    testcase_rw_session();
+    testcase_user_login();
+
+    for (keybitlen = 512; keybitlen <= 4096; keybitlen = 2 * keybitlen) {
+
+	testcase_begin("CCA export/import test with RSA %u key", keybitlen);
+
+	if (!is_cca_token(SLOT_ID)) {
+	    testcase_skip("this slot is not a CCA token");
+	    goto out;
+	}
+
+	// create ock rsa keypair
+
+	rc = generate_RSA_PKCS_KeyPair(session, keybitlen,
+				       exp, sizeof(exp),
+				       &publ_key, &priv_key);
+	if (rc != CKR_OK) {
+	    testcase_error("generate_RSA_PKCS_KeyPair() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+
+	testcase_new_assertion();
+
+	// sign with original private key
+
+	rc = funcs->C_SignInit(session, &mech, priv_key);
+	if (rc != CKR_OK) {
+	    testcase_error("C_SignInit() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+	msglen = (keybitlen / 8) / 2;
+	siglen = sizeof(sig);
+	rc = funcs->C_Sign(session, msg, msglen, sig, &siglen);
+	if (rc != CKR_OK) {
+	    testcase_error("C_Sign() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// verify with original public key
+
+	rc = funcs->C_VerifyInit(session, &mech, publ_key);
+	if (rc != CKR_OK) {
+	    testcase_error("C_VerifyInit() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+	rc = funcs->C_Verify(session, msg, msglen, sig, siglen);
+	if (rc == CKR_OK) {
+	    ;
+	} else if (rc == CKR_SIGNATURE_INVALID || rc == CKR_SIGNATURE_LEN_RANGE) {
+	    testcase_fail("signature verify failed");
+	    goto error;
+	} else {
+	    testcase_error("C_Verify() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// export original private key's cca token
+
+	rc = export_ibm_opaque(session, priv_key, &priv_opaquekey, &priv_opaquekeylen);
+	if (rc != CKR_OK) {
+	    testcase_fail("export_ibm_opaque on private key failed rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+#if 0
+	printf("priv_opaquekey (%lu bytes):\n", priv_opaquekeylen);
+	print_hex(priv_opaquekey, priv_opaquekeylen);
+#endif
+
+	// re-import this cca private rsa key token as new private rsa key
+
+	snprintf(label, sizeof(label), "re-imported_rsa%u_private_key", keybitlen);
+	rc = import_rsa_priv_key(session, label, priv_opaquekey, priv_opaquekeylen, &imp_priv_key);
+	if (rc != CKR_OK) {
+	    testcase_fail("import_rsa_priv_key on exported cca rsa key token failed rc=%s",
+			  p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// export original public key's cca token
+
+	rc = export_ibm_opaque(session, publ_key, &publ_opaquekey, &publ_opaquekeylen);
+	if (rc != CKR_OK) {
+	    testcase_fail("export_ibm_opaque on public key failed rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+#if 0
+	printf("publ_opaquekey (%lu bytes):\n", publ_opaquekeylen);
+	print_hex(publ_opaquekey, publ_opaquekeylen);
+#endif
+
+	// re-import this cca public rsa key token as new public rsa key
+
+	snprintf(label, sizeof(label), "re-imported_rsa%u_public_key", keybitlen);
+	rc = import_rsa_publ_key(session, label, publ_opaquekey, publ_opaquekeylen, &imp_publ_key);
+	if (rc != CKR_OK) {
+	    testcase_fail("import_rsa_publ_key on exported cca rsa key token failed rc=%s",
+			  p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// sign with re-imported private key
+
+	rc = funcs->C_SignInit(session, &mech, imp_priv_key);
+	if (rc != CKR_OK) {
+	    testcase_error("C_SignInit() with re-imported priv key failed, rc=%s",
+			   p11_get_ckr(rc));
+	    goto error;
+	}
+	siglen = sizeof(sig);
+	rc = funcs->C_Sign(session, msg, msglen, sig, &siglen);
+	if (rc != CKR_OK) {
+	    testcase_error("C_Sign() with re-imported priv key failed, rc=%s",
+			   p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// verify with original public key
+
+	rc = funcs->C_VerifyInit(session, &mech, publ_key);
+	if (rc != CKR_OK) {
+	    testcase_error("C_VerifyInit() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+	rc = funcs->C_Verify(session, msg, msglen, sig, siglen);
+	if (rc == CKR_OK) {
+	    ;
+	} else if (rc == CKR_SIGNATURE_INVALID || rc == CKR_SIGNATURE_LEN_RANGE) {
+	    testcase_fail("signature verify on signature generated with re-imported priv key failed, rc=%s",
+			  p11_get_ckr(rc));
+	    goto error;
+	} else {
+	    testcase_error("C_Verify() on signature generated with re-imported priv key failed, rc=%s",
+			   p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// sign with original private key
+
+	rc = funcs->C_SignInit(session, &mech, priv_key);
+	if (rc != CKR_OK) {
+	    testcase_error("C_SignInit() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+	msglen = (keybitlen / 8) / 2;
+	siglen = sizeof(sig);
+	rc = funcs->C_Sign(session, msg, msglen, sig, &siglen);
+	if (rc != CKR_OK) {
+	    testcase_error("C_Sign() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// verify with re-imported public key
+
+	rc = funcs->C_VerifyInit(session, &mech, imp_publ_key);
+	if (rc != CKR_OK) {
+	    testcase_error("C_VerifyInit() with re-imported pub key failed, rc=%s",
+			   p11_get_ckr(rc));
+	    goto error;
+	}
+	rc = funcs->C_Verify(session, msg, msglen, sig, siglen);
+	if (rc == CKR_OK) {
+	    ;
+	} else if (rc == CKR_SIGNATURE_INVALID || rc == CKR_SIGNATURE_LEN_RANGE) {
+	    testcase_fail("signature verify with re-imported pub key on signature failed");
+	    goto error;
+	} else {
+	    testcase_error("C_Verify() with re-imported pub key on signature failed, rc=%s",
+			   p11_get_ckr(rc));
+	    goto error;
+	}
+
+	testcase_pass("CCA export/import test with RSA %u key: ok", keybitlen);
+
+error:
+	free(priv_opaquekey);
+	priv_opaquekey = NULL;
+	free(publ_opaquekey);
+	publ_opaquekey = NULL;
+    }
+
+testcase_cleanup:
+    testcase_close_session();
+out:
+    return rc;
+}
+
+static CK_BYTE brainpoolP160r1[] = OCK_BRAINPOOL_P160R1;
+static CK_BYTE brainpoolP160t1[] = OCK_BRAINPOOL_P160T1;
+static CK_BYTE brainpoolP192r1[] = OCK_BRAINPOOL_P192R1;
+static CK_BYTE brainpoolP192t1[] = OCK_BRAINPOOL_P192T1;
+static CK_BYTE brainpoolP224r1[] = OCK_BRAINPOOL_P224R1;
+static CK_BYTE brainpoolP224t1[] = OCK_BRAINPOOL_P224T1;
+static CK_BYTE brainpoolP256r1[] = OCK_BRAINPOOL_P256R1;
+static CK_BYTE brainpoolP256t1[] = OCK_BRAINPOOL_P256T1;
+static CK_BYTE brainpoolP320r1[] = OCK_BRAINPOOL_P320R1;
+static CK_BYTE brainpoolP320t1[] = OCK_BRAINPOOL_P320T1;
+static CK_BYTE brainpoolP384r1[] = OCK_BRAINPOOL_P384R1;
+static CK_BYTE brainpoolP384t1[] = OCK_BRAINPOOL_P384T1;
+static CK_BYTE brainpoolP512r1[] = OCK_BRAINPOOL_P512R1;
+static CK_BYTE brainpoolP512t1[] = OCK_BRAINPOOL_P512T1;
+static CK_BYTE prime192v1[] = OCK_PRIME192V1;
+static CK_BYTE secp224r1[] = OCK_SECP224R1;
+static CK_BYTE prime256v1[] = OCK_PRIME256V1;
+static CK_BYTE secp384r1[] = OCK_SECP384R1;
+static CK_BYTE secp521r1[] = OCK_SECP521R1;
+static CK_BYTE secp256k1[] = OCK_SECP256K1;
+static CK_BYTE curve25519[] = OCK_CURVE25519;
+static CK_BYTE curve448[] = OCK_CURVE448;
+static CK_BYTE ed25519[] = OCK_ED25519;
+static CK_BYTE ed448[] = OCK_ED448;
+
+static struct {
+    CK_BYTE *curve;
+    CK_ULONG size;
+    const char *name;
+} ec_curves[] = {
+    {brainpoolP160r1, sizeof(brainpoolP160r1), "brainpoolP160r1"},
+    {brainpoolP160t1, sizeof(brainpoolP160t1), "brainpoolP160t1"},
+    {brainpoolP192r1, sizeof(brainpoolP192r1), "brainpoolP192r1"},
+    {brainpoolP192t1, sizeof(brainpoolP192t1), "brainpoolP192t1"},
+    {brainpoolP224r1, sizeof(brainpoolP224r1), "brainpoolP224r1"},
+    {brainpoolP224t1, sizeof(brainpoolP224t1), "brainpoolP224t1"},
+    {brainpoolP256r1, sizeof(brainpoolP256r1), "brainpoolP256r1"},
+    {brainpoolP256t1, sizeof(brainpoolP256t1), "brainpoolP256t1"},
+    {brainpoolP320r1, sizeof(brainpoolP320r1), "brainpoolP320r1"},
+    {brainpoolP320t1, sizeof(brainpoolP320t1), "brainpoolP320t1"},
+    {brainpoolP384r1, sizeof(brainpoolP384r1), "brainpoolP384r1"},
+    {brainpoolP384t1, sizeof(brainpoolP384t1), "brainpoolP384t1"},
+    {brainpoolP512r1, sizeof(brainpoolP512r1), "brainpoolP512r1"},
+    {brainpoolP512t1, sizeof(brainpoolP512t1), "brainpoolP512t1"},
+    {prime192v1, sizeof(prime192v1), "prime192v1"},
+    {secp224r1, sizeof(secp224r1), "secp224r1"},
+    {prime256v1, sizeof(prime256v1), "prime256v1"},
+    {secp384r1, sizeof(secp384r1), "secp384r1"},
+    {secp521r1, sizeof(secp521r1), "secp521r1"},
+    {secp256k1, sizeof(secp256k1), "secp256k1"},
+    {curve25519, sizeof(curve25519), "curve25519"},
+    {curve448, sizeof(curve448), "curve448"},
+    {ed25519, sizeof(ed25519), "ed25519"},
+    {ed448, sizeof(ed448), "ed448"},
+    {0, 0, 0}
+};
+
+static CK_RV cca_ecc_export_import_tests(void)
+{
+    CK_RV rc = CKR_OK;
+    CK_FLAGS flags;
+    CK_SESSION_HANDLE session;
+    CK_BYTE user_pin[PKCS11_MAX_PIN_LEN];
+    CK_ULONG user_pin_len;
+    CK_OBJECT_HANDLE publ_key, priv_key;
+    CK_OBJECT_HANDLE imp_priv_key, imp_publ_key;
+    CK_BYTE msg[32], sig[256];
+    CK_ULONG msglen, siglen;
+    CK_MECHANISM mech = { CKM_ECDSA, 0, 0};
+    CK_BYTE *priv_opaquekey = NULL, *publ_opaquekey = NULL;
+    CK_ULONG priv_opaquekeylen, publ_opaquekeylen;
+    char label[80];
+    int i;
+
+    testcase_rw_session();
+    testcase_user_login();
+
+    for (i = 0; ec_curves[i].curve; i++) {
+
+	testcase_begin("CCA export/import test with public/private ECC curve %s keys",
+		       ec_curves[i].name);
+
+	if (!is_cca_token(SLOT_ID)) {
+	    testcase_skip("this slot is not a CCA token");
+	    goto out;
+	}
+
+	// create ock ecc keypair
+
+	rc = generate_EC_KeyPair(session,
+				 ec_curves[i].curve, ec_curves[i].size,
+				 &publ_key, &priv_key);
+	if (rc == CKR_CURVE_NOT_SUPPORTED) {
+	    testcase_skip("ECC curve %s not supported yet by CCA token", ec_curves[i].name);
+	    goto error;
+	}
+	if (rc != CKR_OK) {
+	    testcase_error("generate_EC_KeyPair() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+
+	testcase_new_assertion();
+
+	// sign with original private key
+
+	rc = funcs->C_SignInit(session, &mech, priv_key);
+	if (rc != CKR_OK) {
+	    testcase_error("C_SignInit() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+	msglen = sizeof(msg);
+	siglen = sizeof(sig);
+	rc = funcs->C_Sign(session, msg, msglen, sig, &siglen);
+	if (rc != CKR_OK) {
+	    testcase_error("C_Sign() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// verify with original public key
+
+	rc = funcs->C_VerifyInit(session, &mech, publ_key);
+	if (rc != CKR_OK) {
+	    testcase_error("C_VerifyInit() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+	rc = funcs->C_Verify(session, msg, msglen, sig, siglen);
+	if (rc == CKR_OK) {
+	    ;
+	} else if (rc == CKR_SIGNATURE_INVALID || rc == CKR_SIGNATURE_LEN_RANGE) {
+	    testcase_fail("signature verify failed");
+	    goto error;
+	} else {
+	    testcase_error("C_Verify() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// export original private key's cca token
+
+	rc = export_ibm_opaque(session, priv_key, &priv_opaquekey, &priv_opaquekeylen);
+	if (rc != CKR_OK) {
+	    testcase_fail("export_ibm_opaque on private key failed rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+#if 0
+	printf("priv_opaquekey (%lu bytes):\n", priv_opaquekeylen);
+	print_hex(priv_opaquekey, priv_opaquekeylen);
+#endif
+
+	// re-import this cca private ecc key token as new private ecc key
+
+	snprintf(label, sizeof(label), "re-imported_ecc_%s_private_key", ec_curves[i].name);
+	rc = import_ecc_priv_key(session, label, priv_opaquekey, priv_opaquekeylen, &imp_priv_key);
+	if (rc != CKR_OK) {
+	    testcase_fail("import_ecc_priv_key on exported cca ecc key token failed rc=%s",
+			  p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// export original public key's cca token
+
+	rc = export_ibm_opaque(session, publ_key, &publ_opaquekey, &publ_opaquekeylen);
+	if (rc != CKR_OK) {
+	    testcase_fail("export_ibm_opaque on public key failed rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+#if 0
+	printf("publ_opaquekey (%lu bytes):\n", publ_opaquekeylen);
+	print_hex(publ_opaquekey, publ_opaquekeylen);
+#endif
+
+	// re-import this cca public ecc key token as new public ecc key
+
+	snprintf(label, sizeof(label), "re-imported_ecc_%s_public_key", ec_curves[i].name);
+	rc = import_ecc_publ_key(session, label, publ_opaquekey, publ_opaquekeylen, &imp_publ_key);
+	if (rc != CKR_OK) {
+	    testcase_fail("import_ecc_publ_key on exported cca ecc key token failed rc=%s",
+			  p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// sign with re-imported private key
+
+	rc = funcs->C_SignInit(session, &mech, imp_priv_key);
+	if (rc != CKR_OK) {
+	    testcase_error("C_SignInit() with re-imported priv key failed, rc=%s",
+			   p11_get_ckr(rc));
+	    goto error;
+	}
+	msglen = sizeof(msg);
+	siglen = sizeof(sig);
+	rc = funcs->C_Sign(session, msg, msglen, sig, &siglen);
+	if (rc != CKR_OK) {
+	    testcase_error("C_Sign() with re-imported priv key failed, rc=%s",
+			   p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// verify with original public key
+
+	rc = funcs->C_VerifyInit(session, &mech, publ_key);
+	if (rc != CKR_OK) {
+	    testcase_error("C_VerifyInit() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+	rc = funcs->C_Verify(session, msg, msglen, sig, siglen);
+	if (rc == CKR_OK) {
+	    ;
+	} else if (rc == CKR_SIGNATURE_INVALID || rc == CKR_SIGNATURE_LEN_RANGE) {
+	    testcase_fail("signature verify on signature generated with re-imported priv key failed, rc=%s",
+			  p11_get_ckr(rc));
+	    goto error;
+	} else {
+	    testcase_error("C_Verify() on signature generated with re-imported priv key failed, rc=%s",
+			   p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// sign with original private key
+
+	rc = funcs->C_SignInit(session, &mech, priv_key);
+	if (rc != CKR_OK) {
+	    testcase_error("C_SignInit() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+	msglen = sizeof(msg);
+	siglen = sizeof(sig);
+	rc = funcs->C_Sign(session, msg, msglen, sig, &siglen);
+	if (rc != CKR_OK) {
+	    testcase_error("C_Sign() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// verify with re-imported public key
+
+	rc = funcs->C_VerifyInit(session, &mech, imp_publ_key);
+	if (rc != CKR_OK) {
+	    testcase_error("C_VerifyInit() with re-imported pub key failed, rc=%s",
+			   p11_get_ckr(rc));
+	    goto error;
+	}
+	rc = funcs->C_Verify(session, msg, msglen, sig, siglen);
+	if (rc == CKR_OK) {
+	    ;
+	} else if (rc == CKR_SIGNATURE_INVALID || rc == CKR_SIGNATURE_LEN_RANGE) {
+	    testcase_fail("signature verify with re-imported pub key on signature failed");
+	    goto error;
+	} else {
+	    testcase_error("C_Verify() with re-imported pub key on signature failed, rc=%s",
+			   p11_get_ckr(rc));
+	    goto error;
+	}
+
+	testcase_pass("CCA export/import test with public/private ECC curve %s keys: ok",
+		      ec_curves[i].name);
+
+error:
+	free(priv_opaquekey);
+	priv_opaquekey = NULL;
+	free(publ_opaquekey);
+	publ_opaquekey = NULL;
+    }
+
+testcase_cleanup:
+    testcase_close_session();
+out:
+    return rc;
+}
+
+static CK_RV cca_export_import_tests(void)
+{
+    CK_RV rc = CKR_OK, rv = CKR_OK;
+
+    testsuite_begin("CCA export/import tests");
+
+    rc = cca_des_data_export_import_tests();
+    if (rc != CKR_OK && rv == CKR_OK)
+	rv = rc;
+
+    rc = cca_des3_data_export_import_tests();
+    if (rc != CKR_OK && rv == CKR_OK)
+	rv = rc;
+
+    rc = cca_aes_data_export_import_tests();
+    if (rc != CKR_OK && rv == CKR_OK)
+	rv = rc;
+
+    rc = cca_hmac_data_export_import_tests();
+    if (rc != CKR_OK && rv == CKR_OK)
+	rv = rc;
+
+    rc = cca_rsa_export_import_tests();
+    if (rc != CKR_OK && rv == CKR_OK)
+	rv = rc;
+
+    rc = cca_ecc_export_import_tests();
+    if (rc != CKR_OK && rv == CKR_OK)
+	rv = rc;
+
+    rc = cca_aes_cipher_import_tests();
+    if (rc != CKR_OK && rv == CKR_OK)
+	rv = rc;
+
+    return rv;
+}
+
+int main(int argc, char **argv)
+{
+    CK_C_INITIALIZE_ARGS cinit_args;
+    int rc;
+    CK_RV rv;
+
+    rc = do_ParseArgs(argc, argv);
+    if (rc != 1)
+	return rc;
+
+    printf("Using slot #%lu...\n", SLOT_ID);
+
+    rc = do_GetFunctionList();
+    if (!rc) {
+	testcase_error("do_getFunctionList(), rc=%s", p11_get_ckr(rc));
+	return rc;
+    }
+
+    memset(&cinit_args, 0x0, sizeof(cinit_args));
+    cinit_args.flags = CKF_OS_LOCKING_OK;
+
+    // SAB Add calls to ALL functions before the C_Initialize gets hit
+
+    funcs->C_Initialize(&cinit_args);
+
+    {
+	CK_SESSION_HANDLE hsess = 0;
+
+	rc = funcs->C_GetFunctionStatus(hsess);
+	if (rc != CKR_FUNCTION_NOT_PARALLEL)
+	    return rc;
+
+	rc = funcs->C_CancelFunction(hsess);
+	if (rc != CKR_FUNCTION_NOT_PARALLEL)
+	    return rc;
+
+    }
+
+    testcase_setup(0);
+    rv = cca_export_import_tests();
+    testcase_print_result();
+
+    funcs->C_Finalize(NULL);
+
+    /* make sure we return non-zero if rv is non-zero */
+    return ((rv == 0) || (rv % 256) ? (int)rv : -1);
+}

--- a/testcases/misc_tests/misc_tests.mk
+++ b/testcases/misc_tests/misc_tests.mk
@@ -6,7 +6,8 @@ noinst_PROGRAMS +=							\
 	testcases/misc_tests/tok_des					\
 	testcases/misc_tests/fork testcases/misc_tests/multi_instance   \
 	testcases/misc_tests/obj_lock testcases/misc_tests/tok2tok_transport \
-	testcases/misc_tests/obj_lock testcases/misc_tests/reencrypt
+	testcases/misc_tests/obj_lock testcases/misc_tests/reencrypt    \
+	testcases/misc_tests/cca_export_import_test
 
 testcases_misc_tests_obj_mgmt_tests_CFLAGS = ${testcases_inc}
 testcases_misc_tests_obj_mgmt_tests_LDADD =				\
@@ -61,8 +62,14 @@ testcases_misc_tests_tok2tok_transport_CFLAGS = ${testcases_inc}
 testcases_misc_tests_tok2tok_transport_LDADD = testcases/common/libcommon.la
 testcases_misc_tests_tok2tok_transport_SOURCES = 			\
 	testcases/misc_tests/tok2tok_transport.c
-	
+
 testcases_misc_tests_reencrypt_CFLAGS = ${testcases_inc}
 testcases_misc_tests_reencrypt_LDADD = testcases/common/libcommon.la
 testcases_misc_tests_reencrypt_SOURCES = 			\
 	testcases/misc_tests/reencrypt.c
+
+testcases_misc_tests_cca_export_import_test_CFLAGS = ${testcases_inc}
+testcases_misc_tests_cca_export_import_test_LDADD =			\
+	testcases/common/libcommon.la
+testcases_misc_tests_cca_export_import_test_SOURCES =			\
+	testcases/misc_tests/cca_export_import_test.c

--- a/usr/lib/cca_stdll/cca_specific.c
+++ b/usr/lib/cca_stdll/cca_specific.c
@@ -26,6 +26,7 @@
 #include <limits.h>
 #include <syslog.h>
 #include <dlfcn.h>
+#include <ctype.h>
 #include <arpa/inet.h>
 #include "cca_stdll.h"
 #include "pkcs11types.h"
@@ -239,6 +240,300 @@ static const CK_ULONG cca_mech_list_len =
                         (sizeof(cca_mech_list) / sizeof(MECH_LIST_ELEMENT));
 
 
+#ifdef DEBUG
+/* Debug function: hexdump buffer with TRACE_DEBUG */
+static void dump_mem(const char *prestr, void *buf, unsigned len)
+{
+    int i;
+    unsigned char b;
+    char line[70];
+    unsigned char *p = (unsigned char *) buf;
+
+    while (len) {
+        memset(line, ' ', sizeof(line));
+        for (i=0; i < 16; i++) {
+            if (len) {
+                b = *p >> 4;
+                line[3*i+2] = b < 10 ? '0' + b : 'a' - 10 + b;
+                b = *p & 0x0F;
+                line[3*i+3] = b < 10 ? '0' + b : 'a' - 10 + b;
+                line[3*i+4] = ' ';
+                line[51+i] = isalnum(*p) ? *p : '.';
+                p++; len--;
+            }
+        }
+        line[67] = '\0';
+        TRACE_DEBUG("%s%s\n", prestr, line);
+    }
+}
+
+/* Debug function: dump one attribute via TRACE_DEBUG */
+static void dump_attr(CK_ATTRIBUTE *a)
+{
+    char tbuf[128];
+    const char *typestr = NULL;
+
+    switch (a->type) {
+    case CKA_CLASS: typestr = "CKA_CLASS"; break;
+    case CKA_TOKEN: typestr = "CKA_TOKEN"; break;
+    case CKA_PRIVATE: typestr = "CKA_PRIVATE"; break;
+    case CKA_LABEL: typestr = "CKA_LABEL"; break;
+    case CKA_UNIQUE_ID: typestr = "CKA_UNIQUE_ID"; break;
+    case CKA_VALUE: typestr = "CKA_VALUE"; break;
+    case CKA_OBJECT_ID: typestr = "CKA_OBJECT_ID"; break;
+    case CKA_CERTIFICATE_TYPE: typestr = "CKA_CERTIFICATE_TYPE"; break;
+    case CKA_ISSUER: typestr = "CKA_ISSUER"; break;
+    case CKA_SERIAL_NUMBER: typestr = "CKA_SERIAL_NUMBER"; break;
+    case CKA_ATTR_TYPES: typestr = "CKA_ATTR_TYPES"; break;
+    case CKA_TRUSTED: typestr = "CKA_TRUSTED"; break;
+    case CKA_KEY_TYPE: typestr = "CKA_KEY_TYPE"; break;
+    case CKA_SUBJECT: typestr = "CKA_SUBJECT"; break;
+    case CKA_ID: typestr = "CKA_ID"; break;
+    case CKA_SENSITIVE: typestr = "CKA_SENSITIVE"; break;
+    case CKA_ENCRYPT: typestr = "CKA_ENCRYPT"; break;
+    case CKA_DECRYPT: typestr = "CKA_DECRYPT"; break;
+    case CKA_WRAP: typestr = "CKA_WRAP"; break;
+    case CKA_UNWRAP: typestr = "CKA_UNWRAP"; break;
+    case CKA_SIGN: typestr = "CKA_SIGN"; break;
+    case CKA_SIGN_RECOVER: typestr = "CKA_SIGN_RECOVER"; break;
+    case CKA_VERIFY: typestr = "CKA_VERIFY"; break;
+    case CKA_VERIFY_RECOVER: typestr = "CKA_VERIFY_RECOVER"; break;
+    case CKA_DERIVE: typestr = "CKA_DERIVE"; break;
+    case CKA_START_DATE: typestr = "CKA_START_DATE"; break;
+    case CKA_END_DATE: typestr = "CKA_END_DATE"; break;
+    case CKA_MODULUS: typestr = "CKA_MODULUS"; break;
+    case CKA_MODULUS_BITS: typestr = "CKA_MODULUS_BITS"; break;
+    case CKA_PUBLIC_EXPONENT: typestr = "CKA_PUBLIC_EXPONENT"; break;
+    case CKA_PRIVATE_EXPONENT: typestr = "CKA_PRIVATE_EXPONENT"; break;
+    case CKA_PRIME_1: typestr = "CKA_PRIME_1"; break;
+    case CKA_PRIME_2: typestr = "CKA_PRIME_2"; break;
+    case CKA_EXPONENT_1: typestr = "CKA_EXPONENT_1"; break;
+    case CKA_EXPONENT_2: typestr = "CKA_EXPONENT_2"; break;
+    case CKA_COEFFICIENT: typestr = "CKA_COEFFICIENT"; break;
+    case CKA_PRIME: typestr = "CKA_PRIME"; break;
+    case CKA_SUBPRIME: typestr = "CKA_SUBPRIME"; break;
+    case CKA_BASE: typestr = "CKA_BASE"; break;
+    case CKA_PRIME_BITS: typestr = "CKA_PRIME_BITS"; break;
+    case CKA_SUBPRIME_BITS: typestr = "CKA_SUBPRIME_BITS"; break;
+    case CKA_VALUE_BITS: typestr = "CKA_VALUE_BITS"; break;
+    case CKA_VALUE_LEN: typestr = "CKA_VALUE_LEN"; break;
+    case CKA_EXTRACTABLE: typestr = "CKA_EXTRACTABLE"; break;
+    case CKA_LOCAL: typestr = "CKA_LOCAL"; break;
+    case CKA_NEVER_EXTRACTABLE: typestr = "CKA_NEVER_EXTRACTABLE"; break;
+    case CKA_ALWAYS_SENSITIVE: typestr = "CKA_ALWAYS_SENSITIVE"; break;
+    case CKA_KEY_GEN_MECHANISM: typestr = "CKA_KEY_GEN_MECHANISM"; break;
+    case CKA_MODIFIABLE: typestr = "CKA_MODIFIABLE"; break;
+    case CKA_EC_PARAMS: typestr = "CKA_EC_PARAMS"; break;
+    case CKA_EC_POINT: typestr = "CKA_EC_POINT"; break;
+    case CKA_ALWAYS_AUTHENTICATE: typestr = "CKA_ALWAYS_AUTHENTICATE"; break;
+    case CKA_IBM_OPAQUE: typestr = "CKA_IBM_OPAQUE"; break;
+    default:
+        sprintf(tbuf, "unknown type 0x%08lx", a->type);
+        typestr = tbuf;
+        break;
+    }
+
+    switch (a->ulValueLen) {
+    case 0:
+        TRACE_DEBUG("  %s: len=0 pValue=%p\n", typestr, a->pValue);
+        break;
+    case 1:
+        TRACE_DEBUG("  %s: len=%lu value=0x%02hhx\n",
+                    typestr, a->ulValueLen, *((uint8_t *)(a->pValue)));
+        break;
+    case 2:
+        TRACE_DEBUG("  %s: len=%lu value=0x%04hx\n",
+                    typestr, a->ulValueLen, *((uint16_t *)(a->pValue)));
+        break;
+    case 4:
+        TRACE_DEBUG("  %s: len=%lu value=0x%08x\n",
+                    typestr, a->ulValueLen, *((uint32_t *)(a->pValue)));
+        break;
+    case 8:
+        TRACE_DEBUG("  %s: len=%lu value=0x%016lx\n",
+                    typestr, a->ulValueLen, *((uint64_t *)(a->pValue)));
+        break;
+    default:
+        TRACE_DEBUG("  %s: len=%lu value:\n", typestr, a->ulValueLen);
+        dump_mem("  ", a->pValue, a->ulValueLen);
+        break;
+    }
+}
+
+/* Debug function: dump list of attribues from a template via TRACE_DEBUG */
+static void dump_template(TEMPLATE *tmpl)
+{
+    DL_NODE *node = NULL;
+    CK_ATTRIBUTE *a = NULL;
+
+    node = tmpl->attribute_list;
+    while (node) {
+        a = (CK_ATTRIBUTE *) node->data;
+        dump_attr(a);
+        node = node->next;
+    }
+}
+#endif
+
+/* cca token type enum, used with analyse_cca_key_token() */
+enum cca_token_type {
+    sec_des_data_key,
+    sec_aes_data_key,
+    sec_aes_cipher_key,
+    sec_hmac_key,
+    sec_rsa_priv_key,
+    sec_rsa_publ_key,
+    sec_ecc_priv_key,
+    sec_ecc_publ_key
+};
+
+/*
+ * Helper function: Analyse given CCA token.
+ * returns TRUE and keytype and keybitsize if token is known and seems
+ * to be valid (only basic checks are done), otherwise FALSE.
+ */
+static CK_BBOOL analyse_cca_key_token(const CK_BYTE *t, CK_ULONG tlen,
+                                      enum cca_token_type *keytype,
+                                      unsigned int *keybitsize)
+{
+    if (t[0] == 0x01 && (t[4] == 0x00 || t[4] == 0x01)) {
+        /* internal secure cca des data key with exact 64 bytes */
+        if (tlen != 64) {
+            TRACE_DEVEL("CCA DES token has invalid token size %lu != 64\n", tlen);
+            return FALSE;
+        }
+        *keytype = sec_des_data_key;
+        if (t[4] == 0x00)
+            *keybitsize = 8 * 8;
+        else if (t[59] == 0x10)
+            *keybitsize = 16 * 8;
+        else if (t[59] == 0x20)
+            *keybitsize = 24 * 8;
+        else {
+            TRACE_DEVEL("CCA DES data key token has invalid/unknown keysize 0x%02x\n", (int)t[59]);
+            return FALSE;
+        }
+        return TRUE;
+    }
+
+    if (t[0] == 0x01 && t[4] == 0x04) {
+        /* internal secure cca aes data key with exact 64 bytes */
+        if (tlen != 64) {
+            TRACE_DEVEL("CCA AES data key token has invalid token size %lu != 64\n", tlen);
+            return FALSE;
+        }
+        *keytype = sec_aes_data_key;
+        *keybitsize = *((uint16_t *)(t + 56));
+        if (*keybitsize != 128 && *keybitsize != 192 && *keybitsize != 256) {
+            TRACE_DEVEL("CCA AES data key token has invalid/unknown keybitsize %u\n", *keybitsize);
+            return FALSE;
+        }
+        return TRUE;
+    }
+
+    if (t[0] == 0x01 && t[4] == 0x05 && t[41] == 0x02) {
+        /* internal variable length secure cca aes cipher key */
+        uint16_t key_type = *((uint16_t*)(t + 42));
+        if (key_type != 0x0001) {
+            TRACE_DEVEL("CCA AES cipher key token has invalid/unknown keytype 0x%04hx\n", key_type);
+            return FALSE;
+        }
+        *keytype = sec_aes_cipher_key;
+        *keybitsize = 0; /* no chance to find out the key bit size */
+        return TRUE;
+    }
+
+    if (t[0] == 0x01 && t[4] == 0x05 && t[41] == 0x03) {
+        /* internal variable length HMAC key */
+        uint16_t key_type = *((uint16_t*)(t + 42));
+        if (key_type != 0x0002) {
+            TRACE_DEVEL("CCA HMAC key token has invalid/unknown keytype 0x%04hx\n", key_type);
+            return FALSE;
+        }
+        if (t[8] != 0x03) {
+            TRACE_DEVEL("CCA HMAC key token has unsupported format t[8]=%hhu != 0x03\n", t[8]);
+            return FALSE;
+        }
+        if (t[26] != 0x02) {
+            TRACE_DEVEL("CCA HMAC key token has unsupported format t[26]=%hhu != 0x02\n", t[26]);
+            return FALSE;
+        }
+        if (t[27] != 0x02) {
+            TRACE_DEVEL("CCA HMAC key token has unsupported format t[27]=%hhu != 0x02\n", t[26]);
+            return FALSE;
+        }
+        if (t[28] != 0x00) {
+            TRACE_DEVEL("CCA HMAC key token has unsupported format t[28]=%hhu != 0x00\n", t[26]);
+            return FALSE;
+        }
+        *keytype = sec_hmac_key;
+        *keybitsize = *((uint16_t *)(t + CCA_HMAC_INTTOK_PAYLOAD_LENGTH_OFFSET));
+        /* this is not really the bitsize but the bitsize of the payload */
+        if (*keybitsize < 80 || *keybitsize > 2432) {
+            TRACE_DEVEL("CCA HMAC key token has invalid/unknown payload bit size %u\n", *keybitsize);
+            return FALSE;
+        }
+        return TRUE;
+    }
+
+    if (t[0] == 0x1f &&
+        (t[CCA_RSA_INTTOK_PRIVKEY_OFFSET] == 0x30 ||
+         t[CCA_RSA_INTTOK_PRIVKEY_OFFSET] == 0x31)) {
+        /* internal secure cca private rsa key, ME or CRT format */
+        uint16_t n, privsec_len;
+        privsec_len = *((uint16_t *)(t + CCA_RSA_INTTOK_PRIVKEY_OFFSET + 2));
+        if (CCA_RSA_INTTOK_PRIVKEY_OFFSET + privsec_len >= (int) tlen) {
+            TRACE_DEVEL("CCA RSA key token has invalid priv section len or token size\n");
+            return FALSE;
+        }
+        if (t[CCA_RSA_INTTOK_PRIVKEY_OFFSET + privsec_len] != 0x04) {
+            TRACE_DEVEL("CCA RSA key token has invalid pub section marker\n");
+            return FALSE;
+        }
+        n = *((uint16_t *)(t + CCA_RSA_INTTOK_PRIVKEY_OFFSET + privsec_len + 8));
+        *keytype = sec_rsa_priv_key;
+        *keybitsize = n;
+        return TRUE;
+    }
+
+    if (t[0] == 0x1e && t[CCA_RSA_INTTOK_HDR_LENGTH] == 0x04) {
+        /* external RSA public key token */
+        uint16_t n;
+        n = *((uint16_t *)(t + CCA_RSA_INTTOK_HDR_LENGTH + 8));
+        *keytype = sec_rsa_publ_key;
+        *keybitsize = n;
+        return TRUE;
+    }
+
+    if (t[0] == 0x1f && t[8] == 0x20) {
+        /* internal secure cca private ecc key */
+        uint16_t ec_curve_bits;
+        if (t[8+4] != 0x01) {
+            TRACE_DEVEL("CCA private ECC key token has invalid wrapping method 0x%02hhx\n", t[8+4]);
+            return FALSE;
+        }
+        if (t[8+10] != 0x08) {
+            TRACE_DEVEL("CCA private ECC key token has invalid key format 0x%02hhx\n", t[8+10]);
+            return FALSE;
+        }
+        ec_curve_bits = *((uint16_t *)(t + 8 + 12));
+        *keytype = sec_ecc_priv_key;
+        *keybitsize = ec_curve_bits;
+        return TRUE;
+    }
+
+    if (t[0] == 0x1e && t[8] == 0x21) {
+        /* external ECC public key token */
+        uint16_t ec_curve_bits;
+        ec_curve_bits = *((uint16_t *)(t + 8 + 10));
+        *keytype = sec_ecc_publ_key;
+        *keybitsize = ec_curve_bits;
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
 /* Helper function: build attribute and update template */
 static CK_RV build_update_attribute(TEMPLATE * tmpl,
                                     CK_ATTRIBUTE_TYPE type,
@@ -252,7 +547,7 @@ static CK_RV build_update_attribute(TEMPLATE * tmpl,
         return rv;
     }
     if ((rv = template_update_attribute(tmpl, attr))) {
-	TRACE_DEVEL("Template update for type=%lu failed, rv=0x%lx\n", type, rv);
+        TRACE_DEVEL("Template update for type=%lu failed, rv=0x%lx\n", type, rv);
         return rv;
     }
 
@@ -711,52 +1006,122 @@ CK_RV token_specific_tdes_cbc(STDLL_TokData_t * tokdata,
                                   out_data_len, key, init_v, encrypt);
 }
 
-uint16_t cca_inttok_privkey_get_len(CK_BYTE * tok)
+static uint16_t cca_rsa_inttok_privkey_get_len(CK_BYTE * tok)
 {
     return *(uint16_t *) & tok[CCA_RSA_INTTOK_PRIVKEY_LENGTH_OFFSET];
 }
 
-/* Given a CCA internal token private key object, get the modulus */
-CK_RV cca_inttok_privkey_get_n(CK_BYTE * tok, CK_ULONG * n_len, CK_BYTE * n)
+/* Extract modulus n from a priv key section within an CCA internal RSA private key token */
+static CK_RV cca_rsa_inttok_privkeysec_get_n(CK_BYTE *sec, CK_ULONG *n_len, CK_BYTE *n)
 {
+    int n_len_offset, n_value_offset;
     uint16_t n_length;
 
-    n_length = *(uint16_t *) &tok[CCA_RSA_INTTOK_PRIVKEY_N_LENGTH_OFFSET];
+    if (sec[0] == 0x30) {
+        /* internal CCA RSA key token, 4096 bits, ME format */
+        n_len_offset = CCA_RSA_INTTOK_PRIVKEY_ME_N_LENGTH_OFFSET;
+        n_value_offset = CCA_RSA_INTTOK_PRIVKEY_ME_N_OFFSET;
+    } else if (sec[0] == 0x31) {
+        /* internal CCA RSA key token, 4096 bits, CRT format */
+        n_len_offset = CCA_RSA_INTTOK_PRIVKEY_CRT_N_LENGTH_OFFSET;
+        n_value_offset = CCA_RSA_INTTOK_PRIVKEY_CRT_N_OFFSET;
+    } else {
+        TRACE_ERROR("Invalid private key section identifier 0x%02hhx\n", sec[0]);
+        return CKR_FUNCTION_FAILED;
+    }
 
+    n_length = *(uint16_t *) &sec[n_len_offset];
     if (n_length > (*n_len)) {
-        TRACE_ERROR("Not enough room to return n.(Got %lu, need %hu)\n",
+        TRACE_ERROR("Not enough room to return n (Got %lu, need %hu).\n",
                     *n_len, n_length);
         return CKR_FUNCTION_FAILED;
     }
 
-    memcpy(n, &tok[CCA_RSA_INTTOK_PRIVKEY_N_OFFSET], (size_t) n_length);
+    memcpy(n, &sec[n_value_offset], (size_t) n_length);
     *n_len = n_length;
 
     return CKR_OK;
 }
 
-/* Given a CCA internal token pubkey object, get the public exponent */
-static CK_RV cca_inttok_pubkey_get_e(CK_BYTE * tok, CK_ULONG * e_len, CK_BYTE * e)
+/* Extract exponent e from a pubkey section within an CCA internal RSA private key token */
+static CK_RV cca_rsa_inttok_pubkeysec_get_e(CK_BYTE *sec, CK_ULONG *e_len, CK_BYTE *e)
 {
     uint16_t e_length;
 
-    e_length = *(uint16_t *) & tok[CCA_RSA_INTTOK_PUBKEY_E_LENGTH_OFFSET];
+    if (sec[0] != 0x04) {
+        TRACE_ERROR("Invalid public key section identifier 0x%02hhx\n", sec[0]);
+        return CKR_FUNCTION_FAILED;
+    }
 
+    e_length = *((uint16_t *) &sec[CCA_RSA_INTTOK_PUBKEY_E_LENGTH_OFFSET]);
     if (e_length > (*e_len)) {
-        TRACE_ERROR("Not enough room to return e.(Got %lu, need %hu)\n",
+        TRACE_ERROR("Not enough room to return e (Got %lu, need %hu).\n",
                     *e_len, e_length);
         return CKR_FUNCTION_FAILED;
     }
 
-    memcpy(e, &tok[CCA_RSA_INTTOK_PUBKEY_E_OFFSET], (size_t) e_length);
+    memcpy(e, &sec[CCA_RSA_INTTOK_PUBKEY_E_OFFSET], (size_t) e_length);
+    *e_len = (CK_ULONG) e_length;
+
+    return CKR_OK;
+}
+
+/* Get modulus n from an CCA external public RSA key token's pub key section  */
+static CK_RV cca_rsa_exttok_pubkeysec_get_n(CK_BYTE *sec, CK_ULONG *n_len, CK_BYTE *n)
+{
+    uint16_t e_length, n_length, n_offset;
+
+    if (sec[0] != 0x04) {
+        TRACE_ERROR("Invalid public key section identifier 0x%02hhx\n", sec[0]);
+        return CKR_FUNCTION_FAILED;
+    }
+
+    n_length = *((uint16_t *)&sec[CCA_RSA_EXTTOK_PUBKEY_N_LENGTH_OFFSET]);
+    e_length = *((uint16_t *)&sec[CCA_RSA_INTTOK_PUBKEY_E_LENGTH_OFFSET]);
+    n_offset = CCA_RSA_INTTOK_PUBKEY_E_OFFSET + e_length;
+
+    if (n_length == 0) {
+        TRACE_ERROR("n_length is 0 - pub section from priv key given ?!?.\n");
+        return CKR_FUNCTION_FAILED;
+    }
+    if (n_length > (*n_len)) {
+        TRACE_ERROR("Not enough room to return n (Got %lu, need %hu).\n",
+                    *n_len, n_length);
+        return CKR_FUNCTION_FAILED;
+    }
+
+    memcpy(n, &sec[n_offset], (size_t) n_length);
+    *n_len = n_length;
+
+    return CKR_OK;
+}
+
+/* Get exponent e from an CCA external public RSA key token's pub key section  */
+static CK_RV cca_rsa_exttok_pubkeysec_get_e(CK_BYTE *sec, CK_ULONG *e_len, CK_BYTE *e)
+{
+    uint16_t e_length;
+
+    if (sec[0] != 0x04) {
+        TRACE_ERROR("Invalid public key section identifier 0x%02hhx\n", sec[0]);
+        return CKR_FUNCTION_FAILED;
+    }
+
+    e_length = *((uint16_t *) &sec[CCA_RSA_INTTOK_PUBKEY_E_LENGTH_OFFSET]);
+    if (e_length > (*e_len)) {
+        TRACE_ERROR("Not enough room to return e (Got %lu, need %hu).\n",
+                    *e_len, e_length);
+        return CKR_FUNCTION_FAILED;
+    }
+
+    memcpy(e, &sec[CCA_RSA_INTTOK_PUBKEY_E_OFFSET], (size_t) e_length);
     *e_len = (CK_ULONG) e_length;
 
     return CKR_OK;
 }
 
 /* Pull n and e from RSA priv key token and add to template */
-static CK_RV add_n_and_e_to_rsa_key_template(TEMPLATE * tmpl,
-                                             CK_BYTE *cca_rsa_priv_key_token)
+static CK_RV add_n_and_e_from_rsa_priv_key_to_templ(TEMPLATE *tmpl,
+                                                    CK_BYTE *cca_rsa_priv_key_token)
 {
     uint16_t privkey_len, pubkey_offset;
     CK_BYTE n[CCATOK_MAX_N_LEN], e[CCATOK_MAX_E_LEN];
@@ -764,19 +1129,25 @@ static CK_RV add_n_and_e_to_rsa_key_template(TEMPLATE * tmpl,
     CK_RV rv;
     CK_BYTE *tok = cca_rsa_priv_key_token;
 
+    if (tok[0] != 0x1F) {
+        TRACE_ERROR("Invalid cca rsa private key token identifier 0x%02hhx\n", tok[0]);
+        return CKR_FUNCTION_FAILED;
+    }
+
     privkey_len =
-        cca_inttok_privkey_get_len(&tok[CCA_RSA_INTTOK_PRIVKEY_OFFSET]);
+        cca_rsa_inttok_privkey_get_len(&tok[CCA_RSA_INTTOK_PRIVKEY_OFFSET]);
     pubkey_offset = privkey_len + CCA_RSA_INTTOK_HDR_LENGTH;
 
     /* That's right, n is stored in the private key area. Get it there */
-    if ((rv = cca_inttok_privkey_get_n(&tok[CCA_RSA_INTTOK_PRIVKEY_OFFSET],
-                                       &n_len, n))) {
+    rv = cca_rsa_inttok_privkeysec_get_n(&tok[CCA_RSA_INTTOK_PRIVKEY_OFFSET],
+                                         &n_len, n);
+    if (rv != CKR_OK) {
         TRACE_DEVEL("cca_inttok_privkey_get_n() failed. rv=0x%lx\n", rv);
         return rv;
     }
 
     /* Get e */
-    if ((rv = cca_inttok_pubkey_get_e(&tok[pubkey_offset], &e_len, e))) {
+    if ((rv = cca_rsa_inttok_pubkeysec_get_e(&tok[pubkey_offset], &e_len, e))) {
         TRACE_DEVEL("cca_inttok_pubkey_get_e() failed. rv=0x%lx\n", rv);
         return rv;
     }
@@ -983,9 +1354,9 @@ CK_RV token_specific_rsa_generate_keypair(STDLL_TokData_t * tokdata,
                 publ_key_token_length);
 
     /* update priv template, add n, e and ibm opaque attr with priv key token */
-    rv = add_n_and_e_to_rsa_key_template(priv_tmpl, priv_key_token);
+    rv = add_n_and_e_from_rsa_priv_key_to_templ(priv_tmpl, priv_key_token);
     if (rv != CKR_OK) {
-        TRACE_DEVEL("add_n_and_e_to_rsa_key_template failed. rv:%lu\n", rv);
+        TRACE_DEVEL("add_n_and_e_from_rsa_priv_key_to_templ failed. rv:%lu\n", rv);
         return rv;
     }
     rv = build_update_attribute(priv_tmpl, CKA_IBM_OPAQUE,
@@ -997,9 +1368,9 @@ CK_RV token_specific_rsa_generate_keypair(STDLL_TokData_t * tokdata,
     }
 
     /* update pub template, add n, e and ibm opaque attr with pub key token */
-    rv = add_n_and_e_to_rsa_key_template(publ_tmpl, priv_key_token);
+    rv = add_n_and_e_from_rsa_priv_key_to_templ(publ_tmpl, priv_key_token);
     if (rv != CKR_OK) {
-        TRACE_DEVEL("add_n_and_e_to_rsa_key_template failed. rv:%lu\n", rv);
+        TRACE_DEVEL("add_n_and_e_from_rsa_priv_key_to_templ failed. rv:%lu\n", rv);
         return rv;
     }
     rv = build_update_attribute(publ_tmpl, CKA_IBM_OPAQUE,
@@ -1845,8 +2216,8 @@ CK_RV token_specific_aes_ecb(STDLL_TokData_t * tokdata,
         TRACE_ERROR("Could not find CKA_IBM_OPAQUE for the key.\n");
         return CKR_FUNCTION_FAILED;
     }
+    key_len = attr->ulValueLen;
 
-    key_len = 64;
     rule_array_count = 4;
     memcpy(rule_array, "AES     ECB     KEYIDENTINITIAL ",
            rule_array_count * (size_t) CCA_KEYWORD_SIZE);
@@ -1945,6 +2316,7 @@ CK_RV token_specific_aes_cbc(STDLL_TokData_t * tokdata,
         TRACE_ERROR("Could not find CKA_IBM_OPAQUE for the key.\n");
         return CKR_FUNCTION_FAILED;
     }
+    key_len = attr->ulValueLen;
 
     if (in_data_len % 16 == 0) {
         rule_array_count = 3;
@@ -1965,7 +2337,6 @@ CK_RV token_specific_aes_cbc(STDLL_TokData_t * tokdata,
     }
 
     length = in_data_len;
-    key_len = 64;
     if (encrypt) {
         dll_CSNBSAE(&return_code,
                     &reason_code,
@@ -2400,6 +2771,7 @@ CK_RV token_specific_ec_sign(STDLL_TokData_t * tokdata,
     /* CCA doc: page 113 */
     rule_array_count = 1;
     memcpy(rule_array, "ECDSA   ", CCA_KEYWORD_SIZE);
+    *out_data_len = *out_data_len > 132 ? 132 : *out_data_len;
 
     dll_CSNDDSG(&return_code,
                 &reason_code,
@@ -3379,469 +3751,743 @@ CK_RV token_specific_hmac_verify_final(STDLL_TokData_t * tokdata,
                              &sig_len, FALSE);
 }
 
-static CK_RV rsa_import_privkey_crt(TEMPLATE * priv_tmpl)
+static CK_RV import_rsa_privkey(TEMPLATE * priv_tmpl)
 {
-    long return_code, reason_code, rule_array_count, total = 0;
-    unsigned char rule_array[CCA_RULE_ARRAY_SIZE] = { 0, };
-
-    long offset, key_value_structure_length = CCA_KEY_VALUE_STRUCT_SIZE;
-    long private_key_name_length, key_token_length, target_key_token_length;
-
-    unsigned char key_value_structure[CCA_KEY_VALUE_STRUCT_SIZE] = { 0, };
-    unsigned char private_key_name[CCA_PRIVATE_KEY_NAME_SIZE] = { 0, };
-    unsigned char key_token[CCA_KEY_TOKEN_SIZE] = { 0, };
-    unsigned char target_key_token[CCA_KEY_TOKEN_SIZE] = { 0, };
-    unsigned char transport_key_identifier[CCA_KEY_ID_SIZE] = { 0, };
-
-    uint16_t size_of_e;
-    uint16_t mod_bits, mod_bytes, bytes;
-    CK_ATTRIBUTE *opaque_key = NULL, *pub_exp = NULL, *mod = NULL,
-        *p_prime = NULL, *q_prime = NULL, *dmp1 = NULL, *dmq1 = NULL, *iqmp =
-        NULL, *priv_exp = NULL;
     CK_RV rc;
+    CK_ATTRIBUTE *opaque_attr = NULL;
 
-    /* Look for parameters to set key in the CRT format */
-    if (!template_attribute_find(priv_tmpl, CKA_PRIME_1, &p_prime)) {
-        TRACE_ERROR("CKA_PRIME_1 attribute missing for CRT.\n");
-        return CKR_TEMPLATE_INCOMPLETE;
-    }
-    total += p_prime->ulValueLen;
+    rc = template_attribute_find(priv_tmpl, CKA_IBM_OPAQUE, &opaque_attr);
+    if (rc == TRUE) {
+        /*
+         * This is an import of an existing secure rsa private key which
+         * is stored in the CKA_IBM_OPAQUE attribute.
+         */
 
-    if (!template_attribute_find(priv_tmpl, CKA_PRIME_2, &q_prime)) {
-        TRACE_ERROR("CKA_PRIME_2 attribute missing for CRT.\n");
-        return CKR_TEMPLATE_INCOMPLETE;
-    }
-    total += q_prime->ulValueLen;
+        enum cca_token_type token_type;
+        unsigned int token_keybitsize;
+        CK_BYTE *t, n[CCATOK_MAX_N_LEN], e[CCATOK_MAX_E_LEN];
+        CK_ULONG n_len = CCATOK_MAX_N_LEN, e_len = CCATOK_MAX_E_LEN;
+        uint16_t privkey_len, pubkey_offset;
 
-    if (!template_attribute_find(priv_tmpl, CKA_EXPONENT_1, &dmp1)) {
-        TRACE_ERROR("CKA_EXPONENT_1 attribute missing for CRT.\n");
-        return CKR_TEMPLATE_INCOMPLETE;
-    }
-    total += dmp1->ulValueLen;
+        if (analyse_cca_key_token(opaque_attr->pValue, opaque_attr->ulValueLen,
+                                  &token_type, &token_keybitsize) != TRUE) {
+            TRACE_ERROR("Invalid/unknown cca token in CKA_IBM_OPAQUE attribute\n");
+            return CKR_ATTRIBUTE_VALUE_INVALID;
+        }
+        if (token_type != sec_rsa_priv_key) {
+            TRACE_ERROR("CCA token type in CKA_IBM_OPAQUE does not match to keytype CKK_RSA\n");
+            return CKR_TEMPLATE_INCONSISTENT;
+        }
 
-    if (!template_attribute_find(priv_tmpl, CKA_EXPONENT_2, &dmq1)) {
-        TRACE_ERROR("CKA_EXPONENT_2 attribute missing for CRT.\n");
-        return CKR_TEMPLATE_INCOMPLETE;
-    }
-    total += dmq1->ulValueLen;
+        t = opaque_attr->pValue;
+        privkey_len = cca_rsa_inttok_privkey_get_len(&t[CCA_RSA_INTTOK_PRIVKEY_OFFSET]);
+        pubkey_offset = CCA_RSA_INTTOK_HDR_LENGTH + privkey_len;
 
-    if (!template_attribute_find(priv_tmpl, CKA_COEFFICIENT, &iqmp)) {
-        TRACE_ERROR("CKA_COEFFICIENT attribute missing for CRT.\n");
-        return CKR_TEMPLATE_INCOMPLETE;
-    }
-    total += iqmp->ulValueLen;
+        /* modulus n is stored in the private (!) key area, get it there */
+        rc =  cca_rsa_inttok_privkeysec_get_n(&t[CCA_RSA_INTTOK_PRIVKEY_OFFSET], &n_len, n);
+        if (rc != CKR_OK) {
+            TRACE_DEVEL("cca_inttok_privkey_get_n() failed. rc=0x%lx\n", rc);
+            return rc;
+        }
 
-    if (!template_attribute_find(priv_tmpl, CKA_PUBLIC_EXPONENT, &pub_exp)) {
-        TRACE_ERROR("CKA_PUBLIC_EXPONENT attribute missing for CRT.\n");
-        return CKR_TEMPLATE_INCOMPLETE;
-    }
-    total += pub_exp->ulValueLen;
+        /* get public exponent e */
+        rc = cca_rsa_inttok_pubkeysec_get_e(&t[pubkey_offset], &e_len, e);
+        if (rc != CKR_OK) {
+            TRACE_DEVEL("cca_inttok_pubkey_get_e() failed. rc=0x%lx\n", rc);
+            return rc;
+        }
 
-    if (!template_attribute_find(priv_tmpl, CKA_MODULUS, &mod)) {
-        TRACE_ERROR("CKA_MODULUS attribute missing for CRT.\n");
-        return CKR_TEMPLATE_INCOMPLETE;
-    }
-    total += mod->ulValueLen;
+        /* add n's value to the template */
+        rc = build_update_attribute(priv_tmpl, CKA_MODULUS, n, n_len);
+        if (rc != CKR_OK) {
+            TRACE_DEVEL("build_update_attribute for n failed. rc=0x%lx\n", rc);
+            return rc;
+        }
 
-    /* check total length does not exceed key_value_structure_length */
-    if ((total + 18) > key_value_structure_length) {
-        TRACE_ERROR("total length of key exceeds CCA_KEY_VALUE_STRUCT_SIZE.\n");
-        return CKR_KEY_SIZE_RANGE;
-    }
+        /* Add e's value to the template */
+        rc = build_update_attribute(priv_tmpl, CKA_PUBLIC_EXPONENT, e, e_len);
+        if (rc != CKR_OK) {
+            TRACE_DEVEL("build_update_attribute for e failed. rc=0x%lx\n", rc);
+            return rc;
+        }
 
-    /* Build key token for RSA-PRIV format.
-     * Fields according to Table 9.
-     * PKA_Key_Token_Build key-values-structure
-     */
+        /* Add dummy attributes to satisfy PKCS#11 */
+        build_update_attribute(priv_tmpl, CKA_PRIVATE_EXPONENT, NULL, 0);
+        build_update_attribute(priv_tmpl, CKA_PRIME_1, NULL, 0);
+        build_update_attribute(priv_tmpl, CKA_PRIME_2, NULL, 0);
+        build_update_attribute(priv_tmpl, CKA_EXPONENT_1, NULL, 0);
+        build_update_attribute(priv_tmpl, CKA_EXPONENT_2, NULL, 0);
+        build_update_attribute(priv_tmpl, CKA_COEFFICIENT, NULL, 0);
 
-    memset(key_value_structure, 0, key_value_structure_length);
+    } else {
+        /*
+         * This is an import of a clear key value which is to be transfered
+         * into a CCA RSA private key.
+         */
 
-    /* Field #1 - Length of modulus in bits */
-    mod_bits = htons(mod->ulValueLen * 8);
-    memcpy(&key_value_structure[0], &mod_bits, sizeof(uint16_t));
+        long return_code, reason_code, rule_array_count, total = 0;
+        unsigned char rule_array[CCA_RULE_ARRAY_SIZE] = { 0, };
 
-    /* Field #2 - Length of modulus field in bytes */
-    mod_bytes = htons(mod->ulValueLen);
-    memcpy(&key_value_structure[2], &mod_bytes, sizeof(uint16_t));
+        long offset, key_value_structure_length = CCA_KEY_VALUE_STRUCT_SIZE;
+        long private_key_name_length, key_token_length, target_key_token_length;
 
-    /* Field #3 - Length of public exponent field in bytes */
-    size_of_e = htons(pub_exp->ulValueLen);
-    memcpy(&key_value_structure[4], &size_of_e, sizeof(uint16_t));
+        unsigned char key_value_structure[CCA_KEY_VALUE_STRUCT_SIZE] = { 0, };
+        unsigned char private_key_name[CCA_PRIVATE_KEY_NAME_SIZE] = { 0, };
+        unsigned char key_token[CCA_KEY_TOKEN_SIZE] = { 0, };
+        unsigned char target_key_token[CCA_KEY_TOKEN_SIZE] = { 0, };
+        unsigned char transport_key_identifier[CCA_KEY_ID_SIZE] = { 0, };
 
-    /* Field #4 - Reserved, binary zero, two bytes */
+        uint16_t size_of_e;
+        uint16_t mod_bits, mod_bytes, bytes;
+        CK_ATTRIBUTE *pub_exp = NULL, *mod = NULL, *p_prime = NULL, *q_prime = NULL;
+        CK_ATTRIBUTE *dmp1 = NULL, *dmq1 = NULL, *iqmp = NULL, *priv_exp = NULL;
 
-    /* Field #5 - Length of prime P */
-    bytes = htons(p_prime->ulValueLen);
-    memcpy(&key_value_structure[8], &bytes, sizeof(uint16_t));
+        /* Look for parameters to set key in the CRT format */
+        if (!template_attribute_find(priv_tmpl, CKA_PRIME_1, &p_prime)) {
+            TRACE_ERROR("CKA_PRIME_1 attribute missing for CRT.\n");
+            return CKR_TEMPLATE_INCOMPLETE;
+        }
+        total += p_prime->ulValueLen;
 
-    /* Field #6 - Length of prime Q */
-    bytes = htons(q_prime->ulValueLen);
-    memcpy(&key_value_structure[10], &bytes, sizeof(uint16_t));
+        if (!template_attribute_find(priv_tmpl, CKA_PRIME_2, &q_prime)) {
+            TRACE_ERROR("CKA_PRIME_2 attribute missing for CRT.\n");
+            return CKR_TEMPLATE_INCOMPLETE;
+        }
+        total += q_prime->ulValueLen;
 
-    /* Field #7 - Length of dp in bytes */
-    bytes = htons(dmp1->ulValueLen);
-    memcpy(&key_value_structure[12], &bytes, sizeof(uint16_t));
+        if (!template_attribute_find(priv_tmpl, CKA_EXPONENT_1, &dmp1)) {
+            TRACE_ERROR("CKA_EXPONENT_1 attribute missing for CRT.\n");
+            return CKR_TEMPLATE_INCOMPLETE;
+        }
+        total += dmp1->ulValueLen;
 
-    /* Field #8 - Length of dq in bytes */
-    bytes = htons(dmq1->ulValueLen);
-    memcpy(&key_value_structure[14], &bytes, sizeof(uint16_t));
+        if (!template_attribute_find(priv_tmpl, CKA_EXPONENT_2, &dmq1)) {
+            TRACE_ERROR("CKA_EXPONENT_2 attribute missing for CRT.\n");
+            return CKR_TEMPLATE_INCOMPLETE;
+        }
+        total += dmq1->ulValueLen;
 
-    /* Field #9 - Length of U in bytes */
-    bytes = htons(iqmp->ulValueLen);
-    memcpy(&key_value_structure[16], &bytes, sizeof(uint16_t));
+        if (!template_attribute_find(priv_tmpl, CKA_COEFFICIENT, &iqmp)) {
+            TRACE_ERROR("CKA_COEFFICIENT attribute missing for CRT.\n");
+            return CKR_TEMPLATE_INCOMPLETE;
+        }
+        total += iqmp->ulValueLen;
 
-    /* Field #10 - Modulus */
-    memcpy(&key_value_structure[18], mod->pValue, mod_bytes);
+        if (!template_attribute_find(priv_tmpl, CKA_PUBLIC_EXPONENT, &pub_exp)) {
+            TRACE_ERROR("CKA_PUBLIC_EXPONENT attribute missing for CRT.\n");
+            return CKR_TEMPLATE_INCOMPLETE;
+        }
+        total += pub_exp->ulValueLen;
 
-    offset = 18 + mod_bytes;
+        if (!template_attribute_find(priv_tmpl, CKA_MODULUS, &mod)) {
+            TRACE_ERROR("CKA_MODULUS attribute missing for CRT.\n");
+            return CKR_TEMPLATE_INCOMPLETE;
+        }
+        total += mod->ulValueLen;
 
-    /* Field #11 - Public Exponent */
-    memcpy(&key_value_structure[offset], pub_exp->pValue, pub_exp->ulValueLen);
+        /* check total length does not exceed key_value_structure_length */
+        if ((total + 18) > key_value_structure_length) {
+            TRACE_ERROR("total length of key exceeds CCA_KEY_VALUE_STRUCT_SIZE.\n");
+            return CKR_KEY_SIZE_RANGE;
+        }
 
-    offset += pub_exp->ulValueLen;
+        /* Build key token for RSA-PRIV format.
+         * Fields according to Table 9.
+         * PKA_Key_Token_Build key-values-structure
+         */
 
-    /* Field #12 - Prime numer, p */
-    memcpy(&key_value_structure[offset], p_prime->pValue, p_prime->ulValueLen);
+        memset(key_value_structure, 0, key_value_structure_length);
 
-    offset += p_prime->ulValueLen;
+        /* Field #1 - Length of modulus in bits */
+        mod_bits = htons(mod->ulValueLen * 8);
+        memcpy(&key_value_structure[0], &mod_bits, sizeof(uint16_t));
 
-    /* Field #13 - Prime numer, q */
-    memcpy(&key_value_structure[offset], q_prime->pValue, q_prime->ulValueLen);
+        /* Field #2 - Length of modulus field in bytes */
+        mod_bytes = htons(mod->ulValueLen);
+        memcpy(&key_value_structure[2], &mod_bytes, sizeof(uint16_t));
 
-    offset += q_prime->ulValueLen;
+        /* Field #3 - Length of public exponent field in bytes */
+        size_of_e = htons(pub_exp->ulValueLen);
+        memcpy(&key_value_structure[4], &size_of_e, sizeof(uint16_t));
 
-    /* Field #14 - dp = dmod(p-1) */
-    memcpy(&key_value_structure[offset], dmp1->pValue, dmp1->ulValueLen);
+        /* Field #4 - Reserved, binary zero, two bytes */
 
-    offset += dmp1->ulValueLen;
+        /* Field #5 - Length of prime P */
+        bytes = htons(p_prime->ulValueLen);
+        memcpy(&key_value_structure[8], &bytes, sizeof(uint16_t));
 
-    /* Field #15 - dq = dmod(q-1) */
-    memcpy(&key_value_structure[offset], dmq1->pValue, dmq1->ulValueLen);
+        /* Field #6 - Length of prime Q */
+        bytes = htons(q_prime->ulValueLen);
+        memcpy(&key_value_structure[10], &bytes, sizeof(uint16_t));
 
-    offset += dmq1->ulValueLen;
+        /* Field #7 - Length of dp in bytes */
+        bytes = htons(dmp1->ulValueLen);
+        memcpy(&key_value_structure[12], &bytes, sizeof(uint16_t));
 
-    /* Field #16 - U = (q^-1)mod(p)  */
-    memcpy(&key_value_structure[offset], iqmp->pValue, iqmp->ulValueLen);
+        /* Field #8 - Length of dq in bytes */
+        bytes = htons(dmq1->ulValueLen);
+        memcpy(&key_value_structure[14], &bytes, sizeof(uint16_t));
 
-    /* Now build a key token with the imported public key */
+        /* Field #9 - Length of U in bytes */
+        bytes = htons(iqmp->ulValueLen);
+        memcpy(&key_value_structure[16], &bytes, sizeof(uint16_t));
 
-    rule_array_count = 2;
-    memcpy(rule_array, "RSA-AESCKEY-MGMT", (size_t) (CCA_KEYWORD_SIZE * 2));
+        /* Field #10 - Modulus */
+        memcpy(&key_value_structure[18], mod->pValue, mod_bytes);
 
-    private_key_name_length = 0;
+        offset = 18 + mod_bytes;
 
-    key_token_length = CCA_KEY_TOKEN_SIZE;
+        /* Field #11 - Public Exponent */
+        memcpy(&key_value_structure[offset], pub_exp->pValue, pub_exp->ulValueLen);
 
-    dll_CSNDPKB(&return_code, &reason_code, NULL, NULL, &rule_array_count,
-                rule_array, &key_value_structure_length, key_value_structure,
-                &private_key_name_length, private_key_name, 0, NULL, 0, NULL,
-                0, NULL, 0, NULL, 0, NULL, &key_token_length, key_token);
+        offset += pub_exp->ulValueLen;
 
-    if (return_code != CCA_SUCCESS) {
-        TRACE_ERROR("CSNDPKB (RSA KEY TOKEN BUILD RSA CRT) failed."
-                    " return:%ld, reason:%ld\n", return_code, reason_code);
-        rc = CKR_FUNCTION_FAILED;
-        goto err;
-    }
+        /* Field #12 - Prime numer, p */
+        memcpy(&key_value_structure[offset], p_prime->pValue, p_prime->ulValueLen);
 
-    /* Now import the PKA key token */
-    rule_array_count = 0;
-    /* memcpy(rule_array, "        ", (size_t)(CCA_KEYWORD_SIZE * 1)); */
+        offset += p_prime->ulValueLen;
 
-    target_key_token_length = CCA_KEY_TOKEN_SIZE;
+        /* Field #13 - Prime numer, q */
+        memcpy(&key_value_structure[offset], q_prime->pValue, q_prime->ulValueLen);
 
-    key_token_length = CCA_KEY_TOKEN_SIZE;
+        offset += q_prime->ulValueLen;
 
-    dll_CSNDPKI(&return_code, &reason_code, NULL, NULL, &rule_array_count,
-                rule_array, &key_token_length, key_token,
-                transport_key_identifier, &target_key_token_length,
-                target_key_token);
+        /* Field #14 - dp = dmod(p-1) */
+        memcpy(&key_value_structure[offset], dmp1->pValue, dmp1->ulValueLen);
 
-    if (return_code != CCA_SUCCESS) {
-        TRACE_ERROR("CSNDPKI (RSA KEY TOKEN IMPORT) failed."
-                    " return:%ld, reason:%ld\n", return_code, reason_code);
-        rc = CKR_FUNCTION_FAILED;
-        goto err;
-    }
+        offset += dmp1->ulValueLen;
 
-    /* Add the key object to the template */
-    if ((rc = build_attribute(CKA_IBM_OPAQUE, target_key_token,
-                              target_key_token_length, &opaque_key))) {
-        TRACE_DEVEL("build_attribute failed\n");
-        goto err;
-    }
-    rc = template_update_attribute(priv_tmpl, opaque_key);
-    if (rc != CKR_OK) {
-        TRACE_DEVEL("template_update_attribute failed\n");
-        goto err;
-    }
+        /* Field #15 - dq = dmod(q-1) */
+        memcpy(&key_value_structure[offset], dmq1->pValue, dmq1->ulValueLen);
 
-    OPENSSL_cleanse(p_prime->pValue, p_prime->ulValueLen);
-    OPENSSL_cleanse(q_prime->pValue, q_prime->ulValueLen);
-    OPENSSL_cleanse(dmp1->pValue, dmp1->ulValueLen);
-    OPENSSL_cleanse(dmq1->pValue, dmq1->ulValueLen);
-    OPENSSL_cleanse(iqmp->pValue, iqmp->ulValueLen);
-    if (template_attribute_find(priv_tmpl, CKA_PRIVATE_EXPONENT, &priv_exp)) {
-        OPENSSL_cleanse(priv_exp->pValue, priv_exp->ulValueLen);
-    }
+        offset += dmq1->ulValueLen;
 
-    rc =CKR_OK;
+        /* Field #16 - U = (q^-1)mod(p)  */
+        memcpy(&key_value_structure[offset], iqmp->pValue, iqmp->ulValueLen);
 
+        /* Now build a key token with the imported public key */
+
+        rule_array_count = 2;
+        memcpy(rule_array, "RSA-AESCKEY-MGMT", (size_t) (CCA_KEYWORD_SIZE * 2));
+
+        private_key_name_length = 0;
+
+        key_token_length = CCA_KEY_TOKEN_SIZE;
+
+        dll_CSNDPKB(&return_code, &reason_code, NULL, NULL, &rule_array_count,
+                    rule_array, &key_value_structure_length, key_value_structure,
+                    &private_key_name_length, private_key_name, 0, NULL, 0, NULL,
+                    0, NULL, 0, NULL, 0, NULL, &key_token_length, key_token);
+
+        if (return_code != CCA_SUCCESS) {
+            TRACE_ERROR("CSNDPKB (RSA KEY TOKEN BUILD RSA CRT) failed."
+                        " return:%ld, reason:%ld\n", return_code, reason_code);
+            rc = CKR_FUNCTION_FAILED;
+            goto err;
+        }
+
+        /* Now import the PKA key token */
+        rule_array_count = 0;
+
+        target_key_token_length = CCA_KEY_TOKEN_SIZE;
+
+        key_token_length = CCA_KEY_TOKEN_SIZE;
+
+        dll_CSNDPKI(&return_code, &reason_code, NULL, NULL, &rule_array_count,
+                    rule_array, &key_token_length, key_token,
+                    transport_key_identifier, &target_key_token_length,
+                    target_key_token);
+
+        if (return_code != CCA_SUCCESS) {
+            TRACE_ERROR("CSNDPKI (RSA KEY TOKEN IMPORT) failed."
+                        " return:%ld, reason:%ld\n", return_code, reason_code);
+            rc = CKR_FUNCTION_FAILED;
+            goto err;
+        }
+
+        /* Add the key object to the template */
+        if ((rc = build_attribute(CKA_IBM_OPAQUE, target_key_token,
+                                  target_key_token_length, &opaque_attr))) {
+            TRACE_DEVEL("build_attribute failed\n");
+            goto err;
+        }
+        rc = template_update_attribute(priv_tmpl, opaque_attr);
+        if (rc != CKR_OK) {
+            TRACE_DEVEL("template_update_attribute failed\n");
+            goto err;
+        }
+
+        OPENSSL_cleanse(p_prime->pValue, p_prime->ulValueLen);
+        OPENSSL_cleanse(q_prime->pValue, q_prime->ulValueLen);
+        OPENSSL_cleanse(dmp1->pValue, dmp1->ulValueLen);
+        OPENSSL_cleanse(dmq1->pValue, dmq1->ulValueLen);
+        OPENSSL_cleanse(iqmp->pValue, iqmp->ulValueLen);
+        if (template_attribute_find(priv_tmpl, CKA_PRIVATE_EXPONENT, &priv_exp)) {
+            OPENSSL_cleanse(priv_exp->pValue, priv_exp->ulValueLen);
+        }
+
+        rc = CKR_OK;
 err:
-    OPENSSL_cleanse(key_value_structure, sizeof(key_value_structure));
+        OPENSSL_cleanse(key_value_structure, sizeof(key_value_structure));
+    }
+
+#ifdef DEBUG
+    if (rc == CKR_OK) {
+        TRACE_DEBUG("%s: imported object template attributes:\n", __func__);
+        dump_template(priv_tmpl);
+    }
+#endif
+
     return rc;
 }
 
-static CK_RV rsa_import_pubkey(TEMPLATE * publ_tmpl)
+static CK_RV import_rsa_pubkey(TEMPLATE * publ_tmpl)
 {
-    long return_code, reason_code, rule_array_count;
-    unsigned char rule_array[CCA_RULE_ARRAY_SIZE] = { 0, };
-
-    long key_value_structure_length = CCA_KEY_VALUE_STRUCT_SIZE;
-    long private_key_name_length, key_token_length;
-    unsigned char key_value_structure[CCA_KEY_VALUE_STRUCT_SIZE] = { 0, };
-    unsigned char private_key_name[CCA_PRIVATE_KEY_NAME_SIZE] = { 0, };
-    unsigned char key_token[CCA_KEY_TOKEN_SIZE] = { 0, };
-
-    uint16_t size_of_e;
-    uint16_t mod_bits, mod_bytes;
-    CK_ATTRIBUTE *opaque_key = NULL, *pub_exp = NULL;
-    CK_ATTRIBUTE *pub_mod = NULL, *attr = NULL;
     CK_RV rc;
+    CK_ATTRIBUTE *opaque_attr = NULL;
 
-    /* check that modulus and public exponent are available */
-    if (!template_attribute_find(publ_tmpl, CKA_PUBLIC_EXPONENT, &pub_exp)) {
-        TRACE_ERROR("CKA_PUBLIC_EXPONENT attribute missing.\n");
-        return CKR_TEMPLATE_INCOMPLETE;
+    rc = template_attribute_find(publ_tmpl, CKA_IBM_OPAQUE, &opaque_attr);
+    if (rc == TRUE) {
+        /*
+         * This is an import of an existing secure rsa public key which
+         * is stored in the CKA_IBM_OPAQUE attribute.
+         */
+
+        enum cca_token_type token_type;
+        unsigned int token_keybitsize;
+        CK_BYTE *t, n[CCATOK_MAX_N_LEN], e[CCATOK_MAX_E_LEN];
+        CK_ULONG n_len = CCATOK_MAX_N_LEN, e_len = CCATOK_MAX_E_LEN;
+
+        if (analyse_cca_key_token(opaque_attr->pValue, opaque_attr->ulValueLen,
+                                  &token_type, &token_keybitsize) != TRUE) {
+            TRACE_ERROR("Invalid/unknown cca token in CKA_IBM_OPAQUE attribute\n");
+            return CKR_ATTRIBUTE_VALUE_INVALID;
+        }
+        if (token_type != sec_rsa_publ_key) {
+            TRACE_ERROR("CCA token type in CKA_IBM_OPAQUE does not match to keytype CKK_RSA\n");
+            return CKR_TEMPLATE_INCONSISTENT;
+        }
+
+        t = opaque_attr->pValue;
+
+        /* extract modulus n from public key section */
+        rc = cca_rsa_exttok_pubkeysec_get_n(&t[CCA_RSA_EXTTOK_PUBKEY_OFFSET], &n_len, n);
+        if (rc != CKR_OK) {
+            TRACE_DEVEL("cca_exttok_pubkey_get_n() failed. rc=0x%lx\n", rc);
+            return rc;
+        }
+
+        /* extract exponent e from public key section */
+        rc = cca_rsa_exttok_pubkeysec_get_e(&t[CCA_RSA_EXTTOK_PUBKEY_OFFSET], &e_len, e);
+        if (rc != CKR_OK) {
+            TRACE_DEVEL("cca_exttok_pubkey_get_e() failed. rc=0x%lx\n", rc);
+            return rc;
+        }
+
+        /* add n's value to the template */
+        rc = build_update_attribute(publ_tmpl, CKA_MODULUS, n, n_len);
+        if (rc != CKR_OK) {
+            TRACE_DEVEL("build_update_attribute for n failed. rc=0x%lx\n", rc);
+            return rc;
+        }
+
+        /* Add e's value to the template */
+        rc = build_update_attribute(publ_tmpl, CKA_PUBLIC_EXPONENT, e, e_len);
+        if (rc != CKR_OK) {
+            TRACE_DEVEL("build_update_attribute for e failed. rc=0x%lx\n", rc);
+            return rc;
+        }
+
+    } else {
+        /*
+         * This is an import of a clear key value which is to be transfered
+         * into a CCA RSA private key.
+         */
+
+        long return_code, reason_code, rule_array_count;
+        unsigned char rule_array[CCA_RULE_ARRAY_SIZE] = { 0, };
+
+        long key_value_structure_length = CCA_KEY_VALUE_STRUCT_SIZE;
+        long private_key_name_length, key_token_length;
+        unsigned char key_value_structure[CCA_KEY_VALUE_STRUCT_SIZE] = { 0, };
+        unsigned char private_key_name[CCA_PRIVATE_KEY_NAME_SIZE] = { 0, };
+        unsigned char key_token[CCA_KEY_TOKEN_SIZE] = { 0, };
+
+        uint16_t size_of_e;
+        uint16_t mod_bits, mod_bytes;
+        CK_ATTRIBUTE *pub_exp = NULL, *pub_mod = NULL, *attr = NULL;
+
+        /* check that modulus and public exponent are available */
+        if (!template_attribute_find(publ_tmpl, CKA_PUBLIC_EXPONENT, &pub_exp)) {
+            TRACE_ERROR("CKA_PUBLIC_EXPONENT attribute missing.\n");
+            return CKR_TEMPLATE_INCOMPLETE;
+        }
+
+        if (!template_attribute_find(publ_tmpl, CKA_MODULUS, &pub_mod)) {
+            TRACE_ERROR("CKA_MODULUS attribute missing.\n");
+            return CKR_TEMPLATE_INCOMPLETE;
+        }
+
+        if (!template_attribute_find(publ_tmpl, CKA_MODULUS_BITS, &attr)) {
+            TRACE_ERROR("CKA_MODULUS_BITS attribute missing.\n");
+            return CKR_TEMPLATE_INCOMPLETE;
+        }
+
+        /* check total length does not exceed key_value_structure_length */
+        if ((pub_mod->ulValueLen + 8) > (CK_ULONG)key_value_structure_length) {
+            TRACE_ERROR("total length of key exceeds CCA_KEY_VALUE_STRUCT_SIZE.\n");
+            return CKR_KEY_SIZE_RANGE;
+        }
+
+        /* In case the application hasn't filled it */
+        if (*(CK_ULONG *) attr->pValue == 0)
+            mod_bits = htons(pub_mod->ulValueLen * 8);
+        else
+            mod_bits = htons(*(CK_ULONG *) attr->pValue);
+
+        /* Build key token for RSA-PUBL format */
+        memset(key_value_structure, 0, key_value_structure_length);
+
+        /* Fields according to Table 9.
+         * PKA_Key_Token_Build key-values-structure
+         */
+
+        /* Field #1 - Length of modulus in bits */
+        memcpy(&key_value_structure[0], &mod_bits, sizeof(uint16_t));
+
+        /* Field #2 - Length of modulus field in bytes */
+        mod_bytes = htons(pub_mod->ulValueLen);
+        memcpy(&key_value_structure[2], &mod_bytes, sizeof(uint16_t));
+
+        /* Field #3 - Length of public exponent field in bytes */
+        size_of_e = htons((uint16_t) pub_exp->ulValueLen);
+        memcpy(&key_value_structure[4], &size_of_e, sizeof(uint16_t));
+
+        /* Field #4 - private key exponent length; skip */
+
+        /* Field #5 - Modulus */
+        memcpy(&key_value_structure[8], pub_mod->pValue,
+               (size_t) pub_mod->ulValueLen);
+
+        /* Field #6 - Public exponent. Its offset depends on modulus size */
+        memcpy(&key_value_structure[8 + mod_bytes],
+               pub_exp->pValue, (size_t) pub_exp->ulValueLen);
+
+        /* Field #7 - Private exponent. Skip */
+
+        rule_array_count = 1;
+        memcpy(rule_array, "RSA-PUBL", (size_t) (CCA_KEYWORD_SIZE * 1));
+
+        private_key_name_length = 0;
+
+        key_token_length = CCA_KEY_TOKEN_SIZE;
+
+        // Create a key token for the public key.
+        // Public keys do not need to be wrapped, so just call PKB.
+        dll_CSNDPKB(&return_code, &reason_code, NULL, NULL, &rule_array_count,
+                    rule_array, &key_value_structure_length, key_value_structure,
+                    &private_key_name_length, private_key_name, 0, NULL, 0,
+                    NULL, 0, NULL, 0, NULL, 0, NULL, &key_token_length, key_token);
+
+        if (return_code != CCA_SUCCESS) {
+            TRACE_ERROR("CSNDPKB (RSA KEY TOKEN BUILD RSA-PUBL) failed."
+                        " return:%ld, reason:%ld\n", return_code, reason_code);
+            return CKR_FUNCTION_FAILED;
+        }
+        // Add the key object to the template.
+        if ((rc = build_attribute(CKA_IBM_OPAQUE, key_token, key_token_length,
+                                  &opaque_attr))) {
+            TRACE_DEVEL("build_attribute failed\n");
+            return rc;
+        }
+
+        rc = template_update_attribute(publ_tmpl, opaque_attr);
+        if (rc != CKR_OK) {
+            TRACE_DEVEL("template_update_attribute failed\n");
+            return rc;
+        }
     }
 
-    if (!template_attribute_find(publ_tmpl, CKA_MODULUS, &pub_mod)) {
-        TRACE_ERROR("CKA_MODULUS attribute missing.\n");
-        return CKR_TEMPLATE_INCOMPLETE;
+#ifdef DEBUG
+    if (rc == CKR_OK) {
+        TRACE_DEBUG("%s: imported object template attributes:\n", __func__);
+        dump_template(publ_tmpl);
     }
+#endif
 
-    if (!template_attribute_find(publ_tmpl, CKA_MODULUS_BITS, &attr)) {
-        TRACE_ERROR("CKA_MODULUS_BITS attribute missing.\n");
-        return CKR_TEMPLATE_INCOMPLETE;
-    }
-
-    /* check total length does not exceed key_value_structure_length */
-    if ((pub_mod->ulValueLen + 8) > (CK_ULONG)key_value_structure_length) {
-        TRACE_ERROR("total length of key exceeds CCA_KEY_VALUE_STRUCT_SIZE.\n");
-        return CKR_KEY_SIZE_RANGE;
-    }
-
-    /* In case the application hasn't filled it */
-    if (*(CK_ULONG *) attr->pValue == 0)
-        mod_bits = htons(pub_mod->ulValueLen * 8);
-    else
-        mod_bits = htons(*(CK_ULONG *) attr->pValue);
-
-    /* Build key token for RSA-PUBL format */
-    memset(key_value_structure, 0, key_value_structure_length);
-
-    /* Fields according to Table 9.
-     * PKA_Key_Token_Build key-values-structure
-     */
-
-    /* Field #1 - Length of modulus in bits */
-    memcpy(&key_value_structure[0], &mod_bits, sizeof(uint16_t));
-
-    /* Field #2 - Length of modulus field in bytes */
-    mod_bytes = htons(pub_mod->ulValueLen);
-    memcpy(&key_value_structure[2], &mod_bytes, sizeof(uint16_t));
-
-    /* Field #3 - Length of public exponent field in bytes */
-    size_of_e = htons((uint16_t) pub_exp->ulValueLen);
-    memcpy(&key_value_structure[4], &size_of_e, sizeof(uint16_t));
-
-    /* Field #4 - private key exponent length; skip */
-
-    /* Field #5 - Modulus */
-    memcpy(&key_value_structure[8], pub_mod->pValue,
-           (size_t) pub_mod->ulValueLen);
-
-    /* Field #6 - Public exponent. Its offset depends on modulus size */
-    memcpy(&key_value_structure[8 + mod_bytes],
-           pub_exp->pValue, (size_t) pub_exp->ulValueLen);
-
-    /* Field #7 - Private exponent. Skip */
-
-    rule_array_count = 1;
-    memcpy(rule_array, "RSA-PUBL", (size_t) (CCA_KEYWORD_SIZE * 1));
-
-    private_key_name_length = 0;
-
-    key_token_length = CCA_KEY_TOKEN_SIZE;
-
-    // Create a key token for the public key.
-    // Public keys do not need to be wrapped, so just call PKB.
-    dll_CSNDPKB(&return_code, &reason_code, NULL, NULL, &rule_array_count,
-                rule_array, &key_value_structure_length, key_value_structure,
-                &private_key_name_length, private_key_name, 0, NULL, 0,
-                NULL, 0, NULL, 0, NULL, 0, NULL, &key_token_length, key_token);
-
-    if (return_code != CCA_SUCCESS) {
-        TRACE_ERROR("CSNDPKB (RSA KEY TOKEN BUILD RSA-PUBL) failed."
-                    " return:%ld, reason:%ld\n", return_code, reason_code);
-        return CKR_FUNCTION_FAILED;
-    }
-    // Add the key object to the template.
-    if ((rc = build_attribute(CKA_IBM_OPAQUE, key_token, key_token_length,
-                              &opaque_key))) {
-        TRACE_DEVEL("build_attribute failed\n");
-        return rc;
-    }
-
-    rc = template_update_attribute(publ_tmpl, opaque_key);
-    if (rc != CKR_OK) {
-        TRACE_DEVEL("template_update_attribute failed\n");
-        return rc;
-    }
-
-    return CKR_OK;
+    return rc;
 }
 
 static CK_RV import_symmetric_key(OBJECT * object, CK_ULONG keytype)
 {
     CK_RV rc;
-    long return_code, reason_code, rule_array_count;
-    unsigned char target_key_id[CCA_KEY_ID_SIZE] = { 0 };
-    unsigned char rule_array[CCA_RULE_ARRAY_SIZE] = { 0 };
-    CK_ATTRIBUTE *opaque_key = NULL;
-    CK_ATTRIBUTE *attr = NULL;
+    CK_ATTRIBUTE *opaque_attr = NULL;
+    CK_ATTRIBUTE *value_attr = NULL;
 
-    rc = template_attribute_find(object->template, CKA_VALUE, &attr);
+    rc = template_attribute_find(object->template, CKA_VALUE, &value_attr);
     if (rc == FALSE) {
         TRACE_ERROR("Incomplete key template\n");
         return CKR_TEMPLATE_INCOMPLETE;
     }
 
-    switch (keytype) {
-    case CKK_AES:
-        memcpy(rule_array, "AES     ", CCA_KEYWORD_SIZE);
-        break;
-    case CKK_DES:
-    case CKK_DES3:
-        memcpy(rule_array, "DES     ", CCA_KEYWORD_SIZE);
-        break;
-    default:
-        return CKR_KEY_FUNCTION_NOT_PERMITTED;
-    }
+    rc = template_attribute_find(object->template, CKA_IBM_OPAQUE, &opaque_attr);
+    if (rc == TRUE) {
+        /*
+         * This is an import of an existing secure key which is stored in
+         * the CKA_IBM_OPAQUE attribute. The CKA_VALUE attribute is only
+         * a dummy reflecting the clear key byte size. However, let's
+         * check if the template attributes match to the cca key in the
+         * CKA_IBM_OPAQUE attribute.
+         */
 
-    rule_array_count = 1;
+        enum cca_token_type token_type;
+        unsigned int token_keybitsize;
 
-    dll_CSNBCKM(&return_code, &reason_code, NULL, NULL, &rule_array_count,
-                rule_array, (long int *)&attr->ulValueLen, attr->pValue,
-                target_key_id);
+        if (analyse_cca_key_token(opaque_attr->pValue, opaque_attr->ulValueLen,
+                                  &token_type, &token_keybitsize) != TRUE) {
+            TRACE_ERROR("Invalid/unknown cca token in CKA_IBM_OPAQUE attribute\n");
+            return CKR_ATTRIBUTE_VALUE_INVALID;
+        }
 
-    if (return_code != CCA_SUCCESS) {
-        TRACE_ERROR("CSNBCKM failed. return:%ld, reason:%ld\n",
-                    return_code, reason_code);
-        return CKR_FUNCTION_FAILED;
-    }
+        if (keytype == CKK_DES) {
+            if (value_attr->ulValueLen != 8) {
+                TRACE_ERROR("CKA_VALUE length %lu != 8 (DES key byte size)\n",
+                            value_attr->ulValueLen);
+                return CKR_ATTRIBUTE_VALUE_INVALID;
+            }
+            if (token_type != sec_des_data_key) {
+                TRACE_ERROR("CCA token type in CKA_IBM_OPAQUE does not match to keytype CKK_DES\n");
+                return CKR_TEMPLATE_INCONSISTENT;
+            }
+            if (token_keybitsize != 8 * value_attr->ulValueLen) {
+                TRACE_ERROR("CCA token keybitsize %u does not match to CKA_VALUE len\n",
+                            token_keybitsize);
+                return CKR_TEMPLATE_INCONSISTENT;
+            }
+        } else if (keytype == CKK_DES3) {
+            if (value_attr->ulValueLen != 24) {
+                TRACE_ERROR("CKA_VALUE length %lu != 24 (DES3 key byte size)\n",
+                            value_attr->ulValueLen);
+                return CKR_ATTRIBUTE_VALUE_INVALID;
+            }
+            if (token_type != sec_des_data_key) {
+                TRACE_ERROR("CCA token type in CKA_IBM_OPAQUE does not match to keytype CKK_DES3\n");
+                return CKR_TEMPLATE_INCONSISTENT;
+            }
+            if (token_keybitsize != 8 * value_attr->ulValueLen) {
+                TRACE_ERROR("CCA token keybitsize %u does not match to CKA_VALUE len\n",
+                            token_keybitsize);
+                return CKR_TEMPLATE_INCONSISTENT;
+            }
+        } else if (keytype == CKK_AES) {
+            if (value_attr->ulValueLen != 16 &&
+                value_attr->ulValueLen != 24 &&
+                value_attr->ulValueLen != 32) {
+                TRACE_ERROR("CKA_VALUE length %lu != 16/24/32 (valid AES key byte sizes)\n",
+                            value_attr->ulValueLen);
+                return CKR_ATTRIBUTE_VALUE_INVALID;
+            }
+            if (token_type == sec_aes_data_key) {
+                if (token_keybitsize != 8 * value_attr->ulValueLen) {
+                    TRACE_ERROR("CCA token keybitsize %u does not match to CKA_VALUE len\n",
+                                token_keybitsize);
+                    return CKR_TEMPLATE_INCONSISTENT;
+                }
+            } else if (token_type == sec_aes_cipher_key) {
+                /* no chance to check keybitsize, we have to trust the value length */
+                ;
+            } else {
+                TRACE_ERROR("CCA token type in CKA_IBM_OPAQUE does not match to keytype CKK_AES\n");
+                return CKR_TEMPLATE_INCONSISTENT;
+            }
+        } else {
+            TRACE_DEBUG("Unknown/unsupported keytype in function %s line %d\n", __func__, __LINE__);
+            return CKR_KEY_FUNCTION_NOT_PERMITTED;
+        }
 
-    /* Add the key object to the template */
-    if ((rc = build_attribute(CKA_IBM_OPAQUE, target_key_id,
-                              CCA_KEY_ID_SIZE, &opaque_key))) {
-        TRACE_DEVEL("build_attribute(CKA_IBM_OPAQUE) failed\n");
-        return rc;
-    }
-    rc = template_update_attribute(object->template, opaque_key);
-    if (rc != CKR_OK) {
-        TRACE_DEVEL("template_update_attribute(CKA_IBM_OPAQUE) failed\n");
-        return rc;
+    } else {
+        /*
+         * This is an import of a clear key value which is to be transfered
+         * into a CCA Data AES or DES key now.
+         */
+
+        long return_code, reason_code, rule_array_count;
+        unsigned char target_key[CCA_KEY_ID_SIZE] = { 0 };
+        unsigned char rule_array[CCA_RULE_ARRAY_SIZE] = { 0 };
+
+        switch (keytype) {
+        case CKK_AES:
+            memcpy(rule_array, "AES     ", CCA_KEYWORD_SIZE);
+            break;
+        case CKK_DES:
+        case CKK_DES3:
+            memcpy(rule_array, "DES     ", CCA_KEYWORD_SIZE);
+            break;
+        default:
+            return CKR_KEY_FUNCTION_NOT_PERMITTED;
+        }
+
+        rule_array_count = 1;
+
+        dll_CSNBCKM(&return_code, &reason_code, NULL, NULL,
+                    &rule_array_count, rule_array,
+                    (long int *)&value_attr->ulValueLen, value_attr->pValue,
+                    target_key);
+
+        if (return_code != CCA_SUCCESS) {
+            TRACE_ERROR("CSNBCKM failed. return:%ld, reason:%ld\n",
+                        return_code, reason_code);
+            return CKR_FUNCTION_FAILED;
+        }
+
+        /* Add the key object to the template */
+        if ((rc = build_attribute(CKA_IBM_OPAQUE, target_key,
+                                  CCA_KEY_ID_SIZE, &opaque_attr))) {
+            TRACE_DEVEL("build_attribute(CKA_IBM_OPAQUE) failed\n");
+            return rc;
+        }
+        rc = template_update_attribute(object->template, opaque_attr);
+        if (rc != CKR_OK) {
+            TRACE_DEVEL("template_update_attribute(CKA_IBM_OPAQUE) failed\n");
+            return rc;
+        }
     }
 
     /* zero clear key value */
-    OPENSSL_cleanse(attr->pValue, attr->ulValueLen);
+    OPENSSL_cleanse(value_attr->pValue, value_attr->ulValueLen);
+
+#ifdef DEBUG
+    TRACE_DEBUG("%s: imported object template attributes:\n", __func__);
+    dump_template(object->template);
+#endif
 
     return CKR_OK;
 }
 
-
 static CK_RV import_generic_secret_key(OBJECT * object)
 {
     CK_RV rc;
-    long return_code, reason_code, rule_array_count;
-    unsigned char key_token[CCA_KEY_TOKEN_SIZE] = { 0 };
-    unsigned char rule_array[CCA_RULE_ARRAY_SIZE] = { 0 };
-    long key_name_len = 0, clr_key_len = 0;
-    long user_data_len = 0, key_part_len = 0;
-    long token_data_len = 0, verb_data_len = 0;
-    long key_token_len = sizeof(key_token);
-    CK_ATTRIBUTE *opaque_key = NULL;
-    CK_ATTRIBUTE *attr = NULL;
-    CK_ULONG keylen;
+    CK_ATTRIBUTE *opaque_attr = NULL;
+    CK_ATTRIBUTE *value_attr = NULL;
+    CK_ULONG keylen, keybitlen;
 
-    rc = template_attribute_find(object->template, CKA_VALUE, &attr);
+    rc = template_attribute_find(object->template, CKA_VALUE, &value_attr);
     if (rc == FALSE) {
         TRACE_ERROR("Incomplete Generic Secret (HMAC) key template\n");
         return CKR_TEMPLATE_INCOMPLETE;
     }
-    keylen = attr->ulValueLen;
-    /* key len needs to be 80-2048 bits */
-    if (8 * keylen < 80 || 8 * keylen > 2048) {
-        TRACE_ERROR("HMAC key size of %lu bits not within"
-                    " CCA required range of 80-2048 bits\n", 8 * keylen);
+    keylen = value_attr->ulValueLen;
+    keybitlen = 8 * keylen;
+
+    /* key bit length needs to be 80-2048 bits */
+    if (keybitlen < 80 || keybitlen > 2048) {
+        TRACE_ERROR("HMAC key bit size of %lu not within CCA range (80-2048 bits)\n", keybitlen);
         return CKR_KEY_SIZE_RANGE;
     }
 
-    memcpy(rule_array, "INTERNALNO-KEY  HMAC    MAC     GENERATE",
-           5 * CCA_KEYWORD_SIZE);
-    rule_array_count = 5;
+    rc = template_attribute_find(object->template, CKA_IBM_OPAQUE, &opaque_attr);
+    if (rc == TRUE) {
+        /*
+         * This is an import of an existing secure key which is stored in
+         * the CKA_IBM_OPAQUE attribute. The CKA_VALUE attribute is only
+         * a dummy reflecting the clear key byte size. However, let's
+         * check if the template attributes match to the cca key in the
+         * CKA_IBM_OPAQUE attribute.
+         */
 
-    dll_CSNBKTB2(&return_code, &reason_code, NULL, NULL, &rule_array_count,
-                 rule_array, &clr_key_len, NULL, &key_name_len, NULL,
-                 &user_data_len, NULL, &token_data_len, NULL, &verb_data_len,
-                 NULL, &key_token_len, key_token);
-    if (return_code != CCA_SUCCESS) {
-        TRACE_ERROR("CSNBKTB2 (HMAC KEY TOKEN BUILD) failed."
-                    " return:%ld, reason:%ld\n", return_code, reason_code);
-        return CKR_FUNCTION_FAILED;
-    }
+        enum cca_token_type token_type;
+        unsigned int token_payloadbitsize, plbitsize;
 
-    memcpy(rule_array, "HMAC    FIRST   MIN1PART", 3 * CCA_KEYWORD_SIZE);
-    rule_array_count = 3;
-    key_part_len = keylen * 8;
-    key_token_len = sizeof(key_token);
+        if (analyse_cca_key_token(opaque_attr->pValue, opaque_attr->ulValueLen,
+                                  &token_type, &token_payloadbitsize) != TRUE) {
+            TRACE_ERROR("Invalid/unknown cca token in CKA_IBM_OPAQUE attribute\n");
+            return CKR_ATTRIBUTE_VALUE_INVALID;
+        }
 
-    dll_CSNBKPI2(&return_code, &reason_code, NULL, NULL, &rule_array_count,
-                 rule_array, &key_part_len, attr->pValue, &key_token_len,
-                 key_token);
-    if (return_code != CCA_SUCCESS) {
-        TRACE_ERROR("CSNBKPI2 (HMAC KEY IMPORT FIRST) failed."
-                    " return:%ld, reason:%ld\n", return_code, reason_code);
-        return CKR_FUNCTION_FAILED;
-    }
+        if (token_type != sec_hmac_key) {
+            TRACE_ERROR("CCA token type in CKA_IBM_OPAQUE does not match to"
+                        " keytype CKK_GENERIC_SECRET\n");
+            return CKR_TEMPLATE_INCONSISTENT;
+        }
 
-    memcpy(rule_array, "HMAC    COMPLETE", 2 * CCA_KEYWORD_SIZE);
-    rule_array_count = 2;
-    key_part_len = 0;
-    key_token_len = sizeof(key_token);
+        /* calculate expected payload size from the given keybitlen */
+        plbitsize = (((keybitlen + 32) + 63) & (~63)) + 320;
+        /* and check with the payload size within the cca hmac token */
+        if (plbitsize != token_payloadbitsize) {
+            TRACE_ERROR("CCA HMAC token payload size and keysize do not match\n");
+            return CKR_TEMPLATE_INCONSISTENT;
+        }
 
-    dll_CSNBKPI2(&return_code, &reason_code, NULL, NULL, &rule_array_count,
-                 rule_array, &key_part_len, NULL, &key_token_len, key_token);
-    if (return_code != CCA_SUCCESS) {
-        TRACE_ERROR("CSNBKPI2 (HMAC KEY IMPORT COMPLETE) failed."
-                    " return:%ld, reason:%ld\n", return_code, reason_code);
-        return CKR_FUNCTION_FAILED;
-    }
+    } else {
+        /*
+         * This is an import of a clear key value which is to be transfered
+         * into a CCA HMAC key now.
+         */
 
-    /* Add the key object to the template */
-    if ((rc = build_attribute(CKA_IBM_OPAQUE, key_token, key_token_len,
-                              &opaque_key))) {
-        TRACE_DEVEL("build_attribute(CKA_IBM_OPAQUE) failed\n");
-        return rc;
-    }
-    rc = template_update_attribute(object->template, opaque_key);
-    if (rc != CKR_OK) {
-        TRACE_DEVEL("template_update_attribute(CKA_IBM_OPAQUE) failed\n");
-        return rc;
+        long return_code, reason_code, rule_array_count;
+        unsigned char key_token[CCA_KEY_TOKEN_SIZE] = { 0 };
+        unsigned char rule_array[CCA_RULE_ARRAY_SIZE] = { 0 };
+        long key_name_len = 0, clr_key_len = 0;
+        long user_data_len = 0, key_part_len = 0;
+        long token_data_len = 0, verb_data_len = 0;
+        long key_token_len = sizeof(key_token);
+
+        memcpy(rule_array, "INTERNALNO-KEY  HMAC    MAC     GENERATE",
+               5 * CCA_KEYWORD_SIZE);
+        rule_array_count = 5;
+
+        dll_CSNBKTB2(&return_code, &reason_code, NULL, NULL, &rule_array_count,
+                     rule_array, &clr_key_len, NULL, &key_name_len, NULL,
+                     &user_data_len, NULL, &token_data_len, NULL, &verb_data_len,
+                     NULL, &key_token_len, key_token);
+        if (return_code != CCA_SUCCESS) {
+            TRACE_ERROR("CSNBKTB2 (HMAC KEY TOKEN BUILD) failed."
+                        " return:%ld, reason:%ld\n", return_code, reason_code);
+            return CKR_FUNCTION_FAILED;
+        }
+
+        memcpy(rule_array, "HMAC    FIRST   MIN1PART", 3 * CCA_KEYWORD_SIZE);
+        rule_array_count = 3;
+        key_part_len = keylen * 8;
+        key_token_len = sizeof(key_token);
+
+        dll_CSNBKPI2(&return_code, &reason_code, NULL, NULL, &rule_array_count,
+                     rule_array, &key_part_len, value_attr->pValue,
+                     &key_token_len, key_token);
+        if (return_code != CCA_SUCCESS) {
+            TRACE_ERROR("CSNBKPI2 (HMAC KEY IMPORT FIRST) failed."
+                        " return:%ld, reason:%ld\n", return_code, reason_code);
+            return CKR_FUNCTION_FAILED;
+        }
+
+        memcpy(rule_array, "HMAC    COMPLETE", 2 * CCA_KEYWORD_SIZE);
+        rule_array_count = 2;
+        key_part_len = 0;
+        key_token_len = sizeof(key_token);
+
+        dll_CSNBKPI2(&return_code, &reason_code, NULL, NULL, &rule_array_count,
+                     rule_array, &key_part_len, NULL, &key_token_len, key_token);
+        if (return_code != CCA_SUCCESS) {
+            TRACE_ERROR("CSNBKPI2 (HMAC KEY IMPORT COMPLETE) failed."
+                        " return:%ld, reason:%ld\n", return_code, reason_code);
+            return CKR_FUNCTION_FAILED;
+        }
+
+        /* Add the key object to the template */
+        if ((rc = build_update_attribute(object->template, CKA_IBM_OPAQUE,
+                                         key_token, key_token_len))) {
+            TRACE_DEVEL("build_update_attribute(CKA_IBM_OPAQUE) failed\n");
+            return rc;
+        }
     }
 
     /* zero clear key value */
-    OPENSSL_cleanse(attr->pValue, attr->ulValueLen);
+    OPENSSL_cleanse(value_attr->pValue, value_attr->ulValueLen);
+
+#ifdef DEBUG
+    TRACE_DEBUG("%s: imported object template attributes:\n", __func__);
+    dump_template(object->template);
+#endif
 
     return CKR_OK;
 }
@@ -3940,220 +4586,438 @@ static CK_RV build_public_EC_key_value_structure(CK_BYTE *pubkey, CK_ULONG puble
     return CKR_OK;
 }
 
-static CK_RV ec_import_privkey(TEMPLATE *priv_templ)
+/* helper function, check cca ec type, keybits and add the CKA_EC_PARAMS attribute */
+static CK_RV check_cca_ec_type_and_add_params(uint8_t cca_ec_type,
+                                              uint16_t cca_ec_bits,
+                                              TEMPLATE *templ)
 {
-    long private_key_name_length, key_token_length, target_key_token_length;
-    long return_code, reason_code, rule_array_count, exit_data_len = 0;
-    long key_value_structure_length, param1=0;
-    unsigned char rule_array[CCA_RULE_ARRAY_SIZE] = { 0, };
-    unsigned char key_value_structure[CCA_KEY_VALUE_STRUCT_SIZE] = { 0, };
-    unsigned char private_key_name[CCA_PRIVATE_KEY_NAME_SIZE] = { 0, };
-    unsigned char key_token[CCA_KEY_TOKEN_SIZE] = { 0, };
-    unsigned char transport_key_identifier[CCA_KEY_ID_SIZE] = { 0, };
-    unsigned char target_key_token[CCA_KEY_TOKEN_SIZE] = { 0, };
-    unsigned char *exit_data = NULL;
-    unsigned char *param2=NULL;
-    CK_BYTE *privkey = NULL, *pubkey = NULL;
-    CK_ATTRIBUTE *attr = NULL, *opaque_key;
-    CK_ULONG privlen = 0, publen = 0;
     CK_RV rc;
-    uint8_t curve_type;
-    uint16_t curve_bitlen;
-    CK_ULONG field_len;
 
-    /* Check if curve supported and determine curve type and bitlen */
-    rc = curve_supported(priv_templ, &curve_type, &curve_bitlen);
-    if (rc != CKR_OK) {
-        TRACE_ERROR("Curve not supported by this token.\n");
-        return rc;
-    }
-
-    /* Find private key data in template */
-    rc = template_attribute_find(priv_templ, CKA_VALUE, &attr);
-    if (rc == FALSE) {
-        TRACE_ERROR("%s\n", ock_err(ERR_TEMPLATE_INCOMPLETE));
-        return CKR_TEMPLATE_INCOMPLETE;
-    }
-
-    privlen = attr->ulValueLen;
-    privkey = attr->pValue;
-
-    /* Find public key data as BER encoded OCTET STRING in template */
-    rc = template_attribute_find(priv_templ, CKA_EC_POINT, &attr);
-    if (rc == FALSE) {
-        TRACE_ERROR("%s\n", ock_err(ERR_TEMPLATE_INCOMPLETE));
-        return CKR_TEMPLATE_INCOMPLETE;
-    }
-
-    rc = ber_decode_OCTET_STRING(attr->pValue, &pubkey, &publen,
-                                 &field_len);
-    if (rc != CKR_OK || attr->ulValueLen != field_len) {
-        TRACE_DEVEL("ber decoding of public key failed\n");
+    switch (cca_ec_type) {
+    case 0x00: /* Prime curve */
+        switch (cca_ec_bits) {
+        case 192:
+            {
+                CK_BYTE curve[] = OCK_PRIME192V1;
+                rc = build_update_attribute(templ, CKA_EC_PARAMS, curve, sizeof(curve));
+            }
+            break;
+        case 224:
+            {
+                CK_BYTE curve[] = OCK_SECP224R1;
+                rc = build_update_attribute(templ, CKA_EC_PARAMS, curve, sizeof(curve));
+            }
+            break;
+        case 256:
+            {
+                CK_BYTE curve[] = OCK_PRIME256V1;
+                rc = build_update_attribute(templ, CKA_EC_PARAMS, curve, sizeof(curve));
+            }
+            break;
+        case 384:
+            {
+                CK_BYTE curve[] = OCK_SECP384R1;
+                rc = build_update_attribute(templ, CKA_EC_PARAMS, curve, sizeof(curve));
+            }
+            break;
+        case 521:
+            {
+                CK_BYTE curve[] = OCK_SECP521R1;
+                rc = build_update_attribute(templ, CKA_EC_PARAMS, curve, sizeof(curve));
+            }
+            break;
+        default:
+            TRACE_ERROR("CCA token type with unknown prime curve bits %hu\n", cca_ec_bits);
+            return CKR_ATTRIBUTE_VALUE_INVALID;
+        }
+        break;
+    case 0x01: /* Brainpool curve */
+        switch (cca_ec_bits) {
+        case 160:
+            {
+                CK_BYTE curve[] = OCK_BRAINPOOL_P160R1;
+                rc = build_update_attribute(templ, CKA_EC_PARAMS, curve, sizeof(curve));
+            }
+            break;
+        case 192:
+            {
+                CK_BYTE curve[] = OCK_BRAINPOOL_P192R1;
+                rc = build_update_attribute(templ, CKA_EC_PARAMS, curve, sizeof(curve));
+            }
+            break;
+        case 224:
+            {
+                CK_BYTE curve[] = OCK_BRAINPOOL_P224R1;
+                rc = build_update_attribute(templ, CKA_EC_PARAMS, curve, sizeof(curve));
+            }
+            break;
+        case 256:
+            {
+                CK_BYTE curve[] = OCK_BRAINPOOL_P256R1;
+                rc = build_update_attribute(templ, CKA_EC_PARAMS, curve, sizeof(curve));
+            }
+            break;
+        case 320:
+            {
+                CK_BYTE curve[] = OCK_BRAINPOOL_P320R1;
+                rc = build_update_attribute(templ, CKA_EC_PARAMS, curve, sizeof(curve));
+            }
+            break;
+        case 384:
+            {
+                CK_BYTE curve[] = OCK_BRAINPOOL_P384R1;
+                rc = build_update_attribute(templ, CKA_EC_PARAMS, curve, sizeof(curve));
+            }
+            break;
+        case 512:
+            {
+                CK_BYTE curve[] = OCK_BRAINPOOL_P512R1;
+                rc = build_update_attribute(templ, CKA_EC_PARAMS, curve, sizeof(curve));
+            }
+            break;
+        default:
+            TRACE_ERROR("CCA token type with unknown brainpool curve bits %hu\n", cca_ec_bits);
+            return CKR_ATTRIBUTE_VALUE_INVALID;
+        }
+        break;
+    case 0x02: /* Edwards curve */
+        switch (cca_ec_bits) {
+        case 255:
+            {
+                CK_BYTE curve[] = OCK_ED25519;
+                rc = build_update_attribute(templ, CKA_EC_PARAMS, curve, sizeof(curve));
+            }
+            break;
+        case 448:
+            {
+                CK_BYTE curve[] = OCK_ED448;
+                rc = build_update_attribute(templ, CKA_EC_PARAMS, curve, sizeof(curve));
+            }
+            break;
+        default:
+            TRACE_ERROR("CCA token type with unknown edwards curve bits %hu\n", cca_ec_bits);
+            return CKR_ATTRIBUTE_VALUE_INVALID;
+        }
+        break;
+    default:
+        TRACE_ERROR("CCA token type with invalid/unknown curve type %hhu\n", cca_ec_type);
         return CKR_ATTRIBUTE_VALUE_INVALID;
     }
 
-    /* Build key_value_structure */
-    memset(key_value_structure, 0, CCA_KEY_VALUE_STRUCT_SIZE);
-
-    rc = build_private_EC_key_value_structure(privkey, privlen,
-            pubkey, publen, curve_type, curve_bitlen,
-            (unsigned char *)&key_value_structure,
-            &key_value_structure_length);
-    if (rc != CKR_OK)
-        return rc;
-
-    /* Build key token */
-    rule_array_count = 1;
-    memcpy(rule_array, "ECC-PAIR", (size_t)(CCA_KEYWORD_SIZE));
-    private_key_name_length = 0;
-    key_token_length = CCA_KEY_TOKEN_SIZE;
-    key_value_structure_length = CCA_KEY_VALUE_STRUCT_SIZE;
-
-    dll_CSNDPKB(&return_code, &reason_code,
-            &exit_data_len, exit_data,
-            &rule_array_count, rule_array,
-            &key_value_structure_length, key_value_structure,
-            &private_key_name_length, private_key_name,
-            &param1, param2, &param1, param2, &param1, param2,
-            &param1, param2, &param1, param2,
-            &key_token_length,
-            key_token);
-
-    if (return_code != CCA_SUCCESS) {
-        TRACE_ERROR("CSNDPKB (EC KEY TOKEN BUILD) failed. return:%ld,"
-                " reason:%ld\n", return_code, reason_code);
-        if (is_curve_error(return_code, reason_code))
-            return CKR_CURVE_NOT_SUPPORTED;
-        return CKR_FUNCTION_FAILED;
-    }
-
-    /* Now import the PKA key token */
-    rule_array_count = 1;
-    memcpy(rule_array, "ECC     ", (size_t)(CCA_KEYWORD_SIZE));
-    key_token_length = CCA_KEY_TOKEN_SIZE;
-    target_key_token_length = CCA_KEY_TOKEN_SIZE;
-
-    dll_CSNDPKI(&return_code, &reason_code, NULL, NULL,
-            &rule_array_count, rule_array,
-            &key_token_length, key_token,
-            transport_key_identifier,
-            &target_key_token_length, target_key_token);
-
-    if (return_code != CCA_SUCCESS) {
-        TRACE_ERROR("CSNDPKI (EC KEY TOKEN IMPORT) failed." " return:%ld, reason:%ld\n",
-                return_code, reason_code);
-        if (is_curve_error(return_code, reason_code))
-            return CKR_CURVE_NOT_SUPPORTED;
-        return CKR_FUNCTION_FAILED;
-    }
-
-    /* Add key token to template as CKA_IBM_OPAQUE */
-    if ((rc = build_attribute(CKA_IBM_OPAQUE, target_key_token,
-                        target_key_token_length, &opaque_key))) {
-        TRACE_DEVEL("build_attribute(CKA_IBM_OPAQUE) failed\n");
-        return rc;
-    }
-
-    rc = template_update_attribute(priv_templ, opaque_key);
     if (rc != CKR_OK) {
-        TRACE_DEVEL("template_update_attribute(CKA_IBM_OPAQUE) failed\n");
+        TRACE_DEVEL("build_update_attribute(CKA_EC_PARAMS) failed\n");
         return rc;
     }
-
-    /* zero clear key values */
-    OPENSSL_cleanse(privkey, privlen);
 
     return CKR_OK;
 }
 
-static CK_RV ec_import_pubkey(TEMPLATE *pub_templ)
+static CK_RV import_ec_privkey(TEMPLATE *priv_templ)
 {
     CK_RV rc;
-    long return_code, reason_code, rule_array_count, exit_data_len = 0;
-    long private_key_name_length, key_token_length;
-    unsigned char *exit_data = NULL;
-    unsigned char rule_array[CCA_RULE_ARRAY_SIZE] = { 0, };
-    long key_value_structure_length;
-    unsigned char key_value_structure[CCA_KEY_VALUE_STRUCT_SIZE] = { 0, };
-    unsigned char private_key_name[CCA_PRIVATE_KEY_NAME_SIZE] = { 0, };
-    unsigned char key_token[CCA_KEY_TOKEN_SIZE] = { 0, };
-    CK_ATTRIBUTE *opaque_key;
-    long param1=0;
-    unsigned char *param2=NULL;
-    uint8_t curve_type;
-    uint16_t curve_bitlen;
-    CK_BYTE *pubkey = NULL;
-    CK_ULONG publen = 0;
-    CK_ATTRIBUTE *attr = NULL;
-    CK_ULONG field_len;
+    CK_ATTRIBUTE *opaque_attr = NULL;
 
-    /* Check if curve supported and determine curve type and bitlen */
-    rc = curve_supported(pub_templ, &curve_type, &curve_bitlen);
-    if (rc != CKR_OK) {
-        TRACE_ERROR("Curve not supported by this token.\n");
-        return rc;
+    rc = template_attribute_find(priv_templ, CKA_IBM_OPAQUE, &opaque_attr);
+    if (rc == TRUE) {
+        /*
+         * This is an import of an existing secure ecc private key which
+         * is stored in the CKA_IBM_OPAQUE attribute.
+         */
+        enum cca_token_type token_type;
+        unsigned int token_keybitsize;
+        CK_BYTE *t;
+
+        if (analyse_cca_key_token(opaque_attr->pValue, opaque_attr->ulValueLen,
+                                  &token_type, &token_keybitsize) != TRUE) {
+            TRACE_ERROR("Invalid/unknown cca token in CKA_IBM_OPAQUE attribute\n");
+            return CKR_ATTRIBUTE_VALUE_INVALID;
+        }
+        if (token_type != sec_ecc_priv_key) {
+            TRACE_ERROR("CCA token type in CKA_IBM_OPAQUE does not match to keytype CKK_EC\n");
+            return CKR_TEMPLATE_INCONSISTENT;
+        }
+
+        /* check curve and add CKA_EC_PARAMS attribute */
+        t = opaque_attr->pValue;
+        rc = check_cca_ec_type_and_add_params(t[8+9], token_keybitsize, priv_templ);
+        if (rc != CKR_OK)
+            return rc;
+
+    } else {
+        /*
+         * This is an import of a clear ecc private key which is to be transfered
+         * into a CCA ECC private key.
+         */
+
+        long private_key_name_length, key_token_length, target_key_token_length;
+        long return_code, reason_code, rule_array_count, exit_data_len = 0;
+        long key_value_structure_length, param1=0;
+        unsigned char rule_array[CCA_RULE_ARRAY_SIZE] = { 0, };
+        unsigned char key_value_structure[CCA_KEY_VALUE_STRUCT_SIZE] = { 0, };
+        unsigned char private_key_name[CCA_PRIVATE_KEY_NAME_SIZE] = { 0, };
+        unsigned char key_token[CCA_KEY_TOKEN_SIZE] = { 0, };
+        unsigned char transport_key_identifier[CCA_KEY_ID_SIZE] = { 0, };
+        unsigned char target_key_token[CCA_KEY_TOKEN_SIZE] = { 0, };
+        unsigned char *exit_data = NULL;
+        unsigned char *param2=NULL;
+        CK_BYTE *privkey = NULL, *pubkey = NULL;
+        CK_ATTRIBUTE *attr = NULL;
+        CK_ULONG privlen = 0, publen = 0;
+        uint8_t curve_type;
+        uint16_t curve_bitlen;
+        CK_ULONG field_len;
+
+        /* Check if curve supported and determine curve type and bitlen */
+        rc = curve_supported(priv_templ, &curve_type, &curve_bitlen);
+        if (rc != CKR_OK) {
+            TRACE_ERROR("Curve not supported by this token.\n");
+            return rc;
+        }
+
+        /* Find private key data in template */
+        rc = template_attribute_find(priv_templ, CKA_VALUE, &attr);
+        if (rc == FALSE) {
+            TRACE_ERROR("%s\n", ock_err(ERR_TEMPLATE_INCOMPLETE));
+            return CKR_TEMPLATE_INCOMPLETE;
+        }
+
+        privlen = attr->ulValueLen;
+        privkey = attr->pValue;
+
+        /* Find public key data as BER encoded OCTET STRING in template */
+        rc = template_attribute_find(priv_templ, CKA_EC_POINT, &attr);
+        if (rc == FALSE) {
+            TRACE_ERROR("%s\n", ock_err(ERR_TEMPLATE_INCOMPLETE));
+            return CKR_TEMPLATE_INCOMPLETE;
+        }
+
+        rc = ber_decode_OCTET_STRING(attr->pValue, &pubkey, &publen,
+                                     &field_len);
+        if (rc != CKR_OK || attr->ulValueLen != field_len) {
+            TRACE_DEVEL("ber decoding of public key failed\n");
+            return CKR_ATTRIBUTE_VALUE_INVALID;
+        }
+
+        /* Build key_value_structure */
+        memset(key_value_structure, 0, CCA_KEY_VALUE_STRUCT_SIZE);
+
+        rc = build_private_EC_key_value_structure(privkey, privlen,
+                                                  pubkey, publen,
+                                                  curve_type, curve_bitlen,
+                                                  (unsigned char *)&key_value_structure,
+                                                  &key_value_structure_length);
+        if (rc != CKR_OK)
+            return rc;
+
+        /* Build key token */
+        rule_array_count = 1;
+        memcpy(rule_array, "ECC-PAIR", (size_t)(CCA_KEYWORD_SIZE));
+        private_key_name_length = 0;
+        key_token_length = CCA_KEY_TOKEN_SIZE;
+        key_value_structure_length = CCA_KEY_VALUE_STRUCT_SIZE;
+
+        dll_CSNDPKB(&return_code, &reason_code,
+                    &exit_data_len, exit_data,
+                    &rule_array_count, rule_array,
+                    &key_value_structure_length, key_value_structure,
+                    &private_key_name_length, private_key_name,
+                    &param1, param2, &param1, param2, &param1, param2,
+                    &param1, param2, &param1, param2,
+                    &key_token_length,
+                    key_token);
+
+        if (return_code != CCA_SUCCESS) {
+            TRACE_ERROR("CSNDPKB (EC KEY TOKEN BUILD) failed. return:%ld,"
+                        " reason:%ld\n", return_code, reason_code);
+            if (is_curve_error(return_code, reason_code))
+                return CKR_CURVE_NOT_SUPPORTED;
+            return CKR_FUNCTION_FAILED;
+        }
+
+        /* Now import the PKA key token */
+        rule_array_count = 1;
+        memcpy(rule_array, "ECC     ", (size_t)(CCA_KEYWORD_SIZE));
+        key_token_length = CCA_KEY_TOKEN_SIZE;
+        target_key_token_length = CCA_KEY_TOKEN_SIZE;
+
+        dll_CSNDPKI(&return_code, &reason_code, NULL, NULL,
+                    &rule_array_count, rule_array,
+                    &key_token_length, key_token,
+                    transport_key_identifier,
+                    &target_key_token_length, target_key_token);
+
+        if (return_code != CCA_SUCCESS) {
+            TRACE_ERROR("CSNDPKI (EC KEY TOKEN IMPORT) failed." " return:%ld, reason:%ld\n",
+                        return_code, reason_code);
+            if (is_curve_error(return_code, reason_code))
+                return CKR_CURVE_NOT_SUPPORTED;
+            return CKR_FUNCTION_FAILED;
+        }
+
+        /* Add key token to template as CKA_IBM_OPAQUE */
+        if ((rc = build_update_attribute(priv_templ, CKA_IBM_OPAQUE,
+                                         target_key_token, target_key_token_length))) {
+            TRACE_DEVEL("build_update_attribute(CKA_IBM_OPAQUE) failed\n");
+            return rc;
+        }
+
+        /* zero clear key values */
+        OPENSSL_cleanse(privkey, privlen);
     }
 
-    /* Find public key data as BER encoded OCTET STRING in template */
-    rc = template_attribute_find(pub_templ, CKA_EC_POINT, &attr);
-    if (rc == FALSE) {
-        TRACE_ERROR("%s\n", ock_err(ERR_TEMPLATE_INCOMPLETE));
-        return CKR_TEMPLATE_INCOMPLETE;
+#ifdef DEBUG
+    TRACE_DEBUG("%s: imported object template attributes:\n", __func__);
+    dump_template(priv_templ);
+#endif
+
+    return CKR_OK;
+}
+
+static CK_RV import_ec_pubkey(TEMPLATE *pub_templ)
+{
+    CK_RV rc;
+    CK_ATTRIBUTE *opaque_attr = NULL;
+
+    rc = template_attribute_find(pub_templ, CKA_IBM_OPAQUE, &opaque_attr);
+    if (rc == TRUE) {
+        /*
+         * This is an import of an existing secure ecc public key which
+         * is stored in the CKA_IBM_OPAQUE attribute.
+         */
+        enum cca_token_type token_type;
+        unsigned int token_keybitsize;
+        CK_BYTE *t, *q;
+        uint16_t q_len;
+        CK_BYTE *ecpoint = NULL;
+        CK_ULONG ecpoint_len;
+
+        if (analyse_cca_key_token(opaque_attr->pValue, opaque_attr->ulValueLen,
+                                  &token_type, &token_keybitsize) != TRUE) {
+            TRACE_ERROR("Invalid/unknown cca token in CKA_IBM_OPAQUE attribute\n");
+            return CKR_ATTRIBUTE_VALUE_INVALID;
+        }
+        if (token_type != sec_ecc_publ_key) {
+            TRACE_ERROR("CCA token type in CKA_IBM_OPAQUE does not match to keytype CKK_EC\n");
+            return CKR_TEMPLATE_INCONSISTENT;
+        }
+
+        /* check curve and add CKA_EC_PARAMS attribute */
+        t = opaque_attr->pValue;
+        rc = check_cca_ec_type_and_add_params(t[8+8], token_keybitsize, pub_templ);
+        if (rc != CKR_OK)
+            return rc;
+
+        /* we need to add the CKA_EC_POINT attribute */
+        q = (CK_BYTE *)(t + 8 + 14);
+        q_len = ntohs(*((uint16_t *)(t + 8 + 12)));
+        if (q_len > CCATOK_EC_MAX_Q_LEN) {
+            TRACE_ERROR("Invalid Q len %hu\n", q_len);
+            return CKR_ATTRIBUTE_VALUE_INVALID;
+        }
+        rc = ber_encode_OCTET_STRING(FALSE, &ecpoint, &ecpoint_len, q, q_len);
+        if (rc != CKR_OK) {
+            TRACE_DEVEL("ber_encode_OCTET_STRING failed\n");
+            return rc;
+        }
+        rc = build_update_attribute(pub_templ, CKA_EC_POINT, ecpoint, ecpoint_len);
+        free(ecpoint);
+        if (rc != CKR_OK) {
+            TRACE_DEVEL("build_update_attribute(CKA_EC_POINT) failed\n");
+            return rc;
+        }
+
+    } else {
+        /*
+         * This is an import of a clear ecc public key which is to be transfered
+         * into a CCA ECC public key.
+         */
+
+        long return_code, reason_code, rule_array_count, exit_data_len = 0;
+        long private_key_name_length, key_token_length;
+        unsigned char *exit_data = NULL;
+        unsigned char rule_array[CCA_RULE_ARRAY_SIZE] = { 0, };
+        long key_value_structure_length;
+        unsigned char key_value_structure[CCA_KEY_VALUE_STRUCT_SIZE] = { 0, };
+        unsigned char private_key_name[CCA_PRIVATE_KEY_NAME_SIZE] = { 0, };
+        unsigned char key_token[CCA_KEY_TOKEN_SIZE] = { 0, };
+        long param1=0;
+        unsigned char *param2=NULL;
+        uint8_t curve_type;
+        uint16_t curve_bitlen;
+        CK_BYTE *pubkey = NULL;
+        CK_ULONG publen = 0;
+        CK_ATTRIBUTE *attr = NULL;
+        CK_ULONG field_len;
+
+        /* Check if curve supported and determine curve type and bitlen */
+        rc = curve_supported(pub_templ, &curve_type, &curve_bitlen);
+        if (rc != CKR_OK) {
+            TRACE_ERROR("Curve not supported by this token.\n");
+            return rc;
+        }
+
+        /* Find public key data as BER encoded OCTET STRING in template */
+        rc = template_attribute_find(pub_templ, CKA_EC_POINT, &attr);
+        if (rc == FALSE) {
+            TRACE_ERROR("%s\n", ock_err(ERR_TEMPLATE_INCOMPLETE));
+            return CKR_TEMPLATE_INCOMPLETE;
+        }
+
+        rc = ber_decode_OCTET_STRING(attr->pValue, &pubkey, &publen,
+                                     &field_len);
+        if (rc != CKR_OK || attr->ulValueLen != field_len) {
+            TRACE_DEVEL("ber decoding of public key failed\n");
+            return CKR_ATTRIBUTE_VALUE_INVALID;
+        }
+
+        /* Build key_value_structure */
+        memset(key_value_structure, 0, CCA_KEY_VALUE_STRUCT_SIZE);
+
+        rc = build_public_EC_key_value_structure(pubkey, publen,
+                                                 curve_type, curve_bitlen,
+                                                 (unsigned char *)&key_value_structure,
+                                                 &key_value_structure_length);
+        if (rc != CKR_OK)
+            return rc;
+
+        /* Build public key token */
+        rule_array_count = 1;
+        memcpy(rule_array, "ECC-PUBL", (size_t)(CCA_KEYWORD_SIZE));
+        private_key_name_length = 0;
+        key_token_length = CCA_KEY_TOKEN_SIZE;
+        key_value_structure_length = CCA_KEY_VALUE_STRUCT_SIZE;
+
+        dll_CSNDPKB(&return_code, &reason_code,
+                    &exit_data_len, exit_data,
+                    &rule_array_count, rule_array,
+                    &key_value_structure_length, key_value_structure,
+                    &private_key_name_length, private_key_name,
+                    &param1, param2, &param1, param2, &param1, param2,
+                    &param1, param2, &param1, param2,
+                    &key_token_length,
+                    key_token);
+
+        if (return_code != CCA_SUCCESS) {
+            TRACE_ERROR("CSNDPKB (EC KEY TOKEN BUILD) failed. return:%ld,"
+                        " reason:%ld\n", return_code, reason_code);
+            if (is_curve_error(return_code, reason_code))
+                return CKR_CURVE_NOT_SUPPORTED;
+            return CKR_FUNCTION_FAILED;
+        }
+
+        /* Public keys do not need to be wrapped, so just add public
+           key token to template as CKA_IBM_OPAQUE */
+        if ((rc = build_update_attribute(pub_templ, CKA_IBM_OPAQUE,
+                                         key_token, key_token_length))) {
+            TRACE_DEVEL("build_update_attribute(CKA_IBM_OPAQUE) failed\n");
+            return rc;
+        }
     }
 
-    rc = ber_decode_OCTET_STRING(attr->pValue, &pubkey, &publen,
-                                 &field_len);
-    if (rc != CKR_OK || attr->ulValueLen != field_len) {
-        TRACE_DEVEL("ber decoding of public key failed\n");
-        return CKR_ATTRIBUTE_VALUE_INVALID;
-    }
-
-    /* Build key_value_structure */
-    memset(key_value_structure, 0, CCA_KEY_VALUE_STRUCT_SIZE);
-
-    rc = build_public_EC_key_value_structure(pubkey, publen,
-            curve_type, curve_bitlen,
-            (unsigned char *)&key_value_structure,
-            &key_value_structure_length);
-    if (rc != CKR_OK)
-        return rc;
-
-    /* Build public key token */
-    rule_array_count = 1;
-    memcpy(rule_array, "ECC-PUBL", (size_t)(CCA_KEYWORD_SIZE));
-    private_key_name_length = 0;
-    key_token_length = CCA_KEY_TOKEN_SIZE;
-    key_value_structure_length = CCA_KEY_VALUE_STRUCT_SIZE;
-
-    dll_CSNDPKB(&return_code, &reason_code,
-            &exit_data_len, exit_data,
-            &rule_array_count, rule_array,
-            &key_value_structure_length, key_value_structure,
-            &private_key_name_length, private_key_name,
-            &param1, param2, &param1, param2, &param1, param2,
-            &param1, param2, &param1, param2,
-            &key_token_length,
-            key_token);
-
-    if (return_code != CCA_SUCCESS) {
-        TRACE_ERROR("CSNDPKB (EC KEY TOKEN BUILD) failed. return:%ld,"
-                " reason:%ld\n", return_code, reason_code);
-        if (is_curve_error(return_code, reason_code))
-            return CKR_CURVE_NOT_SUPPORTED;
-        return CKR_FUNCTION_FAILED;
-    }
-
-    /* Public keys do not need to be wrapped, so just add public
-       key token to template as CKA_IBM_OPAQUE */
-    if ((rc = build_attribute(CKA_IBM_OPAQUE, key_token, key_token_length, &opaque_key))) {
-        TRACE_DEVEL("build_attribute(CKA_IBM_OPAQUE) failed\n");
-        return rc;
-    }
-    rc = template_update_attribute(pub_templ, opaque_key);
-    if (rc != CKR_OK) {
-        TRACE_DEVEL("template_update_attribute(CKA_IBM_OPAQUE) failed\n");
-        return rc;
-    }
+#ifdef DEBUG
+    TRACE_DEBUG("%s: imported object template attributes:\n", __func__);
+    dump_template(pub_templ);
+#endif
 
     return CKR_OK;
 }
@@ -4173,52 +5037,59 @@ CK_RV token_specific_object_add(STDLL_TokData_t *tokdata, SESSION *sess, OBJECT 
         return CKR_FUNCTION_FAILED;
     }
 
+    /* CKA_CLASS is mandatory */
+    rc = template_attribute_find(object->template, CKA_CLASS, &attr);
+    if (rc == FALSE) {
+        TRACE_ERROR("%s\n", ock_err(ERR_TEMPLATE_INCOMPLETE));
+        return CKR_TEMPLATE_INCOMPLETE;
+    }
+    keyclass = *(CK_OBJECT_CLASS *)attr->pValue;
+
+    /* we only care about key objects here */
     rc = template_attribute_find(object->template, CKA_KEY_TYPE, &attr);
     if (rc == FALSE) {
         // not a key, so nothing to do. Just return.
         TRACE_DEVEL("object not a key, no need to import.\n");
         return CKR_OK;
     }
-
     keytype = *(CK_KEY_TYPE *)attr->pValue;
+
+    /* fetch CKA_VALUE if available */
+    attr = NULL;
+    template_attribute_find(object->template, CKA_VALUE, &attr);
 
     switch (keytype) {
     case CKK_RSA:
-        rc = template_attribute_find(object->template, CKA_CLASS, &attr);
-        if (rc == FALSE) {
-            TRACE_ERROR("%s\n", ock_err(ERR_TEMPLATE_INCOMPLETE));
-            return CKR_TEMPLATE_INCOMPLETE;
-        }
-
-        keyclass = *(CK_OBJECT_CLASS *)attr->pValue;
-
         switch(keyclass) {
         case CKO_PUBLIC_KEY:
             // do import public key and create opaque object
-            rc = rsa_import_pubkey(object->template);
+            rc = import_rsa_pubkey(object->template);
+            if (rc != CKR_OK) {
+                TRACE_DEVEL("RSA public key import failed, rc=0x%lx\n", rc);
+                return rc;
+            }
+            TRACE_INFO("RSA public key imported\n");
             break;
         case CKO_PRIVATE_KEY:
             // do import keypair and create opaque object
-            rc = rsa_import_privkey_crt(object->template);
+            rc = import_rsa_privkey(object->template);
+            if (rc != CKR_OK) {
+                TRACE_DEVEL("RSA private key import failed, rc=0x%lx\n", rc);
+                return rc;
+            }
+            TRACE_INFO("RSA private key imported\n");
             break;
         default:
             TRACE_ERROR("%s\n", ock_err(ERR_KEY_TYPE_INCONSISTENT));
             return CKR_KEY_TYPE_INCONSISTENT;
         }
-
-        if (rc != CKR_OK) {
-            TRACE_DEVEL("rsa import failed\n");
-            return rc;
-        }
-
         break;
     case CKK_AES:
     case CKK_DES:
     case CKK_DES3:
         rc = import_symmetric_key(object, keytype);
         if (rc != CKR_OK) {
-            TRACE_DEVEL("Symmetric key import failed, rc=0x%lx\n",
-                        rc);
+            TRACE_DEVEL("Symmetric key import failed, rc=0x%lx\n", rc);
             return rc;
         }
         TRACE_INFO("symmetric key with len=%ld successful imported\n",
@@ -4235,31 +5106,28 @@ CK_RV token_specific_object_add(STDLL_TokData_t *tokdata, SESSION *sess, OBJECT 
                    " imported\n", attr->ulValueLen);
         break;
     case CKK_EC:
-        rc = template_attribute_find(object->template, CKA_CLASS, &attr);
-        if (rc == FALSE) {
-            TRACE_ERROR("%s\n", ock_err(ERR_TEMPLATE_INCOMPLETE));
-            return CKR_TEMPLATE_INCOMPLETE;
-        }
-
-        keyclass = *(CK_OBJECT_CLASS *)attr->pValue;
-
         switch(keyclass) {
         case CKO_PUBLIC_KEY:
             // do import public key and create opaque object
-            rc = ec_import_pubkey(object->template);
+            rc = import_ec_pubkey(object->template);
+            if (rc != CKR_OK) {
+                TRACE_DEVEL("ECpublic key import failed, rc=0x%lx\n", rc);
+                return rc;
+            }
+            TRACE_INFO("EC public key imported\n");
             break;
         case CKO_PRIVATE_KEY:
             // do import keypair and create opaque object
-            rc = ec_import_privkey(object->template);
+            rc = import_ec_privkey(object->template);
+            if (rc != CKR_OK) {
+                TRACE_DEVEL("EC private key import failed, rc=0x%lx\n", rc);
+                return rc;
+            }
+            TRACE_INFO("EC private key imported\n");
             break;
         default:
             TRACE_ERROR("%s\n", ock_err(ERR_KEY_TYPE_INCONSISTENT));
             return CKR_KEY_TYPE_INCONSISTENT;
-        }
-
-        if (rc != CKR_OK) {
-            TRACE_DEVEL("ec import failed\n");
-            return rc;
         }
         break;
     default:
@@ -4366,6 +5234,11 @@ CK_RV token_specific_generic_secret_key_gen(STDLL_TokData_t * tokdata,
         TRACE_DEVEL("template_update_attribute(CKA_IBM_OPAQUE) failed.\n");
         return rc;
     }
+
+#ifdef DEBUG
+    TRACE_DEBUG("%s: imported object template attributes:\n", __func__);
+    dump_template(template);
+#endif
 
     return CKR_OK;
 }

--- a/usr/lib/cca_stdll/cca_specific.c
+++ b/usr/lib/cca_stdll/cca_specific.c
@@ -238,6 +238,27 @@ static const MECH_LIST_ELEMENT cca_mech_list[] = {
 static const CK_ULONG cca_mech_list_len =
                         (sizeof(cca_mech_list) / sizeof(MECH_LIST_ELEMENT));
 
+
+/* Helper function: build attribute and update template */
+static CK_RV build_update_attribute(TEMPLATE * tmpl,
+                                    CK_ATTRIBUTE_TYPE type,
+                                    CK_BYTE * data, CK_ULONG data_len)
+{
+    CK_ATTRIBUTE *attr;
+    CK_RV rv;
+
+    if ((rv = build_attribute(type, data, data_len, &attr))) {
+        TRACE_DEVEL("Build attribute for type=%lu failed, rv=0x%lx\n", type, rv);
+        return rv;
+    }
+    if ((rv = template_update_attribute(tmpl, attr))) {
+	TRACE_DEVEL("Template update for type=%lu failed, rv=0x%lx\n", type, rv);
+        return rv;
+    }
+
+    return CKR_OK;
+}
+
 CK_RV token_specific_rng(STDLL_TokData_t * tokdata, CK_BYTE * output,
                          CK_ULONG bytes)
 {
@@ -715,7 +736,7 @@ CK_RV cca_inttok_privkey_get_n(CK_BYTE * tok, CK_ULONG * n_len, CK_BYTE * n)
 }
 
 /* Given a CCA internal token pubkey object, get the public exponent */
-CK_RV cca_inttok_pubkey_get_e(CK_BYTE * tok, CK_ULONG * e_len, CK_BYTE * e)
+static CK_RV cca_inttok_pubkey_get_e(CK_BYTE * tok, CK_ULONG * e_len, CK_BYTE * e)
 {
     uint16_t e_length;
 
@@ -733,14 +754,15 @@ CK_RV cca_inttok_pubkey_get_e(CK_BYTE * tok, CK_ULONG * e_len, CK_BYTE * e)
     return CKR_OK;
 }
 
-CK_RV token_create_keypair_object(TEMPLATE * tmpl, CK_ULONG tok_len,
-                                  CK_BYTE * tok)
+/* Pull n and e from RSA priv key token and add to template */
+static CK_RV add_n_and_e_to_rsa_key_template(TEMPLATE * tmpl,
+                                             CK_BYTE *cca_rsa_priv_key_token)
 {
     uint16_t privkey_len, pubkey_offset;
     CK_BYTE n[CCATOK_MAX_N_LEN], e[CCATOK_MAX_E_LEN];
     CK_ULONG n_len = CCATOK_MAX_N_LEN, e_len = CCATOK_MAX_E_LEN;
-    CK_ATTRIBUTE *modulus, *pub_exp, *opaque_key;
     CK_RV rv;
+    CK_BYTE *tok = cca_rsa_priv_key_token;
 
     privkey_len =
         cca_inttok_privkey_get_len(&tok[CCA_RSA_INTTOK_PRIVKEY_OFFSET]);
@@ -760,25 +782,18 @@ CK_RV token_create_keypair_object(TEMPLATE * tmpl, CK_ULONG tok_len,
     }
 
     /* Add n's value to the template */
-    if ((rv = build_attribute(CKA_MODULUS, n, n_len, &modulus))) {
-        TRACE_DEVEL("build_attribute for n failed. rv=0x%lx\n", rv);
+    rv = build_update_attribute(tmpl, CKA_MODULUS, n, n_len);
+    if (rv != CKR_OK) {
+        TRACE_DEVEL("add CKA_MODULUS attribute to template failed, rv=0x%lx\n", rv);
         return rv;
     }
-    template_update_attribute(tmpl, modulus);
 
     /* Add e's value to the template */
-    if ((rv = build_attribute(CKA_PUBLIC_EXPONENT, e, e_len, &pub_exp))) {
-        TRACE_DEVEL("build_attribute for e failed. rv=0x%lx\n", rv);
+    rv = build_update_attribute(tmpl, CKA_PUBLIC_EXPONENT, e, e_len);
+    if (rv != CKR_OK) {
+        TRACE_DEVEL("add CKA_PUBLIC_EXPONENT attribute to template failed, rv=0x%lx\n", rv);
         return rv;
     }
-    template_update_attribute(tmpl, pub_exp);
-
-    /* Add the opaque key object to the template */
-    if ((rv = build_attribute(CKA_IBM_OPAQUE, tok, tok_len, &opaque_key))) {
-        TRACE_DEVEL("build_attribute for opaque key failed. rv=0x%lx\n", rv);
-        return rv;
-    }
-    template_update_attribute(tmpl, opaque_key);
 
     return CKR_OK;
 }
@@ -833,10 +848,12 @@ CK_RV token_specific_rsa_generate_keypair(STDLL_TokData_t * tokdata,
     unsigned char private_key_name[CCA_PRIVATE_KEY_NAME_SIZE] = { 0, };
     unsigned char key_token[CCA_KEY_TOKEN_SIZE] = { 0, };
 
-    long regeneration_data_length, generated_key_token_length;
+    long regeneration_data_length;
+    long priv_key_token_length, publ_key_token_length;
     unsigned char regeneration_data[CCA_REGENERATION_DATA_SIZE] = { 0, };
     unsigned char transport_key_identifier[CCA_KEY_ID_SIZE] = { 0, };
-    unsigned char generated_key_token[CCA_KEY_TOKEN_SIZE] = { 0, };
+    unsigned char priv_key_token[CCA_KEY_TOKEN_SIZE] = { 0, };
+    unsigned char publ_key_token[CCA_KEY_TOKEN_SIZE] = { 0, };
 
     uint16_t size_of_e;
     uint16_t mod_bits;
@@ -907,25 +924,16 @@ CK_RV token_specific_rsa_generate_keypair(STDLL_TokData_t * tokdata,
 
     rule_array_count = 2;
     memcpy(rule_array, "RSA-AESCKEY-MGMT", (size_t) (CCA_KEYWORD_SIZE * 2));
-
     private_key_name_length = 0;
-
     key_token_length = CCA_KEY_TOKEN_SIZE;
 
-    dll_CSNDPKB(&return_code,
-                &reason_code,
-                NULL,
-                NULL,
-                &rule_array_count,
-                rule_array,
-                &key_value_structure_length,
-                key_value_structure,
-                &private_key_name_length,
-                private_key_name,
-                0,
-                NULL,
-                0,
-                NULL, 0, NULL, 0, NULL, 0, NULL, &key_token_length, key_token);
+    dll_CSNDPKB(&return_code, &reason_code,
+                NULL, NULL,
+                &rule_array_count, rule_array,
+                &key_value_structure_length, key_value_structure,
+                &private_key_name_length, private_key_name,
+                0, NULL, 0, NULL, 0, NULL, 0, NULL, 0, NULL,
+                &key_token_length, key_token);
 
     if (return_code != CCA_SUCCESS) {
         TRACE_ERROR("CSNDPKB (RSA KEY TOKEN BUILD) failed. return:%ld,"
@@ -936,23 +944,16 @@ CK_RV token_specific_rsa_generate_keypair(STDLL_TokData_t * tokdata,
     rule_array_count = 1;
     memset(rule_array, 0, sizeof(rule_array));
     memcpy(rule_array, "MASTER  ", (size_t) CCA_KEYWORD_SIZE);
-
-    generated_key_token_length = CCA_KEY_TOKEN_SIZE;
-
+    priv_key_token_length = CCA_KEY_TOKEN_SIZE;
     regeneration_data_length = 0;
 
-    dll_CSNDPKG(&return_code,
-                &reason_code,
-                NULL,
-                NULL,
-                &rule_array_count,
-                rule_array,
-                &regeneration_data_length,
-                regeneration_data,
-                &key_token_length,
-                key_token,
+    dll_CSNDPKG(&return_code, &reason_code,
+                NULL, NULL,
+                &rule_array_count, rule_array,
+                &regeneration_data_length, regeneration_data,
+                &key_token_length, key_token,
                 transport_key_identifier,
-                &generated_key_token_length, generated_key_token);
+                &priv_key_token_length, priv_key_token);
 
     if (return_code != CCA_SUCCESS) {
         TRACE_ERROR("CSNDPKG (RSA KEY GENERATE) failed. return:%ld,"
@@ -961,21 +962,55 @@ CK_RV token_specific_rsa_generate_keypair(STDLL_TokData_t * tokdata,
     }
 
     TRACE_DEVEL("RSA secure key token generated. size: %ld\n",
-                generated_key_token_length);
+                priv_key_token_length);
 
-    rv = token_create_keypair_object(publ_tmpl, generated_key_token_length,
-                                     generated_key_token);
+    rule_array_count = 0;
+    publ_key_token_length = CCA_KEY_TOKEN_SIZE;
+
+    dll_CSNDPKX(&return_code, &reason_code,
+                NULL, NULL,
+                &rule_array_count, rule_array,
+                &priv_key_token_length, priv_key_token,
+                &publ_key_token_length, publ_key_token);
+
+    if (return_code != CCA_SUCCESS) {
+        TRACE_ERROR("CSNDPKX (PUBLIC KEY TOKEN EXTRACT) failed. return:%ld,"
+                    " reason:%ld\n", return_code, reason_code);
+        return CKR_FUNCTION_FAILED;
+    }
+
+    TRACE_DEVEL("RSA public key token extracted. size: %ld\n",
+                publ_key_token_length);
+
+    /* update priv template, add n, e and ibm opaque attr with priv key token */
+    rv = add_n_and_e_to_rsa_key_template(priv_tmpl, priv_key_token);
     if (rv != CKR_OK) {
-        TRACE_DEVEL("token_create_keypair_object failed. rv:%lu\n", rv);
+        TRACE_DEVEL("add_n_and_e_to_rsa_key_template failed. rv:%lu\n", rv);
+        return rv;
+    }
+    rv = build_update_attribute(priv_tmpl, CKA_IBM_OPAQUE,
+                                priv_key_token,
+                                priv_key_token_length);
+    if (rv != CKR_OK) {
+        TRACE_DEVEL("add CKA_IBM_OPAQUE attribute to priv template failed, rv:%lu\n", rv);
         return rv;
     }
 
-    rv = token_create_keypair_object(priv_tmpl, generated_key_token_length,
-                                     generated_key_token);
-    if (rv != CKR_OK)
-        TRACE_DEVEL("token_create_keypair_object failed. rv:%lu\n", rv);
+    /* update pub template, add n, e and ibm opaque attr with pub key token */
+    rv = add_n_and_e_to_rsa_key_template(publ_tmpl, priv_key_token);
+    if (rv != CKR_OK) {
+        TRACE_DEVEL("add_n_and_e_to_rsa_key_template failed. rv:%lu\n", rv);
+        return rv;
+    }
+    rv = build_update_attribute(publ_tmpl, CKA_IBM_OPAQUE,
+                                publ_key_token,
+                                publ_key_token_length);
+    if (rv != CKR_OK) {
+        TRACE_DEVEL("add CKA_IBM_OPAQUE attribute to publ template failed, rv:%lu\n", rv);
+        return rv;
+    }
 
-    return rv;
+    return CKR_OK;
 }
 
 
@@ -2037,21 +2072,6 @@ CK_RV token_specific_get_mechanism_info(STDLL_TokData_t * tokdata,
     return ock_generic_get_mechanism_info(tokdata, type, pInfo);
 }
 
-CK_RV build_update_attribute(TEMPLATE * tmpl,
-                             CK_ATTRIBUTE_TYPE type,
-                             CK_BYTE * data, CK_ULONG data_len)
-{
-    CK_ATTRIBUTE *attr;
-    CK_RV rv;
-    if ((rv = build_attribute(type, data, data_len, &attr))) {
-        TRACE_DEVEL("Build attribute for type=%lu failed rv=0x%lx\n", type, rv);
-        return rv;
-    }
-    template_update_attribute(tmpl, attr);
-
-    return CKR_OK;
-}
-
 CK_BBOOL is_curve_error(long return_code, long reason_code)
 {
     if (return_code == 8) {
@@ -2136,7 +2156,8 @@ uint16_t cca_ec_publkey_offset(CK_BYTE * tok)
 
 CK_RV token_create_ec_keypair(TEMPLATE * publ_tmpl,
                               TEMPLATE * priv_tmpl,
-                              CK_ULONG tok_len, CK_BYTE * tok)
+                              CK_ULONG priv_tok_len, CK_BYTE *priv_tok,
+                              CK_ULONG publ_tok_len, CK_BYTE *publ_tok)
 {
     uint16_t pubkey_offset, qlen_offset, q_offset;
     CK_ULONG q_len;
@@ -2161,10 +2182,10 @@ CK_RV token_create_ec_keypair(TEMPLATE * publ_tmpl,
     /*
      * Get Q data for public key.
      */
-    pubkey_offset = cca_ec_publkey_offset(tok);
+    pubkey_offset = cca_ec_publkey_offset(priv_tok);
 
     qlen_offset = pubkey_offset + CCA_EC_INTTOK_PUBKEY_Q_LEN_OFFSET;
-    q_len = *(uint16_t *) & tok[qlen_offset];
+    q_len = *(uint16_t *) & priv_tok[qlen_offset];
     q_len = ntohs(q_len);
 
     if (q_len > CCATOK_EC_MAX_Q_LEN) {
@@ -2174,7 +2195,7 @@ CK_RV token_create_ec_keypair(TEMPLATE * publ_tmpl,
     }
 
     q_offset = pubkey_offset + CCA_EC_INTTOK_PUBKEY_Q_OFFSET;
-    memcpy(q, &tok[q_offset], (size_t) q_len);
+    memcpy(q, &priv_tok[q_offset], (size_t) q_len);
 
     rv = ber_encode_OCTET_STRING(FALSE, &ecpoint, &ecpoint_len, q, q_len);
     if (rv != CKR_OK) {
@@ -2203,18 +2224,17 @@ CK_RV token_create_ec_keypair(TEMPLATE * publ_tmpl,
         return rv;
     }
 
-    /*
-     * Save the CKA_IBM_OPAQUE for both keys.
-     */
-    if ((rv = build_update_attribute(publ_tmpl,
-                                     CKA_IBM_OPAQUE, tok, tok_len))) {
-        TRACE_DEVEL("build_update_attribute for tok failed rv=0x%lx\n", rv);
+    /* store publ key token into CKA_IBM_OPAQUE of the public key object */
+    if ((rv = build_update_attribute(publ_tmpl, CKA_IBM_OPAQUE,
+                                     publ_tok, publ_tok_len))) {
+        TRACE_DEVEL("build_update_attribute for publ_tok failed rv=0x%lx\n", rv);
         return rv;
     }
 
-    if ((rv = build_update_attribute(priv_tmpl,
-                                     CKA_IBM_OPAQUE, tok, tok_len))) {
-        TRACE_DEVEL("build_update_attribute for tok failed rv=0x%lx\n", rv);
+    /* store priv key token into CKA_IBM_OPAQUE of the private key object */
+    if ((rv = build_update_attribute(priv_tmpl, CKA_IBM_OPAQUE,
+                                     priv_tok, priv_tok_len))) {
+        TRACE_DEVEL("build_update_attribute for priv_tok failed rv=0x%lx\n", rv);
         return rv;
     }
 
@@ -2232,10 +2252,12 @@ CK_RV token_specific_ec_generate_keypair(STDLL_TokData_t * tokdata,
     unsigned char key_value_structure[CCA_EC_KEY_VALUE_STRUCT_SIZE] = { 0, };
     unsigned char private_key_name[CCA_PRIVATE_KEY_NAME_SIZE] = { 0, };
     unsigned char key_token[CCA_KEY_TOKEN_SIZE] = { 0, };
-    long regeneration_data_length, generated_key_token_length;
+    long regeneration_data_length;
+    long priv_key_token_length, publ_key_token_length;
     unsigned char regeneration_data[CCA_REGENERATION_DATA_SIZE] = { 0, };
     unsigned char transport_key_identifier[CCA_KEY_ID_SIZE] = { 0, };
-    unsigned char generated_key_token[CCA_KEY_TOKEN_SIZE] = { 0, };
+    unsigned char priv_key_token[CCA_KEY_TOKEN_SIZE] = { 0, };
+    unsigned char publ_key_token[CCA_KEY_TOKEN_SIZE] = { 0, };
     CK_RV rv;
     long param1 = 0;
     unsigned char *param2 = NULL;
@@ -2297,7 +2319,7 @@ CK_RV token_specific_ec_generate_keypair(STDLL_TokData_t * tokdata,
     memset(rule_array, 0, sizeof(rule_array));
     memcpy(rule_array, "MASTER  ", (size_t) CCA_KEYWORD_SIZE);
 
-    generated_key_token_length = CCA_KEY_TOKEN_SIZE;
+    priv_key_token_length = CCA_KEY_TOKEN_SIZE;
 
     regeneration_data_length = 0;
 
@@ -2312,7 +2334,7 @@ CK_RV token_specific_ec_generate_keypair(STDLL_TokData_t * tokdata,
                 &key_token_length,
                 key_token,
                 transport_key_identifier,
-                &generated_key_token_length, generated_key_token);
+                &priv_key_token_length, priv_key_token);
 
     if (return_code != CCA_SUCCESS) {
         TRACE_ERROR("CSNDPKG (EC KEY GENERATE) failed."
@@ -2322,12 +2344,30 @@ CK_RV token_specific_ec_generate_keypair(STDLL_TokData_t * tokdata,
         return CKR_FUNCTION_FAILED;
     }
 
-    TRACE_DEVEL("ECC secure key token generated. size: %ld\n",
-                generated_key_token_length);
+    TRACE_DEVEL("ECC secure private key token generated. size: %ld\n",
+                priv_key_token_length);
+
+    rule_array_count = 0;
+    publ_key_token_length = CCA_KEY_TOKEN_SIZE;
+
+    dll_CSNDPKX(&return_code, &reason_code,
+                NULL, NULL,
+                &rule_array_count, rule_array,
+                &priv_key_token_length, priv_key_token,
+                &publ_key_token_length, publ_key_token);
+
+    if (return_code != CCA_SUCCESS) {
+        TRACE_ERROR("CSNDPKX (PUBLIC KEY TOKEN EXTRACT) failed. return:%ld,"
+                    " reason:%ld\n", return_code, reason_code);
+        return CKR_FUNCTION_FAILED;
+    }
+
+    TRACE_DEVEL("ECC secure public key token generated. size: %ld\n",
+                publ_key_token_length);
 
     rv = token_create_ec_keypair(publ_tmpl, priv_tmpl,
-                                 generated_key_token_length,
-                                 generated_key_token);
+                                 priv_key_token_length, priv_key_token,
+                                 publ_key_token_length, publ_key_token);
     if (rv != CKR_OK) {
         TRACE_DEVEL("token_create_ec_keypair failed. rv: %lu\n", rv);
         return rv;

--- a/usr/lib/cca_stdll/cca_specific.c
+++ b/usr/lib/cca_stdll/cca_specific.c
@@ -874,7 +874,7 @@ CK_RV token_specific_rsa_generate_keypair(STDLL_TokData_t * tokdata,
         /* make pValue into CK_ULONG so we can compare */
         tmpexp = 0;
         memcpy((unsigned char *) &tmpexp + sizeof(CK_ULONG) - tmpsize,
-               ptr, tmpsize);	/* right align */
+               ptr, tmpsize);   /* right align */
 
         /* Check for one of the three allowed values */
         if ((tmpexp != 0) && (tmpexp != 3) && (tmpexp != 65537))
@@ -3155,7 +3155,7 @@ send:
     if (sign) {
         dll_CSNBHMG(&return_code, &reason_code, NULL, NULL,
                     &rule_array_count, rule_array,
-		    (long int *)&attr->ulValueLen, attr->pValue,
+                    (long int *)&attr->ulValueLen, attr->pValue,
                     use_buffer ? &buffer_len : (long int *) &in_data_len,
                     use_buffer ? buffer : in_data,
                     &cca_ctx->chain_vector_len, cca_ctx->chain_vector,
@@ -3807,9 +3807,10 @@ static CK_RV import_generic_secret_key(OBJECT * object)
 }
 
 static CK_RV build_private_EC_key_value_structure(CK_BYTE *privkey, CK_ULONG privlen,
-        CK_BYTE *pubkey, CK_ULONG publen,
-        uint8_t curve_type, uint16_t curve_bitlen,
-        unsigned char *key_value_structure, long *key_value_structure_length)
+                                                  CK_BYTE *pubkey, CK_ULONG publen,
+                                                  uint8_t curve_type, uint16_t curve_bitlen,
+                                                  unsigned char *key_value_structure,
+                                                  long *key_value_structure_length)
 {
     ECC_PAIR ecc_pair;
 
@@ -3860,8 +3861,9 @@ static unsigned int bitlen2bytelen(uint16_t bitlen)
 }
 
 static CK_RV build_public_EC_key_value_structure(CK_BYTE *pubkey, CK_ULONG publen,
-        uint8_t curve_type, uint16_t curve_bitlen,
-        unsigned char *key_value_structure, long *key_value_structure_length)
+                                                 uint8_t curve_type, uint16_t curve_bitlen,
+                                                 unsigned char *key_value_structure,
+                                                 long *key_value_structure_length)
 {
     ECC_PUBL ecc_publ;
 
@@ -4118,80 +4120,80 @@ static CK_RV ec_import_pubkey(TEMPLATE *pub_templ)
 
 CK_RV token_specific_object_add(STDLL_TokData_t *tokdata, SESSION *sess, OBJECT *object)
 {
-	CK_RV rc;
-	CK_ATTRIBUTE *attr = NULL;
-	CK_KEY_TYPE keytype;
-	CK_OBJECT_CLASS keyclass;
+    CK_RV rc;
+    CK_ATTRIBUTE *attr = NULL;
+    CK_KEY_TYPE keytype;
+    CK_OBJECT_CLASS keyclass;
 
-	UNUSED(tokdata);
-	UNUSED(sess);
+    UNUSED(tokdata);
+    UNUSED(sess);
 
-	if (!object) {
-		TRACE_ERROR("Invalid argument\n");
-		return CKR_FUNCTION_FAILED;
-	}
+    if (!object) {
+        TRACE_ERROR("Invalid argument\n");
+        return CKR_FUNCTION_FAILED;
+    }
 
-	rc = template_attribute_find(object->template, CKA_KEY_TYPE, &attr);
-	if (rc == FALSE) {
-		// not a key, so nothing to do. Just return.
-		TRACE_DEVEL("object not a key, no need to import.\n");
-		return CKR_OK;
-	}
+    rc = template_attribute_find(object->template, CKA_KEY_TYPE, &attr);
+    if (rc == FALSE) {
+        // not a key, so nothing to do. Just return.
+        TRACE_DEVEL("object not a key, no need to import.\n");
+        return CKR_OK;
+    }
 
-	keytype = *(CK_KEY_TYPE *)attr->pValue;
+    keytype = *(CK_KEY_TYPE *)attr->pValue;
 
-	switch (keytype) {
-	case CKK_RSA:
-		rc = template_attribute_find(object->template, CKA_CLASS, &attr);
-		if (rc == FALSE) {
-			TRACE_ERROR("%s\n", ock_err(ERR_TEMPLATE_INCOMPLETE));
-			return CKR_TEMPLATE_INCOMPLETE;
-		}
+    switch (keytype) {
+    case CKK_RSA:
+        rc = template_attribute_find(object->template, CKA_CLASS, &attr);
+        if (rc == FALSE) {
+            TRACE_ERROR("%s\n", ock_err(ERR_TEMPLATE_INCOMPLETE));
+            return CKR_TEMPLATE_INCOMPLETE;
+        }
 
         keyclass = *(CK_OBJECT_CLASS *)attr->pValue;
 
-		switch(keyclass) {
-		case CKO_PUBLIC_KEY:
-			// do import public key and create opaque object
-			rc = rsa_import_pubkey(object->template);
-			break;
-		case CKO_PRIVATE_KEY:
-			// do import keypair and create opaque object
-			rc = rsa_import_privkey_crt(object->template);
-			break;
-		default:
-			TRACE_ERROR("%s\n", ock_err(ERR_KEY_TYPE_INCONSISTENT));
-			return CKR_KEY_TYPE_INCONSISTENT;
-		}
+        switch(keyclass) {
+        case CKO_PUBLIC_KEY:
+            // do import public key and create opaque object
+            rc = rsa_import_pubkey(object->template);
+            break;
+        case CKO_PRIVATE_KEY:
+            // do import keypair and create opaque object
+            rc = rsa_import_privkey_crt(object->template);
+            break;
+        default:
+            TRACE_ERROR("%s\n", ock_err(ERR_KEY_TYPE_INCONSISTENT));
+            return CKR_KEY_TYPE_INCONSISTENT;
+        }
 
-		if (rc != CKR_OK) {
-			TRACE_DEVEL("rsa import failed\n");
-			return rc;
-		}
+        if (rc != CKR_OK) {
+            TRACE_DEVEL("rsa import failed\n");
+            return rc;
+        }
 
-		break;
-	case CKK_AES:
-	case CKK_DES:
-	case CKK_DES3:
-		rc = import_symmetric_key(object, keytype);
-		if (rc != CKR_OK) {
-			TRACE_DEVEL("Symmetric key import failed, rc=0x%lx\n",
-				     rc);
-			return rc;
-		}
-		TRACE_INFO("symmetric key with len=%ld successful imported\n",
-			    attr->ulValueLen);
-		break;
-	case CKK_GENERIC_SECRET:
-		rc = import_generic_secret_key(object);
-		if (rc != CKR_OK) {
-			TRACE_DEVEL("Generic Secret (HMAC) key import failed "
-				    " with rc=0x%lx\n", rc);
-			return rc;
-		}
-		TRACE_INFO("Generic Secret (HMAC) key with len=%ld successfully"
-			   " imported\n", attr->ulValueLen);
-		break;
+        break;
+    case CKK_AES:
+    case CKK_DES:
+    case CKK_DES3:
+        rc = import_symmetric_key(object, keytype);
+        if (rc != CKR_OK) {
+            TRACE_DEVEL("Symmetric key import failed, rc=0x%lx\n",
+                        rc);
+            return rc;
+        }
+        TRACE_INFO("symmetric key with len=%ld successful imported\n",
+                   attr->ulValueLen);
+        break;
+    case CKK_GENERIC_SECRET:
+        rc = import_generic_secret_key(object);
+        if (rc != CKR_OK) {
+            TRACE_DEVEL("Generic Secret (HMAC) key import failed "
+                        " with rc=0x%lx\n", rc);
+            return rc;
+        }
+        TRACE_INFO("Generic Secret (HMAC) key with len=%ld successfully"
+                   " imported\n", attr->ulValueLen);
+        break;
     case CKK_EC:
         rc = template_attribute_find(object->template, CKA_CLASS, &attr);
         if (rc == FALSE) {
@@ -4220,13 +4222,13 @@ CK_RV token_specific_object_add(STDLL_TokData_t *tokdata, SESSION *sess, OBJECT 
             return rc;
         }
         break;
-	default:
-		/* unknown/unsupported key type */
-		TRACE_ERROR("Unknown/unsupported key type 0x%lx\n", keytype);
-		return CKR_KEY_FUNCTION_NOT_PERMITTED;
-	}
+    default:
+        /* unknown/unsupported key type */
+        TRACE_ERROR("Unknown/unsupported key type 0x%lx\n", keytype);
+        return CKR_KEY_FUNCTION_NOT_PERMITTED;
+    }
 
-	return CKR_OK;
+    return CKR_OK;
 }
 
 CK_RV token_specific_generic_secret_key_gen(STDLL_TokData_t * tokdata,

--- a/usr/lib/cca_stdll/cca_stdll.h
+++ b/usr/lib/cca_stdll/cca_stdll.h
@@ -67,10 +67,14 @@
 /* Offset into an RSA key area of the total length */
 #define CCA_RSA_INTTOK_PRIVKEY_LENGTH_OFFSET 2
 #define CCA_RSA_INTTOK_PUBKEY_LENGTH_OFFSET 2
-/* Offset into an RSA private key area of the length of n, the modulus */
-#define CCA_RSA_INTTOK_PRIVKEY_N_LENGTH_OFFSET 62
-/* Offset into an RSA private key area of n, the modulus */
-#define CCA_RSA_INTTOK_PRIVKEY_N_OFFSET 134
+/* Offset into an RSA private key (4096 bits, ME format) area of the length of n, the modulus */
+#define CCA_RSA_INTTOK_PRIVKEY_ME_N_LENGTH_OFFSET 52
+/* Offset into an RSA private key (4096 bits, ME format) area of n, the modulus */
+#define CCA_RSA_INTTOK_PRIVKEY_ME_N_OFFSET 122
+/* Offset into an RSA private key (4096 bits, CRT format) area of the length of n, the modulus */
+#define CCA_RSA_INTTOK_PRIVKEY_CRT_N_LENGTH_OFFSET 62
+/* Offset into an RSA private key (4096 bits, CRT format) area of n, the modulus */
+#define CCA_RSA_INTTOK_PRIVKEY_CRT_N_OFFSET 134
 /* Offset into an RSA public key area of the length of e, the public exponent */
 #define CCA_RSA_INTTOK_PUBKEY_E_LENGTH_OFFSET 6
 /* Offset into an RSA public key area of the value of e, the public exponent */
@@ -81,6 +85,13 @@
 /* Offset into the rule_array returned by the STATCCAE command for the
  * Current Asymmetric Master Key register status */
 #define CCA_STATCCAE_ASYM_CMK_OFFSET  56
+/* Offset to start of public RSA key section for an external public RSA key token */
+#define CCA_RSA_EXTTOK_PUBKEY_OFFSET  8
+/* Offset to length of n within an public RSA key section in an ext public RSA key token */
+#define CCA_RSA_EXTTOK_PUBKEY_N_LENGTH_OFFSET 10
+
+/* CCA internal HMAC token payload bit length field offset */
+#define CCA_HMAC_INTTOK_PAYLOAD_LENGTH_OFFSET 38
 
 /* CCA STDLL constants */
 

--- a/usr/lib/common/key.c
+++ b/usr/lib/common/key.c
@@ -1126,6 +1126,15 @@ CK_RV rsa_publ_check_required_attributes(TEMPLATE *tmpl, CK_ULONG mode)
     CK_ATTRIBUTE *attr = NULL;
     CK_BBOOL found;
 
+    if (mode == MODE_CREATE &&
+        token_specific.secure_key_token == TRUE &&
+        template_attribute_find(tmpl, CKA_IBM_OPAQUE, &attr) == TRUE) {
+        /*
+         * Import of an already existing secure key. Only
+         * do the base checks for public key templates.
+         */
+        return publ_key_check_required_attributes(tmpl, mode);
+    }
 
     found = template_attribute_find(tmpl, CKA_MODULUS, &attr);
     if (!found) {
@@ -1282,6 +1291,15 @@ CK_RV rsa_priv_check_required_attributes(TEMPLATE *tmpl, CK_ULONG mode)
     CK_ATTRIBUTE *attr = NULL;
     CK_BBOOL found;
 
+    if (mode == MODE_CREATE &&
+        token_specific.secure_key_token == TRUE &&
+        template_attribute_find(tmpl, CKA_IBM_OPAQUE, &attr) == TRUE) {
+        /*
+         * Import of an already existing secure key. Only
+         * do the base checks for private key templates.
+         */
+        return priv_key_check_required_attributes(tmpl, mode);
+    }
 
     found = template_attribute_find(tmpl, CKA_MODULUS, &attr);
     if (!found) {
@@ -2261,6 +2279,15 @@ CK_RV ecdsa_publ_check_required_attributes(TEMPLATE *tmpl, CK_ULONG mode)
     CK_ATTRIBUTE *attr = NULL;
     CK_BBOOL found;
 
+    if (mode == MODE_CREATE &&
+        token_specific.secure_key_token == TRUE &&
+        template_attribute_find(tmpl, CKA_IBM_OPAQUE, &attr) == TRUE) {
+        /*
+         * Import of an already existing secure key. Only
+         * do the base checks for a public key templates.
+         */
+        return publ_key_check_required_attributes(tmpl, mode);
+    }
 
     found = template_attribute_find(tmpl, CKA_ECDSA_PARAMS, &attr);
     if (!found) {
@@ -2364,6 +2391,15 @@ CK_RV ecdsa_priv_check_required_attributes(TEMPLATE *tmpl, CK_ULONG mode)
     CK_ATTRIBUTE *attr = NULL;
     CK_BBOOL found;
 
+    if (mode == MODE_CREATE &&
+        token_specific.secure_key_token == TRUE &&
+        template_attribute_find(tmpl, CKA_IBM_OPAQUE, &attr) == TRUE) {
+        /*
+         * Import of an already existing secure key. Only
+         * do the base checks for private key templates.
+         */
+        return priv_key_check_required_attributes(tmpl, mode);
+    }
 
     found = template_attribute_find(tmpl, CKA_ECDSA_PARAMS, &attr);
     if (!found) {

--- a/usr/lib/common/template.c
+++ b/usr/lib/common/template.c
@@ -1308,7 +1308,7 @@ CK_RV template_validate_base_attribute(TEMPLATE *tmpl, CK_ATTRIBUTE *attr,
         /* Allow this attribute to be modified in order to support
          * migratable keys on secure key tokens.
          */
-        if ((mode & (MODE_COPY | MODE_MODIFY)) != 0)
+        if ((mode & (MODE_CREATE | MODE_COPY | MODE_MODIFY)) != 0)
             return CKR_OK;
         break;
     case CKA_MODIFIABLE:


### PR DESCRIPTION
Please note this is only a heads up - the patch is still work in progress.
I only want to show what I intent to provide soon.

The secure key blob for all the keys used with the CCA token is
stored in an attribute CKA_IBM_OPAQUE. The content is a so called
secure CCA key token and a description can be found in the
  "Secure Key Solution with the Common Cryptographic
   Architecture Application Programmer's Guide".

There is a requirement to export and import these raw secure key token
objects. Export is simple: Just fetch the value the CKA_IBM_OPAQUE
attribute for a key object and dump it for example into a
file. Importing such a value was until now not supported. This patch
enables the possibility to import such a raw CCA key token object with
the C_CreateObject() pkcs#11 function.

To import an CCA DES key token, use a template with these mandatory
attributes:
  CKA_CLASS = CKO_SECRET_KEY
  CK_KEY_TYPE = CKK_DES
  CKA_VALUE - dummy but needs to have byte size of the clear key (8)
  CKA_IBM_OPAQUE - with the CCA DES key token

to import an CCA DES3 key token, use a template with these mandatory
attributes:
  CKA_CLASS = CKO_SECRET_KEY
  CK_KEY_TYPE = CKK_DES3
  CKA_VALUE - dummy but needs to have byte size of the clear key (24)
  CKA_IBM_OPAQUE - with the CCA DES3 key token

to import an CCA AES key token, use a template with these mandatory
attributes:
  CKA_CLASS = CKO_SECRET_KEY
  CK_KEY_TYPE = CKK_AES
  CKA_VALUE - dummy but needs to have byte size of the clear key (16,
	      24, or 32)
  CKA_IBM_OPAQUE - with the CCA AES key token
As of now only CCA AES data key tokens are supported. CCA AES cipher
keys do not work yet.

to import an CCA internal RSA private key token, use a template with
these mandatory attributes:
  CKA_CLASS = CKO_PRIVATE_KEY
  CKA_KEY_TYPE = CKK_RSA
  CKA_IBM_OPAQUE - with the CCA RSA private key token

to import an CCA RSA public key token, use a template with these
mandatory attributes:
  CKA_CLASS = CKO_PUBLIC_KEY
  CKA_KEY_TYPE = CKK_RSA
  CKA_IBM_OPAQUE - with the CCA RSA public key token

to import an CCA HMAC key token, use a template with these mandatory
attributes:
  CKA_CLASS = CKO_SECRET_KEY
  CKA_KEY_TYPE = CKK_GENERIC_SECRET
  CKA_VALUE - with a dummy value the size in bytes of the clear key
	      byte size.
  CKA_IBM_OPAQUE with the CCA RSA private key token.

CCA ECC is still work in progress, and maybe AES cipher key will also come.