### PR TITLE
PKCSCCA: Remove duplicated common code

### DIFF
--- a/usr/lib/common/pkcs_utils.c
+++ b/usr/lib/common/pkcs_utils.c
@@ -136,6 +136,8 @@ done:
     return rc;
 }
 
+#ifndef OCK_NO_LOCAL_RNG
+
 CK_RV local_rng(CK_BYTE *output, CK_ULONG bytes)
 {
     int ranfd;
@@ -156,6 +158,8 @@ CK_RV local_rng(CK_BYTE *output, CK_ULONG bytes)
 
     return CKR_FUNCTION_FAILED;
 }
+
+#endif
 
 CK_RV aes_256_wrap(unsigned char out[40], const unsigned char in[32],
                    const unsigned char kek[32])
@@ -453,6 +457,8 @@ done:
     return ret;
 }
 
+#ifndef OCK_NO_SET_PERM
+
 void set_perm(int file)
 {
     struct group *grp;
@@ -475,3 +481,5 @@ void set_perm(int file)
 error:
     TRACE_DEVEL("Unable to set permissions on file.\n");
 }
+
+#endif

--- a/usr/sbin/pkcscca/pkcscca.h
+++ b/usr/sbin/pkcscca/pkcscca.h
@@ -20,13 +20,8 @@
 
 #include <stdint.h>
 
-#define CCA_LIBRARY "libcsulcca.so"
-#define TOK_DATASTORE   CONFIG_PATH "/ccatok"
-#define MASTER_KEY_SIZE     64
-#define SHA1_HASH_SIZE      20
-#define MD5_HASH_SIZE       16
-#define DES_BLOCK_SIZE      8
-#define DES_KEY_SIZE        8
+#define CCA_LIBRARY         "libcsulcca.so"
+#define TOK_DATASTORE       CONFIG_PATH "/ccatok"
 #define CCA_SUCCESS         0
 
 #define AES_NAME    "AES"
@@ -42,22 +37,6 @@
 #define MK_APKA     2
 #define MK_ASYM     3
 #define MK_SYM      4
-
-int compute_hash(int hash_type, int buf_size, char *buf, char *digest);
-
-#define compute_sha1(a,b,c)     compute_hash(HASH_SHA1,b,a,c)
-#define compute_md5(a,b,c)      compute_hash(HASH_MD5,b,a,c)
-#define HASH_SHA1   1
-#define HASH_MD5    2
-
-CK_RV sw_des3_cbc(CK_BYTE *, CK_ULONG, CK_BYTE *, CK_ULONG *, CK_BYTE *,
-                  CK_BYTE *, CK_BYTE);
-
-#define sw_des3_cbc_encrypt(clear, len, cipher, len2, iv, key) \
-                sw_des3_cbc(clear, len, cipher, len2, iv, key, 1)
-
-#define sw_des3_cbc_decrypt(clear, len, cipher, len2, iv, key) \
-                sw_des3_cbc(clear, len, cipher, len2, iv, key, 0)
 
 #define EVP_SUCCESS 1
 #define print_openssl_errors() \
@@ -78,7 +57,7 @@ static inline void _print_error(const char *file, int line,
     va_list ap;
 
     snprintf(buf, sizeof(buf), "%s:%d ", file, line);
-    off = strlen("%s:%d ");
+    off = strlen(buf);
 
     va_start(ap, fmt);
     vsnprintf(buf + off, sizeof(buf) - off, fmt, ap);
@@ -103,61 +82,6 @@ static inline void _print_error(const char *file, int line,
                     printf(" "); \
             } \
         } while (0)
