### PR TITLE
EP11: Update attributes in key blob when attributes are changed

### DIFF
--- a/usr/lib/cca_stdll/tok_struct.h
+++ b/usr/lib/cca_stdll/tok_struct.h
@@ -132,6 +132,7 @@ token_spec_t token_specific = {
     &token_specific_key_wrap,
     &token_specific_key_unwrap,
     &token_specific_reencrypt_single,
+    NULL,                       // set_attribute_values
 };
 
 #endif

--- a/usr/lib/common/tok_spec_struct.h
+++ b/usr/lib/common/tok_spec_struct.h
@@ -273,6 +273,8 @@ struct token_specific_struct {
                                 ENCR_DECR_CONTEXT *, CK_MECHANISM *, OBJECT *,
                                 ENCR_DECR_CONTEXT *, CK_MECHANISM *, OBJECT *,
                                 CK_BYTE *, CK_ULONG , CK_BYTE *, CK_ULONG *);
+
+    CK_RV(*t_set_attribute_values) (STDLL_TokData_t *, OBJECT *, TEMPLATE *);
 };
 
 typedef struct token_specific_struct token_spec_t;

--- a/usr/lib/common/tok_specific.h
+++ b/usr/lib/common/tok_specific.h
@@ -319,4 +319,7 @@ CK_RV token_specific_reencrypt_single(STDLL_TokData_t *, SESSION *,
                                       CK_MECHANISM *, OBJECT *, CK_BYTE *,
                                       CK_ULONG , CK_BYTE *, CK_ULONG *);
 
+CK_RV token_specific_set_attribute_values(STDLL_TokData_t *, OBJECT *,
+                                          TEMPLATE *);
+
 #endif

--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -1083,7 +1083,6 @@ static CK_RV build_ep11_attrs(TEMPLATE *template, CK_ATTRIBUTE_PTR *p_attrs,
         /* EP11 handles this as 'read only' and reports an error if specified */
         switch (attr->type) {
         case CKA_NEVER_EXTRACTABLE:
-        case CKA_MODIFIABLE:
         case CKA_LOCAL:
             break;
         default:
@@ -1688,11 +1687,11 @@ static CK_RV make_maced_spki(STDLL_TokData_t *tokdata, SESSION * sess,
             break;
 
         case CKA_EXTRACTABLE:
-        //case CKA_NEVER_EXTRACTABLE:
-        //case CKA_MODIFIABLE:
+
+        case CKA_MODIFIABLE:
         case CKA_DERIVE:
         case CKA_WRAP:
-        //case CKA_LOCAL:
+
         case CKA_TRUSTED:
         case CKA_IBM_RESTRICTABLE:
         case CKA_IBM_NEVER_MODIFIABLE:

--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -9585,3 +9585,111 @@ static void free_ep11_target_for_apqn(target_t target)
     }
 }
 
+CK_RV token_specific_set_attribute_values(STDLL_TokData_t *tokdata, OBJECT *obj,
+                                          TEMPLATE *new_tmpl)
+{
+    ep11_private_data_t *ep11_data = tokdata->private_data;
+    CK_OBJECT_CLASS class;
+    size_t keyblobsize = 0;
+    CK_BYTE *keyblob;
+    DL_NODE *node;
+    CK_ATTRIBUTE *ibm_opaque_attr = NULL;
+    CK_ATTRIBUTE_PTR attributes = NULL;
+    CK_ULONG num_attributes = 0;
+    CK_ATTRIBUTE *attr;
+    CK_RV rc;
+
+    rc = template_attribute_get_ulong(obj->template, CKA_CLASS, &class);
+    if (rc != CKR_OK) {
+        TRACE_ERROR("%s CKA_CLASS is missing\n", __func__);
+        return rc;
+    }
+
+    switch (class) {
+    case CKO_SECRET_KEY:
+    case CKO_PRIVATE_KEY:
+    case CKO_PUBLIC_KEY:
+        break;
+    default:
+        /* Not a key, nothing to do */
+        return CKR_OK;
+    }
+
+    rc = obj_opaque_2_blob(tokdata, obj, &keyblob, &keyblobsize);
+    if (rc != CKR_OK) {
+        TRACE_ERROR("%s no key-blob rc=0x%lx\n", __func__, rc);
+        return rc;
+    }
+
+    node = new_tmpl->attribute_list;
+    while (node) {
+        attr = (CK_ATTRIBUTE *)node->data;
+
+        /* EP11 can set certain boolean attributes only */
+        switch (attr->type) {
+        case CKA_EXTRACTABLE:
+        case CKA_MODIFIABLE:
+        case CKA_SIGN:
+        case CKA_SIGN_RECOVER:
+        case CKA_DECRYPT:
+        case CKA_ENCRYPT:
+        case CKA_DERIVE:
+        case CKA_UNWRAP:
+        case CKA_WRAP:
+        case CKA_VERIFY:
+        case CKA_VERIFY_RECOVER:
+        case CKA_WRAP_WITH_TRUSTED:
+        case CKA_TRUSTED:
+        case CKA_IBM_RESTRICTABLE:
+        case CKA_IBM_USE_AS_DATA:
+            rc = add_to_attribute_array(&attributes, &num_attributes,
+                                        attr->type, attr->pValue,
+                                        attr->ulValueLen);
+            if (rc != CKR_OK) {
+                TRACE_ERROR("%s add_to_attribute_array failed rc=0x%lx\n",
+                            __func__, rc);
+                goto out;
+            }
+            break;
+        default:
+            /* Either non-boolean, or read-only */
+            break;
+        }
+
+        node = node->next;
+    }
+
+    if (attributes != NULL && num_attributes > 0) {
+        rc = build_attribute(CKA_IBM_OPAQUE, keyblob, keyblobsize,
+                             &ibm_opaque_attr);
+        if (rc != CKR_OK) {
+            TRACE_ERROR("%s build_attribute failed rc=0x%lx\n", __func__, rc);
+            goto out;
+        }
+
+        rc = dll_m_SetAttributeValue(ibm_opaque_attr->pValue,
+                                     ibm_opaque_attr->ulValueLen, attributes,
+                                     num_attributes, ep11_data->target);
+        if (rc != CKR_OK) {
+            rc = ep11_error_to_pkcs11_error(rc, NULL);
+            TRACE_ERROR("%s m_SetAttributeValue failed rc=0x%lx\n",
+                        __func__, rc);
+            goto out;
+        }
+
+        rc = template_update_attribute(new_tmpl, ibm_opaque_attr);
+        if (rc != CKR_OK) {
+            TRACE_ERROR("%s template_update_attribute failed rc=0x%lx\n",
+                        __func__, rc);
+            free(ibm_opaque_attr);
+            goto out;
+        }
+    }
+
+out:
+    if (attributes)
+        free_attribute_array(attributes, num_attributes);
+
+    return rc;
+}
+

--- a/usr/lib/ep11_stdll/tok_struct.h
+++ b/usr/lib/ep11_stdll/tok_struct.h
@@ -135,6 +135,7 @@ token_spec_t token_specific = {
     NULL,                       // key_wrap
     NULL,                       // key_unwrap
     &token_specific_reencrypt_single,
+    NULL,                       // set_attribute_values
 };
 
 #endif

--- a/usr/lib/ep11_stdll/tok_struct.h
+++ b/usr/lib/ep11_stdll/tok_struct.h
@@ -135,7 +135,7 @@ token_spec_t token_specific = {
     NULL,                       // key_wrap
     NULL,                       // key_unwrap
     &token_specific_reencrypt_single,
-    NULL,                       // set_attribute_values
+    &token_specific_set_attribute_values,
 };
 
 #endif

--- a/usr/lib/ica_s390_stdll/tok_struct.h
+++ b/usr/lib/ica_s390_stdll/tok_struct.h
@@ -145,6 +145,7 @@ token_spec_t token_specific = {
     NULL,                       // key_wrap
     NULL,                       // key_unwrap
     NULL,                       // reencrypt_single
+    NULL,                       // set_attribute_values
 };
 
 #endif

--- a/usr/lib/icsf_stdll/tok_struct.h
+++ b/usr/lib/icsf_stdll/tok_struct.h
@@ -127,6 +127,7 @@ token_spec_t token_specific = {
     NULL,                       // key_wrap
     NULL,                       // key_unwrap
     NULL,                       // reencrypt_single
+    NULL,                       // set_attribute_values
 };
 
 #endif

--- a/usr/lib/soft_stdll/tok_struct.h
+++ b/usr/lib/soft_stdll/tok_struct.h
@@ -170,6 +170,7 @@ token_spec_t token_specific = {
     NULL,                       // key_wrap
     NULL,                       // key_unwrap
     NULL,                       // reencrypt_single
+    NULL,                       // set_attribute_values
 };
 
 #endif

--- a/usr/lib/tpm_stdll/tok_struct.h
+++ b/usr/lib/tpm_stdll/tok_struct.h
@@ -118,4 +118,5 @@ struct token_specific_struct token_specific = {
     &token_specific_key_wrap,
     &token_specific_key_unwrap,
     NULL,                       // reencrypt_single
+    NULL,                       // set_attribute_values
 };


### PR DESCRIPTION
The EP11 key blob also contains a set of attributes (e.g. boolean attributes). Make sure that when attributes are changed (e.g. via C_SetAttributeValues), that the key blob is also updated with the changed attributes. Otherwise the view of the attributes of a key as seen by OCK and the view of the attributes as seen by EP11 may differ. This may cause errors (e.g. rejects of certain operations)  due to different attributes.