-
-
-typedef struct _MASTER_KEY_FILE_T {
-    CK_BYTE key[MASTER_KEY_SIZE];
-    CK_BYTE sha_hash[SHA1_HASH_SIZE];
-} MASTER_KEY_FILE_T;
-
-/* from host_defs.h */
-#include "pkcs32.h"
-typedef struct _TWEAK_VEC {
-    int allow_weak_des;
-    int check_des_parity;
-    int allow_key_mods;
-    int netscape_mods;
-} TWEAK_VEC;
-
-typedef struct _TOKEN_DATA_VERSION {
-    uint32_t version; /* major<<16|minor */
-    /* --- PBKDF2 --- */
-    /* SO login */
-    uint64_t so_login_it;
-    unsigned char so_login_salt[64];
-    unsigned char so_login_key[32];
-    /* User login */
-    uint64_t user_login_it;
-    unsigned char user_login_salt[64];
-    unsigned char user_login_key[32];
-    /* SO MK wrap */
-    uint64_t so_wrap_it;
-    unsigned char so_wrap_salt[64];
-    /* User MK wrap */
-    uint64_t user_wrap_it;
-    unsigned char user_wrap_salt[64];
-} TOKEN_DATA_VERSION;
-
-typedef struct _TOKEN_DATA {
-    CK_TOKEN_INFO_32 token_info;
-
-    CK_BYTE user_pin_sha[3 * DES_BLOCK_SIZE];
-    CK_BYTE so_pin_sha[3 * DES_BLOCK_SIZE];
-    CK_BYTE next_token_object_name[8];
-    TWEAK_VEC tweak_vector;
-
-    /* new for tokversion >= 3.12 */
-    TOKEN_DATA_VERSION dat;
-} TOKEN_DATA;
-
-typedef struct _TOKEN_DATA_OLD {
-    CK_TOKEN_INFO_32 token_info;
-
-    CK_BYTE user_pin_sha[3 * DES_BLOCK_SIZE];
-    CK_BYTE so_pin_sha[3 * DES_BLOCK_SIZE];
-    CK_BYTE next_token_object_name[8];
-    TWEAK_VEC tweak_vector;
-} TOKEN_DATA_OLD;
 
 struct key {
     CK_OBJECT_HANDLE handle;
@@ -184,33 +108,6 @@ struct key_count {
     int hmac;
     int rsa;
 };
-
-typedef struct _DL_NODE
-{
-    struct _DL_NODE   *next;
-    struct _DL_NODE   *prev;
-    void              *data;
-} DL_NODE;
-
-typedef struct _TEMPLATE
-{
-    DL_NODE  *attribute_list;
-} TEMPLATE;
-
-typedef void *SESSION;
-
-typedef struct _OBJECT
-{
-    CK_OBJECT_CLASS   class;
-    CK_BYTE           name[8];   // for token objects
-
-    SESSION          *session;   // creator; only for session objects
-    TEMPLATE         *template;
-    CK_ULONG          count_hi;  // only significant for token objects
-    CK_ULONG          count_lo;  // only significant for token objects
-    CK_ULONG      index;  // SAB  Index into the SHM
-    CK_OBJECT_HANDLE  map_handle;
-} OBJECT;
 
 struct secaeskeytoken {
     unsigned char  type;     /* 0x01 for internal key token */

--- a/usr/sbin/pkcscca/pkcscca.mk
+++ b/usr/sbin/pkcscca/pkcscca.mk
@@ -1,13 +1,51 @@
 sbin_PROGRAMS += usr/sbin/pkcscca/pkcscca
 noinst_HEADERS += usr/sbin/pkcscca/pkcscca.h
+noinst_HEADERS += usr/lib/common/defs.h
+noinst_HEADERS += usr/lib/common/host_defs.h
+noinst_HEADERS += usr/include/local_types.h
+noinst_HEADERS += usr/lib/common/h_extern.h
+noinst_HEADERS += usr/lib/common/pkcs_utils.h
 
-usr_sbin_pkcscca_pkcscca_LDFLAGS = -lcrypto -ldl
+usr_sbin_pkcscca_pkcscca_LDFLAGS = -lcrypto -ldl -lrt
 
 usr_sbin_pkcscca_pkcscca_CFLAGS  =					\
 	-DSTDLL_NAME=\"pkcscca\"					\
-	-I${srcdir}/usr/include -I${srcdir}/usr/lib/common		\
+	-DTOK_NEW_DATA_STORE=0x0003000c					\
+	-DNOCDMF -DNODSA -DNODH						\
+	-DOCK_NO_SET_PERM -DOCK_NO_LOCAL_RNG				\
+	-I${srcdir}/usr/include 					\
+	-I${srcdir}/usr/lib/common					\
 	-I${srcdir}/usr/sbin/pkcscca
 
 usr_sbin_pkcscca_pkcscca_SOURCES =					\
+	usr/lib/common/asn1.c usr/lib/common/dig_mgr.c			\
+	usr/lib/common/hwf_obj.c usr/lib/common/trace.c			\
+	usr/lib/common/key.c usr/lib/common/mech_list.c			\
+	usr/lib/common/mech_dh.c usr/lib/common/sign_mgr.c		\
+	usr/lib/common/cert.c usr/lib/common/dp_obj.c			\
+	usr/lib/common/mech_aes.c usr/lib/common/mech_rsa.c		\
+	usr/lib/common/mech_ec.c usr/lib/common/obj_mgr.c		\
+	usr/lib/common/template.c usr/lib/common/data_obj.c		\
+	usr/lib/common/encr_mgr.c usr/lib/common/key_mgr.c		\
+	usr/lib/common/mech_md2.c usr/lib/common/mech_sha.c		\
+	usr/lib/common/object.c	usr/lib/common/decr_mgr.c		\
+	usr/lib/common/globals.c usr/lib/common/loadsave.c		\
+	usr/lib/common/utility.c usr/lib/common/mech_des.c		\
+	usr/lib/common/mech_des3.c usr/lib/common/mech_md5.c		\
+	usr/lib/common/mech_ssl3.c usr/lib/common/verify_mgr.c		\
 	usr/lib/common/p11util.c usr/lib/common/sw_crypt.c		\
-	usr/lib/common/trace.c usr/sbin/pkcscca/pkcscca.c
+	usr/lib/common/shared_memory.c usr/lib/common/profile_obj.c	\
+	usr/lib/common/attributes.c usr/lib/common/mech_rng.c		\
+	usr/lib/common/pkcs_utils.c 					\
+	usr/sbin/pkcscca/pkcscca.c
+	
+	
+if ENABLE_LOCKS
+usr_sbin_pkcscca_pkcscca_SOURCES +=				\
+	usr/lib/common/lock_btree.c usr/lib/common/lock_sess_mgr.c
+usr_sbin_pkcscca_pkcscca_LDFLAGS += -lpthread
+else
+usr_sbin_pkcscca_pkcscca_SOURCES +=				\
+	usr/lib/common/btree.c usr/lib/common/sess_mgr.c
+usr_sbin_pkcscca_pkcscca_LDFLAGS += -litm
+endif


### PR DESCRIPTION
This is an attempt to remove the duplicated code parts that have been copied from common code files into pkcscca.c. Duplicating code causes a maintenance nightmare.

 Instead of duplicating the code, link the common code parts into pkcscca. Unfortunately, almost all common code parts  need tobe included, to resolve all referenced symbols. That way lots of unused code is included into pkcscca, but at least its the exact same code as for the tokens.

Take a look and let me know what you think. If you prefer to keep the code duplication, thats fine with me, too.....