### PR TITLE
Support import of raw cca tokens with C_ObjectCreate

### DIFF
--- a/testcases/common/common.c
+++ b/testcases/common/common.c
@@ -149,6 +149,9 @@ int create_AESKey(CK_SESSION_HANDLE session,
     };
 
     rc = funcs->C_CreateObject(session, keyTemplate, 5, h_key);
+    if (rc != CKR_OK) {
+        testcase_error("C_CreateObject rc=%s", p11_get_ckr(rc));
+    }
 
     return rc;
 }
@@ -167,6 +170,9 @@ int generate_AESKey(CK_SESSION_HANDLE session,
                                     key_gen_tmpl,
                                     1,
                                     h_key);
+    if (rc != CKR_OK) {
+	testcase_error("C_GenerateKey rc=%s", p11_get_ckr(rc));
+    }
 
     return rc;
 }

--- a/testcases/misc_tests/cca_export_import_test.c
+++ b/testcases/misc_tests/cca_export_import_test.c
@@ -1,0 +1,1448 @@
+/*
+ * COPYRIGHT (c) International Business Machines Corp. 2020
+ *
+ * This program is provided under the terms of the Common Public License,
+ * version 1.0 (CPL-1.0). Any use, reproduction or distribution for this
+ * software constitutes recipient's acceptance of CPL-1.0 terms which can
+ * be found in the file LICENSE file or at
+ * https://opensource.org/licenses/cpl1.0.php
+ *
+ * import/export test for the CCA token
+ * by Harald Freudenberger <freude@de.ibm.com>
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <memory.h>
+#include <stdint.h>
+
+#include "pkcs11types.h"
+#include "ec_curves.h"
+
+#include "regress.h"
+#include "common.c"
+
+// define this to enable the AES cipher key import test:
+// #define CCA_AES_CIPHER_KEY_SUPPORTED
+
+static CK_RV export_ibm_opaque(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE handle,
+			       CK_BYTE **buf, CK_ULONG *buflen)
+{
+    CK_RV rc;
+    CK_ULONG len;
+    CK_ATTRIBUTE a_opaque = { CKA_IBM_OPAQUE, NULL_PTR, 0 };
+
+    rc = funcs->C_GetAttributeValue(session, handle, &a_opaque, 1);
+    if (rc != CKR_OK) {
+	testcase_error("C_GetAttributeValue() rc=%s", p11_get_ckr(rc));
+	return rc;
+    }
+    len = a_opaque.ulValueLen;
+    if (!len) {
+	testcase_error("opaque attribute len is 0");
+	return CKR_ATTRIBUTE_VALUE_INVALID;
+    }
+    a_opaque.pValue = malloc(len);
+    if (!a_opaque.pValue) {
+	testcase_error("malloc(%lu) failed", len);
+	return CKR_HOST_MEMORY;
+    }
+    rc = funcs->C_GetAttributeValue(session, handle, &a_opaque, 1);
+    if (rc != CKR_OK) {
+	testcase_error("C_GetAttributeValue() rc=%s", p11_get_ckr(rc));
+	return rc;
+    }
+
+    *buf = a_opaque.pValue;
+    *buflen = len;
+
+    return CKR_OK;
+}
+
+static CK_RV import_cca_des_key(CK_SESSION_HANDLE session,
+				const char *label,
+				CK_BYTE *ccatoken, CK_ULONG tokenlen,
+				CK_OBJECT_HANDLE *handle)
+{
+    CK_RV rc;
+    CK_OBJECT_CLASS keyClass = CKO_SECRET_KEY;
+    CK_KEY_TYPE keyType = CKK_DES;
+    CK_BBOOL true = TRUE;
+    CK_BBOOL false = FALSE;
+    CK_ATTRIBUTE template[] = {
+	{CKA_CLASS, &keyClass, sizeof(keyClass)},
+	{CKA_KEY_TYPE, &keyType, sizeof(keyType)},
+	{CKA_LABEL, (char *) label, strlen(label) + 1},
+	{CKA_ENCRYPT, &true, sizeof(true)},
+	{CKA_TOKEN, &false, sizeof(false)},
+	{CKA_IBM_OPAQUE, ccatoken, tokenlen}
+    };
+    CK_ULONG nattr = sizeof(template)/sizeof(CK_ATTRIBUTE);
+
+    rc = funcs->C_CreateObject(session, template, nattr, handle);
+    if (rc != CKR_OK) {
+	testcase_error("C_CreateObject() rc=%s", p11_get_ckr(rc));
+    }
+
+    return rc;
+}
+
+static CK_RV import_cca_des3_key(CK_SESSION_HANDLE session,
+				 const char *label,
+				 CK_BYTE *ccatoken, CK_ULONG tokenlen,
+				 CK_OBJECT_HANDLE *handle)
+{
+    CK_RV rc;
+    CK_OBJECT_CLASS keyClass = CKO_SECRET_KEY;
+    CK_KEY_TYPE keyType = CKK_DES3;
+    CK_BBOOL true = TRUE;
+    CK_BBOOL false = FALSE;
+    CK_ATTRIBUTE template[] = {
+	{CKA_CLASS, &keyClass, sizeof(keyClass)},
+	{CKA_KEY_TYPE, &keyType, sizeof(keyType)},
+	{CKA_LABEL, (char *) label, strlen(label) + 1},
+	{CKA_ENCRYPT, &true, sizeof(true)},
+	{CKA_TOKEN, &false, sizeof(false)},
+	{CKA_IBM_OPAQUE, ccatoken, tokenlen}
+    };
+    CK_ULONG nattr = sizeof(template)/sizeof(CK_ATTRIBUTE);
+
+    rc = funcs->C_CreateObject(session, template, nattr, handle);
+    if (rc != CKR_OK) {
+	testcase_error("C_CreateObject() rc=%s", p11_get_ckr(rc));
+    }
+
+    return rc;
+}
+
+static CK_RV import_cca_aes_key(CK_SESSION_HANDLE session,
+				const char *label,
+				CK_BYTE *ccatoken, CK_ULONG tokenlen,
+				CK_OBJECT_HANDLE *handle)
+{
+    CK_RV rc;
+    CK_OBJECT_CLASS keyClass = CKO_SECRET_KEY;
+    CK_KEY_TYPE keyType = CKK_AES;
+    CK_BBOOL true = TRUE;
+    CK_BBOOL false = FALSE;
+    CK_ATTRIBUTE template[] = {
+	{CKA_CLASS, &keyClass, sizeof(keyClass)},
+	{CKA_KEY_TYPE, &keyType, sizeof(keyType)},
+	{CKA_LABEL, (char *) label, strlen(label) + 1},
+	{CKA_ENCRYPT, &true, sizeof(true)},
+	{CKA_TOKEN, &false, sizeof(false)},
+	{CKA_IBM_OPAQUE, ccatoken, tokenlen}
+    };
+    CK_ULONG nattr = sizeof(template)/sizeof(CK_ATTRIBUTE);
+
+    rc = funcs->C_CreateObject(session, template, nattr, handle);
+    if (rc != CKR_OK) {
+	testcase_error("C_CreateObject() rc=%s", p11_get_ckr(rc));
+    }
+
+    return rc;
+}
+
+#if CCA_AES_CIPHER_KEY_SUPPORTED
+static CK_RV import_cca_aes_cipher_key(CK_SESSION_HANDLE session,
+				       const char *label,
+				       CK_BYTE *ccatoken, CK_ULONG tokenlen,
+				       unsigned int keybitsize,
+				       CK_OBJECT_HANDLE *handle)
+{
+    CK_RV rc;
+    CK_OBJECT_CLASS keyClass = CKO_SECRET_KEY;
+    CK_KEY_TYPE keyType = CKK_AES;
+    CK_BYTE value[32];
+    CK_BBOOL true = TRUE;
+    CK_BBOOL false = FALSE;
+    CK_ATTRIBUTE template[] = {
+	{CKA_CLASS, &keyClass, sizeof(keyClass)},
+	{CKA_KEY_TYPE, &keyType, sizeof(keyType)},
+	{CKA_LABEL, (char *) label, strlen(label) + 1},
+	{CKA_ENCRYPT, &true, sizeof(true)},
+	{CKA_TOKEN, &false, sizeof(false)},
+	{CKA_VALUE, value, sizeof(value)},
+	{CKA_IBM_OPAQUE, ccatoken, tokenlen}
+    };
+    CK_ULONG nattr = sizeof(template)/sizeof(CK_ATTRIBUTE);
+
+    memset(value, 0, sizeof(value));
+    template[5].ulValueLen = keybitsize / 8;
+
+    rc = funcs->C_CreateObject(session, template, nattr, handle);
+    if (rc != CKR_OK) {
+	testcase_error("C_CreateObject() rc=%s", p11_get_ckr(rc));
+    }
+
+    return rc;
+}
+#endif
+
+static CK_RV import_cca_gen_sec_key(CK_SESSION_HANDLE session,
+				    const char *label,
+				    CK_BYTE *ccatoken, CK_ULONG tokenlen,
+				    unsigned int keybitsize,
+				    CK_OBJECT_HANDLE *handle)
+{
+    CK_RV rc;
+    CK_OBJECT_CLASS keyClass = CKO_SECRET_KEY;
+    CK_KEY_TYPE keyType = CKK_GENERIC_SECRET;
+    CK_BYTE value[512];
+    CK_BBOOL true = TRUE;
+    CK_BBOOL false = FALSE;
+    CK_ATTRIBUTE template[] = {
+	{CKA_CLASS, &keyClass, sizeof(keyClass)},
+	{CKA_KEY_TYPE, &keyType, sizeof(keyType)},
+	{CKA_LABEL, (char *) label, strlen(label) + 1},
+	{CKA_SIGN, &true, sizeof(true)},
+	{CKA_VERIFY, &true, sizeof(true)},
+	{CKA_TOKEN, &false, sizeof(false)},
+	{CKA_VALUE, value, sizeof(value)},
+	{CKA_IBM_OPAQUE, ccatoken, tokenlen}
+    };
+    CK_ULONG nattr = sizeof(template)/sizeof(CK_ATTRIBUTE);
+    unsigned pl, calc_pl;
+
+    memset(value, 0, sizeof(value));
+
+    // cca only supports hmac key in range 80...2048
+    if (keybitsize < 80 || keybitsize > 2048) {
+	testcase_error("invalid keybitsize %u", keybitsize);
+	return CKR_ATTRIBUTE_VALUE_INVALID;
+    }
+
+    // calculate expected payloadbitsize based on keybitsize
+    calc_pl = (((keybitsize + 32) + 63) & (~63)) + 320;
+    // pull payloadbitsize from the cca hmac token
+    pl = *((uint16_t *)(ccatoken + 38));
+    if (calc_pl != pl) {
+	testcase_error("mismatch keybitsize %u - expected pl bitsize %u / cca pl bitsize %hu",
+		       keybitsize, calc_pl, pl);
+	return CKR_ATTRIBUTE_VALUE_INVALID;
+    }
+
+    template[6].ulValueLen = (keybitsize + 7) / 8;
+
+    rc = funcs->C_CreateObject(session, template, nattr, handle);
+    if (rc != CKR_OK) {
+	testcase_error("C_CreateObject() rc=%s", p11_get_ckr(rc));
+    }
+
+    return rc;
+}
+
+static CK_RV import_rsa_priv_key(CK_SESSION_HANDLE session,
+				 const char *label,
+				 CK_BYTE *ccatoken, CK_ULONG tokenlen,
+				 CK_OBJECT_HANDLE *handle)
+{
+    CK_RV rc;
+    CK_OBJECT_CLASS keyClass = CKO_PRIVATE_KEY;
+    CK_KEY_TYPE keyType = CKK_RSA;
+    CK_BBOOL true = TRUE;
+    CK_BBOOL false = FALSE;
+    CK_ATTRIBUTE template[] = {
+	{CKA_CLASS, &keyClass, sizeof(keyClass)},
+	{CKA_KEY_TYPE, &keyType, sizeof(keyType)},
+	{CKA_LABEL, (char *) label, strlen(label) + 1},
+	{CKA_SIGN, &true, sizeof(true)},
+	{CKA_DECRYPT, &true, sizeof(true)},
+	{CKA_TOKEN, &false, sizeof(false)},
+	{CKA_IBM_OPAQUE, ccatoken, tokenlen}
+    };
+    CK_ULONG nattr = sizeof(template)/sizeof(CK_ATTRIBUTE);
+
+    rc = funcs->C_CreateObject(session, template, nattr, handle);
+    if (rc != CKR_OK) {
+	testcase_error("C_CreateObject() rc=%s", p11_get_ckr(rc));
+    }
+
+    return rc;
+}
+
+static CK_RV import_rsa_publ_key(CK_SESSION_HANDLE session,
+				 const char *label,
+				 CK_BYTE *ccatoken, CK_ULONG tokenlen,
+				 CK_OBJECT_HANDLE *handle)
+{
+    CK_RV rc;
+    CK_OBJECT_CLASS keyClass = CKO_PUBLIC_KEY;
+    CK_KEY_TYPE keyType = CKK_RSA;
+    CK_BBOOL true = TRUE;
+    CK_BBOOL false = FALSE;
+    CK_ATTRIBUTE template[] = {
+	{CKA_CLASS, &keyClass, sizeof(keyClass)},
+	{CKA_KEY_TYPE, &keyType, sizeof(keyType)},
+	{CKA_LABEL, (char *) label, strlen(label) + 1},
+	{CKA_VERIFY, &true, sizeof(true)},
+	{CKA_ENCRYPT, &true, sizeof(true)},
+	{CKA_TOKEN, &false, sizeof(false)},
+	{CKA_IBM_OPAQUE, ccatoken, tokenlen}
+    };
+    CK_ULONG nattr = sizeof(template)/sizeof(CK_ATTRIBUTE);
+
+    rc = funcs->C_CreateObject(session, template, nattr, handle);
+    if (rc != CKR_OK) {
+	testcase_error("C_CreateObject() rc=%s", p11_get_ckr(rc));
+    }
+
+    return rc;
+}
+
+static CK_RV import_ecc_priv_key(CK_SESSION_HANDLE session,
+				 const char *label,
+				 CK_BYTE *ccatoken, CK_ULONG tokenlen,
+				 CK_OBJECT_HANDLE *handle)
+{
+    CK_RV rc;
+    CK_OBJECT_CLASS keyClass = CKO_PRIVATE_KEY;
+    CK_KEY_TYPE keyType = CKK_EC;
+    CK_BBOOL true = TRUE;
+    CK_BBOOL false = FALSE;
+    CK_ATTRIBUTE template[] = {
+	{CKA_CLASS, &keyClass, sizeof(keyClass)},
+	{CKA_KEY_TYPE, &keyType, sizeof(keyType)},
+	{CKA_LABEL, (char *) label, strlen(label) + 1},
+	{CKA_SIGN, &true, sizeof(true)},
+	{CKA_TOKEN, &false, sizeof(false)},
+	{CKA_IBM_OPAQUE, ccatoken, tokenlen}
+    };
+    CK_ULONG nattr = sizeof(template)/sizeof(CK_ATTRIBUTE);
+
+    rc = funcs->C_CreateObject(session, template, nattr, handle);
+    if (rc != CKR_OK) {
+	testcase_error("C_CreateObject() rc=%s", p11_get_ckr(rc));
+    }
+
+    return rc;
+}
+
+static CK_RV import_ecc_publ_key(CK_SESSION_HANDLE session,
+				 const char *label,
+				 CK_BYTE *ccatoken, CK_ULONG tokenlen,
+				 CK_OBJECT_HANDLE *handle)
+{
+    CK_RV rc;
+    CK_OBJECT_CLASS keyClass = CKO_PUBLIC_KEY;
+    CK_KEY_TYPE keyType = CKK_EC;
+    CK_BBOOL true = TRUE;
+    CK_BBOOL false = FALSE;
+    CK_ATTRIBUTE template[] = {
+	{CKA_CLASS, &keyClass, sizeof(keyClass)},
+	{CKA_KEY_TYPE, &keyType, sizeof(keyType)},
+	{CKA_LABEL, (char *) label, strlen(label) + 1},
+	{CKA_VERIFY, &true, sizeof(true)},
+	{CKA_TOKEN, &false, sizeof(false)},
+	{CKA_IBM_OPAQUE, ccatoken, tokenlen}
+    };
+    CK_ULONG nattr = sizeof(template)/sizeof(CK_ATTRIBUTE);
+
+    rc = funcs->C_CreateObject(session, template, nattr, handle);
+    if (rc != CKR_OK) {
+	testcase_error("C_CreateObject() rc=%s", p11_get_ckr(rc));
+    }
+
+    return rc;
+}
+
+static CK_RV cca_des_data_export_import_tests(void)
+{
+    const char *tstr = "CCA export/import test with DES data key";
+    CK_RV rc = CKR_OK;
+    CK_FLAGS flags;
+    CK_SESSION_HANDLE session;
+    CK_BYTE user_pin[PKCS11_MAX_PIN_LEN];
+    CK_ULONG user_pin_len;
+    CK_BYTE key[] = { 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef };
+    CK_BYTE iv[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+    CK_MECHANISM mech = { CKM_DES_CBC, iv, sizeof(iv) };
+    CK_OBJECT_HANDLE hkey, hikey;
+    CK_BYTE data[80], encdata1[80], encdata2[80];
+    CK_ULONG ilen, len;
+    CK_BYTE *opaquekey = NULL;
+    CK_ULONG opaquekeylen;
+    char label[80];
+
+    testcase_begin("%s", tstr);
+
+    if (!is_cca_token(SLOT_ID)) {
+	testcase_skip("%s: this slot is not a CCA token", tstr);
+	goto out;
+    }
+
+    testcase_rw_session();
+    testcase_user_login();
+
+    // create ock des key
+
+    rc = create_DESKey(session, key, sizeof(key), &hkey);
+    if (rc != CKR_OK) {
+	testcase_error("create_DESKey() rc=%s", p11_get_ckr(rc));
+	goto testcase_cleanup;
+    }
+
+    // encrypt some data with this key
+
+    rc = funcs->C_EncryptInit(session, &mech, hkey);
+    if (rc != CKR_OK) {
+	testcase_error("C_EncryptInit rc=%s", p11_get_ckr(rc));
+	goto testcase_cleanup;
+    }
+    ilen = len = sizeof(data);
+    rc = funcs->C_Encrypt(session, data, ilen, encdata1, &len);
+    if (rc != CKR_OK) {
+	testcase_error("C_Encrypt rc=%s", p11_get_ckr(rc));
+	goto testcase_cleanup;
+    }
+    if (ilen != len) {
+	testcase_fail("plain and encrypted data len does not match");
+	goto testcase_cleanup;
+    }
+
+    testcase_new_assertion();
+
+    // export this key's cca token
+
+    rc = export_ibm_opaque(session, hkey, &opaquekey, &opaquekeylen);
+    if (rc != CKR_OK) {
+	testcase_fail("export_ibm_opaque rc=%s", p11_get_ckr(rc));
+	goto testcase_cleanup;
+    }
+
+    // re-import this cca token as a new key object
+
+    snprintf(label, sizeof(label), "re-imported_des_key");
+    rc = import_cca_des_key(session, label, opaquekey, opaquekeylen, &hikey);
+    if (rc != CKR_OK) {
+	testcase_fail("import_cca_des_key rc=%s", p11_get_ckr(rc));
+	goto testcase_cleanup;
+    }
+
+    // encrypt same data with this re-imported key
+
+    rc = funcs->C_EncryptInit(session, &mech, hikey);
+    if (rc != CKR_OK) {
+	testcase_error("C_EncryptInit rc=%s", p11_get_ckr(rc));
+	goto testcase_cleanup;
+    }
+    ilen = len = sizeof(data);
+    rc = funcs->C_Encrypt(session, data, ilen, encdata2, &len);
+    if (rc != CKR_OK) {
+	testcase_error("C_Encrypt rc=%s", p11_get_ckr(rc));
+	goto testcase_cleanup;
+    }
+    if (ilen != len) {
+	testcase_fail("plain and encrypted data len does not match");
+	goto testcase_cleanup;
+    }
+
+    // and check the encrypted data to be equal
+
+    if (memcmp(encdata1, encdata2, len) != 0) {
+	testcase_fail("encrypted data from original and exported/imported key is NOT the same");
+	goto testcase_cleanup;
+    }
+
+    testcase_pass("%s: ok", tstr);
+
+testcase_cleanup:
+    testcase_close_session();
+    free(opaquekey);
+out:
+    return rc;
+}
+
+static CK_RV cca_des3_data_export_import_tests(void)
+{
+    const char *tstr = "CCA export/import test with DES3 data key";
+    CK_RV rc = CKR_OK;
+    CK_FLAGS flags;
+    CK_SESSION_HANDLE session;
+    CK_BYTE user_pin[PKCS11_MAX_PIN_LEN];
+    CK_ULONG user_pin_len;
+    CK_BYTE key[] = { 0xe9, 0x7c, 0x83, 0x13, 0xba, 0x26, 0x5d, 0x43,
+		      0x25, 0x4c, 0xbf, 0x9e, 0x8f, 0x7c, 0x2a, 0xa8,
+		      0xa7, 0x54, 0xd6, 0x5e, 0x8a, 0xe9, 0x97, 0xe3 };
+    CK_BYTE iv[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+    CK_MECHANISM mech = { CKM_DES3_CBC, iv, sizeof(iv) };
+    CK_OBJECT_HANDLE hkey, hikey;
+    CK_BYTE data[80], encdata1[80], encdata2[80];
+    CK_ULONG ilen, len;
+    CK_BYTE *opaquekey = NULL;
+    CK_ULONG opaquekeylen;
+    char label[80];
+
+    testcase_begin("%s", tstr);
+
+    if (!is_cca_token(SLOT_ID)) {
+	testcase_skip("%s: this slot is not a CCA token", tstr);
+	goto out;
+    }
+
+    testcase_rw_session();
+    testcase_user_login();
+
+    // create ock 3des key
+
+    rc = create_DES3Key(session, key, sizeof(key), &hkey);
+    if (rc != CKR_OK) {
+	testcase_error("create_DES3Key() rc=%s", p11_get_ckr(rc));
+	goto testcase_cleanup;
+    }
+
+    // encrypt some data with this key
+
+    rc = funcs->C_EncryptInit(session, &mech, hkey);
+    if (rc != CKR_OK) {
+	testcase_error("C_EncryptInit rc=%s", p11_get_ckr(rc));
+	goto testcase_cleanup;
+    }
+    ilen = len = sizeof(data);
+    rc = funcs->C_Encrypt(session, data, ilen, encdata1, &len);
+    if (rc != CKR_OK) {
+	testcase_error("C_Encrypt rc=%s", p11_get_ckr(rc));
+	goto testcase_cleanup;
+    }
+    if (ilen != len) {
+	testcase_fail("plain and encrypted data len does not match");
+	goto testcase_cleanup;
+    }
+
+    testcase_new_assertion();
+
+    // export this key's cca token
+
+    rc = export_ibm_opaque(session, hkey, &opaquekey, &opaquekeylen);
+    if (rc != CKR_OK) {
+	testcase_fail("export_ibm_opaque rc=%s", p11_get_ckr(rc));
+	goto testcase_cleanup;
+    }
+
+    // re-import this cca token as a new key object
+
+    snprintf(label, sizeof(label), "re-imported_des3_key");
+    rc = import_cca_des3_key(session, label, opaquekey, opaquekeylen, &hikey);
+    if (rc != CKR_OK) {
+	testcase_fail("import_cca_des3_key rc=%s", p11_get_ckr(rc));
+	goto testcase_cleanup;
+    }
+
+    // encrypt same data with this re-imported key
+
+    rc = funcs->C_EncryptInit(session, &mech, hikey);
+    if (rc != CKR_OK) {
+	testcase_error("C_EncryptInit rc=%s", p11_get_ckr(rc));
+	goto testcase_cleanup;
+    }
+    ilen = len = sizeof(data);
+    rc = funcs->C_Encrypt(session, data, ilen, encdata2, &len);
+    if (rc != CKR_OK) {
+	testcase_error("C_Encrypt rc=%s", p11_get_ckr(rc));
+	goto testcase_cleanup;
+    }
+    if (ilen != len) {
+	testcase_fail("plain and encrypted data len does not match");
+	goto testcase_cleanup;
+    }
+
+    // and check the encrypted data to be equal
+
+    if (memcmp(encdata1, encdata2, len) != 0) {
+	testcase_fail("encrypted data from original and exported/imported key is NOT the same");
+	goto testcase_cleanup;
+    }
+
+    testcase_pass("%s: ok", tstr);
+
+testcase_cleanup:
+    testcase_close_session();
+    free(opaquekey);
+out:
+    return rc;
+}
+
+static CK_RV cca_aes_data_export_import_tests(void)
+{
+    CK_RV rc = CKR_OK;
+    CK_FLAGS flags;
+    CK_SESSION_HANDLE session;
+    CK_BYTE user_pin[PKCS11_MAX_PIN_LEN];
+    CK_ULONG user_pin_len;
+    CK_BYTE key[] = { 0x60, 0x3d, 0xeb, 0x10, 0x15, 0xca, 0x71, 0xbe,
+		      0x2b, 0x73, 0xae, 0xf0, 0x85, 0x7d, 0x77, 0x81,
+		      0x1f, 0x35, 0x2c, 0x07, 0x3b, 0x61, 0x08, 0xd7,
+		      0x2d, 0x98, 0x10, 0xa3, 0x09, 0x14, 0xdf, 0xf4 };
+    CK_BYTE iv[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+		     0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f };
+    CK_MECHANISM mech = { CKM_AES_CBC, iv, sizeof(iv) };
+    CK_OBJECT_HANDLE hkey, hikey;
+    CK_BYTE data[160], encdata1[160], encdata2[160];
+    CK_ULONG ilen, len;
+    CK_BYTE *opaquekey = NULL;
+    CK_ULONG opaquekeylen;
+    unsigned int keylen;
+    char label[80];
+
+    testcase_rw_session();
+    testcase_user_login();
+
+    for (keylen = 16; keylen <= 32; keylen += 8) {
+
+	testcase_begin("CCA export/import test with AES%d data key", 8 * keylen);
+
+	if (!is_cca_token(SLOT_ID)) {
+	    testcase_skip("this slot is not a CCA token");
+	    goto out;
+	}
+
+	// create ock aes key
+
+	rc = create_AESKey(session, key, keylen, &hkey);
+	if (rc != CKR_OK) {
+	    testcase_error("create_AESKey() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// encrypt some data with this key
+
+	rc = funcs->C_EncryptInit(session, &mech, hkey);
+	if (rc != CKR_OK) {
+	    testcase_error("C_EncryptInit rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+	ilen = len = sizeof(data);
+	rc = funcs->C_Encrypt(session, data, ilen, encdata1, &len);
+	if (rc != CKR_OK) {
+	    testcase_error("C_Encrypt rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+	if (ilen != len) {
+	    testcase_fail("plain and encrypted data len does not match");
+	    goto error;
+	}
+
+	testcase_new_assertion();
+
+	// export this key's cca token
+
+	rc = export_ibm_opaque(session, hkey, &opaquekey, &opaquekeylen);
+	if (rc != CKR_OK) {
+	    testcase_fail("export_ibm_opaque rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// re-import this cca token as a new key object
+
+	snprintf(label, sizeof(label), "re-imported_aes%u_key", 8 * keylen);
+	rc = import_cca_aes_key(session, label, opaquekey, opaquekeylen, &hikey);
+	if (rc != CKR_OK) {
+	    testcase_fail("import_cca_aes_key rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// encrypt same data with this re-imported key
+
+	rc = funcs->C_EncryptInit(session, &mech, hikey);
+	if (rc != CKR_OK) {
+	    testcase_error("C_EncryptInit rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+	ilen = len = sizeof(data);
+	rc = funcs->C_Encrypt(session, data, ilen, encdata2, &len);
+	if (rc != CKR_OK) {
+	    testcase_error("C_Encrypt rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+	if (ilen != len) {
+	    testcase_fail("plain and encrypted data len does not match");
+	    goto error;
+	}
+
+	// and check the encrypted data to be equal
+
+	if (memcmp(encdata1, encdata2, len) != 0) {
+	    testcase_fail("encrypted data from original and exported/imported key is NOT the same");
+	    goto error;
+	}
+
+	testcase_pass("CCA export/import test with AES%d data key: ok", 8 * keylen);
+
+error:
+	free(opaquekey);
+	opaquekey = NULL;
+    }
+
+testcase_cleanup:
+    testcase_close_session();
+out:
+    return rc;
+}
+
+#if CCA_AES_CIPHER_KEY_SUPPORTED
+static CK_RV cca_aes_cipher_import_tests(void)
+{
+    CK_RV rc = CKR_OK;
+    CK_FLAGS flags;
+    CK_SESSION_HANDLE session;
+    CK_BYTE user_pin[PKCS11_MAX_PIN_LEN];
+    CK_ULONG user_pin_len;
+    CK_BYTE key[1024] = { 0 };
+    CK_BYTE iv[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+		     0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f };
+    CK_MECHANISM mech = { CKM_AES_CBC, iv, sizeof(iv) };
+    CK_OBJECT_HANDLE hkey;;
+    CK_BYTE data[160], encdata[160];
+    CK_ULONG ilen, len, keylen;
+    unsigned int i, keybitlen[] = { 128, 192, 256, 0 };
+    char filename[256], label[80];
+    FILE *f;
+
+    testcase_rw_session();
+    testcase_user_login();
+
+    for (i = 0; keybitlen[i]; i++) {
+
+	testcase_begin("CCA import test with AES%d cipher key", keybitlen[i]);
+
+	if (!is_cca_token(SLOT_ID)) {
+	    testcase_skip("this slot is not a CCA token");
+	    goto out;
+	}
+
+	// Opencryptoki can't create CCA AES cipher keys.
+	// So let's read a raw CCA AES cipher key from the pkey sysfs api
+
+	sprintf(filename, "/sys/devices/virtual/misc/pkey/ccacipher/ccacipher_aes_%u", keybitlen[i]);
+	f = fopen(filename, "r");
+	if (!f) {
+	    testcase_error("Can't open file '%s'", filename);
+	    goto error;
+	}
+	keylen = fread(key, 1, sizeof(key), f);
+	if (ferror(f) || keylen < 1) {
+	    testcase_error("Can't read cipher key from file '%s'", filename);
+	    fclose(f);
+	    goto error;
+	}
+	fclose(f);
+
+	testcase_new_assertion();
+
+	// import this key into Opencryptoki as an AES key object :-)
+
+	snprintf(label, sizeof(label), "imported_aes%u_cipher_key", keybitlen[i]);
+	rc = import_cca_aes_cipher_key(session, label, key, keylen, keybitlen[i], &hkey);
+	if (rc != CKR_OK) {
+	    testcase_fail("import_cca_aes_cipher_key rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// encrypt same data with this key just to make sure it is working
+
+	rc = funcs->C_EncryptInit(session, &mech, hkey);
+	if (rc != CKR_OK) {
+	    testcase_error("C_EncryptInit rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+	ilen = len = sizeof(data);
+	rc = funcs->C_Encrypt(session, data, ilen, encdata, &len);
+	if (rc != CKR_OK) {
+	    testcase_error("C_Encrypt rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+	if (ilen != len) {
+	    testcase_fail("plain and encrypted data len does not match");
+	    goto error;
+	}
+
+	// that's it here
+
+	testcase_pass("CCA import test with AES%d cipher key: ok", keybitlen[i]);
+
+error:
+	;
+    }
+
+testcase_cleanup:
+    testcase_close_session();
+out:
+    return rc;
+}
+#endif
+
+static CK_RV cca_hmac_data_export_import_tests(void)
+{
+    CK_RV rc = CKR_OK;
+    CK_FLAGS flags;
+    CK_SESSION_HANDLE session;
+    CK_BYTE user_pin[PKCS11_MAX_PIN_LEN];
+    CK_ULONG user_pin_len;
+    CK_BYTE key[512] = { 0x00 };
+    CK_OBJECT_HANDLE hkey, hikey;
+    CK_MECHANISM mech = { CKM_SHA_1_HMAC, 0, 0 };
+    CK_BYTE data[4096], mac1[4096], mac2[4096];
+    CK_BYTE *opaquekey = NULL;
+    CK_ULONG mac1len, mac2len, opaquekeylen;
+    unsigned int i, keybits[] = { 80, 160, 320, 640, 1024, 2048, 0 };
+    char label[80];
+
+    testcase_rw_session();
+    testcase_user_login();
+
+    for (i = 0; keybits[i]; i++) {
+
+	testcase_begin("CCA export/import test with generic secret key %u", keybits[i]);
+
+	if (!is_cca_token(SLOT_ID)) {
+	    testcase_skip("this slot is not a CCA token");
+	    goto out;
+	}
+
+	// create hmac key
+
+	rc = create_GenericSecretKey(session, key, keybits[i] / 8, &hkey);
+	if (rc != CKR_OK) {
+	    testcase_error("create_GenericSecretKey() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// sign data with original hmac key
+
+	rc = funcs->C_SignInit(session, &mech, hkey);
+	if (rc != CKR_OK) {
+	    testcase_error("C_SignInit rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+	mac1len = sizeof(mac1);
+	rc = funcs->C_Sign(session, data, sizeof(data), mac1, &mac1len);
+	if (rc != CKR_OK) {
+	    testcase_error("C_Sign rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+
+	testcase_new_assertion();
+
+	// export this key's cca token
+
+	rc = export_ibm_opaque(session, hkey, &opaquekey, &opaquekeylen);
+	if (rc != CKR_OK) {
+	    testcase_fail("export_ibm_opaque rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+
+#if 0
+	printf("cca hmac key token (%lu bytes):\n", opaquekeylen);
+	print_hex(opaquekey, opaquekeylen);
+#endif
+
+	// re-import this cca token as a new key object
+
+	snprintf(label, sizeof(label), "re-imported_hmac%u_key", keybits[i]);
+	rc = import_cca_gen_sec_key(session, label,
+				    opaquekey, opaquekeylen, keybits[i],
+				    &hikey);
+	if (rc != CKR_OK) {
+	    testcase_fail("import_cca_gen_sec_key rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// sign data with re-imported hmac key
+
+	rc = funcs->C_SignInit(session, &mech, hikey);
+	if (rc != CKR_OK) {
+	    testcase_error("C_SignInit with re-imported key failed, rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+	mac2len = sizeof(mac2);
+	rc = funcs->C_Sign(session, data, sizeof(data), mac2, &mac2len);
+	if (rc != CKR_OK) {
+	    testcase_error("C_Sign with re-imported key failed, rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// compare the two signatures
+
+	if (mac1len != mac2len) {
+	    testcase_fail("mac len with orig key %lu differs from mac len with re-imported key %lu",
+			  mac1len, mac2len);
+	    goto error;
+	}
+	if (memcmp(mac1, mac2, mac1len) != 0) {
+	    testcase_fail("signature with orig key differs from signature with re-imported key");
+	    goto error;
+	}
+
+	testcase_pass("CCA export/import test with generic secret key %u: ok", keybits[i]);
+
+error:
+	free(opaquekey);
+	opaquekey = NULL;
+    }
+
+testcase_cleanup:
+    testcase_close_session();
+out:
+    return rc;
+}
+
+static CK_RV cca_rsa_export_import_tests(void)
+{
+    CK_RV rc = CKR_OK;
+    CK_FLAGS flags;
+    CK_SESSION_HANDLE session;
+    CK_BYTE user_pin[PKCS11_MAX_PIN_LEN];
+    CK_ULONG user_pin_len;
+    CK_BYTE exp[] = { 0x01, 0x00, 0x01 };
+    CK_OBJECT_HANDLE publ_key, priv_key;
+    CK_OBJECT_HANDLE imp_priv_key, imp_publ_key;
+    CK_BYTE msg[512], sig[512];
+    CK_ULONG msglen, siglen;
+    CK_MECHANISM mech = {CKM_RSA_PKCS, 0, 0};
+    unsigned int keybitlen;
+    CK_BYTE *priv_opaquekey = NULL, *publ_opaquekey = NULL;
+    CK_ULONG priv_opaquekeylen, publ_opaquekeylen;
+    char label[80];
+
+    testcase_rw_session();
+    testcase_user_login();
+
+    for (keybitlen = 512; keybitlen <= 4096; keybitlen = 2 * keybitlen) {
+
+	testcase_begin("CCA export/import test with RSA %u key", keybitlen);
+
+	if (!is_cca_token(SLOT_ID)) {
+	    testcase_skip("this slot is not a CCA token");
+	    goto out;
+	}
+
+	// create ock rsa keypair
+
+	rc = generate_RSA_PKCS_KeyPair(session, keybitlen,
+				       exp, sizeof(exp),
+				       &publ_key, &priv_key);
+	if (rc != CKR_OK) {
+	    testcase_error("generate_RSA_PKCS_KeyPair() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+
+	testcase_new_assertion();
+
+	// sign with original private key
+
+	rc = funcs->C_SignInit(session, &mech, priv_key);
+	if (rc != CKR_OK) {
+	    testcase_error("C_SignInit() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+	msglen = (keybitlen / 8) / 2;
+	siglen = sizeof(sig);
+	rc = funcs->C_Sign(session, msg, msglen, sig, &siglen);
+	if (rc != CKR_OK) {
+	    testcase_error("C_Sign() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// verify with original public key
+
+	rc = funcs->C_VerifyInit(session, &mech, publ_key);
+	if (rc != CKR_OK) {
+	    testcase_error("C_VerifyInit() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+	rc = funcs->C_Verify(session, msg, msglen, sig, siglen);
+	if (rc == CKR_OK) {
+	    ;
+	} else if (rc == CKR_SIGNATURE_INVALID || rc == CKR_SIGNATURE_LEN_RANGE) {
+	    testcase_fail("signature verify failed");
+	    goto error;
+	} else {
+	    testcase_error("C_Verify() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// export original private key's cca token
+
+	rc = export_ibm_opaque(session, priv_key, &priv_opaquekey, &priv_opaquekeylen);
+	if (rc != CKR_OK) {
+	    testcase_fail("export_ibm_opaque on private key failed rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+#if 0
+	printf("priv_opaquekey (%lu bytes):\n", priv_opaquekeylen);
+	print_hex(priv_opaquekey, priv_opaquekeylen);
+#endif
+
+	// re-import this cca private rsa key token as new private rsa key
+
+	snprintf(label, sizeof(label), "re-imported_rsa%u_private_key", keybitlen);
+	rc = import_rsa_priv_key(session, label, priv_opaquekey, priv_opaquekeylen, &imp_priv_key);
+	if (rc != CKR_OK) {
+	    testcase_fail("import_rsa_priv_key on exported cca rsa key token failed rc=%s",
+			  p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// export original public key's cca token
+
+	rc = export_ibm_opaque(session, publ_key, &publ_opaquekey, &publ_opaquekeylen);
+	if (rc != CKR_OK) {
+	    testcase_fail("export_ibm_opaque on public key failed rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+#if 0
+	printf("publ_opaquekey (%lu bytes):\n", publ_opaquekeylen);
+	print_hex(publ_opaquekey, publ_opaquekeylen);
+#endif
+
+	// re-import this cca public rsa key token as new public rsa key
+
+	snprintf(label, sizeof(label), "re-imported_rsa%u_public_key", keybitlen);
+	rc = import_rsa_publ_key(session, label, publ_opaquekey, publ_opaquekeylen, &imp_publ_key);
+	if (rc != CKR_OK) {
+	    testcase_fail("import_rsa_publ_key on exported cca rsa key token failed rc=%s",
+			  p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// sign with re-imported private key
+
+	rc = funcs->C_SignInit(session, &mech, imp_priv_key);
+	if (rc != CKR_OK) {
+	    testcase_error("C_SignInit() with re-imported priv key failed, rc=%s",
+			   p11_get_ckr(rc));
+	    goto error;
+	}
+	siglen = sizeof(sig);
+	rc = funcs->C_Sign(session, msg, msglen, sig, &siglen);
+	if (rc != CKR_OK) {
+	    testcase_error("C_Sign() with re-imported priv key failed, rc=%s",
+			   p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// verify with original public key
+
+	rc = funcs->C_VerifyInit(session, &mech, publ_key);
+	if (rc != CKR_OK) {
+	    testcase_error("C_VerifyInit() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+	rc = funcs->C_Verify(session, msg, msglen, sig, siglen);
+	if (rc == CKR_OK) {
+	    ;
+	} else if (rc == CKR_SIGNATURE_INVALID || rc == CKR_SIGNATURE_LEN_RANGE) {
+	    testcase_fail("signature verify on signature generated with re-imported priv key failed, rc=%s",
+			  p11_get_ckr(rc));
+	    goto error;
+	} else {
+	    testcase_error("C_Verify() on signature generated with re-imported priv key failed, rc=%s",
+			   p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// sign with original private key
+
+	rc = funcs->C_SignInit(session, &mech, priv_key);
+	if (rc != CKR_OK) {
+	    testcase_error("C_SignInit() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+	msglen = (keybitlen / 8) / 2;
+	siglen = sizeof(sig);
+	rc = funcs->C_Sign(session, msg, msglen, sig, &siglen);
+	if (rc != CKR_OK) {
+	    testcase_error("C_Sign() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// verify with re-imported public key
+
+	rc = funcs->C_VerifyInit(session, &mech, imp_publ_key);
+	if (rc != CKR_OK) {
+	    testcase_error("C_VerifyInit() with re-imported pub key failed, rc=%s",
+			   p11_get_ckr(rc));
+	    goto error;
+	}
+	rc = funcs->C_Verify(session, msg, msglen, sig, siglen);
+	if (rc == CKR_OK) {
+	    ;
+	} else if (rc == CKR_SIGNATURE_INVALID || rc == CKR_SIGNATURE_LEN_RANGE) {
+	    testcase_fail("signature verify with re-imported pub key on signature failed");
+	    goto error;
+	} else {
+	    testcase_error("C_Verify() with re-imported pub key on signature failed, rc=%s",
+			   p11_get_ckr(rc));
+	    goto error;
+	}
+
+	testcase_pass("CCA export/import test with RSA %u key: ok", keybitlen);
+
+error:
+	free(priv_opaquekey);
+	priv_opaquekey = NULL;
+	free(publ_opaquekey);
+	publ_opaquekey = NULL;
+    }
+
+testcase_cleanup:
+    testcase_close_session();
+out:
+    return rc;
+}
+
+static CK_BYTE brainpoolP160r1[] = OCK_BRAINPOOL_P160R1;
+static CK_BYTE brainpoolP160t1[] = OCK_BRAINPOOL_P160T1;
+static CK_BYTE brainpoolP192r1[] = OCK_BRAINPOOL_P192R1;
+static CK_BYTE brainpoolP192t1[] = OCK_BRAINPOOL_P192T1;
+static CK_BYTE brainpoolP224r1[] = OCK_BRAINPOOL_P224R1;
+static CK_BYTE brainpoolP224t1[] = OCK_BRAINPOOL_P224T1;
+static CK_BYTE brainpoolP256r1[] = OCK_BRAINPOOL_P256R1;
+static CK_BYTE brainpoolP256t1[] = OCK_BRAINPOOL_P256T1;
+static CK_BYTE brainpoolP320r1[] = OCK_BRAINPOOL_P320R1;
+static CK_BYTE brainpoolP320t1[] = OCK_BRAINPOOL_P320T1;
+static CK_BYTE brainpoolP384r1[] = OCK_BRAINPOOL_P384R1;
+static CK_BYTE brainpoolP384t1[] = OCK_BRAINPOOL_P384T1;
+static CK_BYTE brainpoolP512r1[] = OCK_BRAINPOOL_P512R1;
+static CK_BYTE brainpoolP512t1[] = OCK_BRAINPOOL_P512T1;
+static CK_BYTE prime192v1[] = OCK_PRIME192V1;
+static CK_BYTE secp224r1[] = OCK_SECP224R1;
+static CK_BYTE prime256v1[] = OCK_PRIME256V1;
+static CK_BYTE secp384r1[] = OCK_SECP384R1;
+static CK_BYTE secp521r1[] = OCK_SECP521R1;
+static CK_BYTE secp256k1[] = OCK_SECP256K1;
+static CK_BYTE curve25519[] = OCK_CURVE25519;
+static CK_BYTE curve448[] = OCK_CURVE448;
+static CK_BYTE ed25519[] = OCK_ED25519;
+static CK_BYTE ed448[] = OCK_ED448;
+
+static struct {
+    CK_BYTE *curve;
+    CK_ULONG size;
+    const char *name;
+} ec_curves[] = {
+    {brainpoolP160r1, sizeof(brainpoolP160r1), "brainpoolP160r1"},
+    {brainpoolP160t1, sizeof(brainpoolP160t1), "brainpoolP160t1"},
+    {brainpoolP192r1, sizeof(brainpoolP192r1), "brainpoolP192r1"},
+    {brainpoolP192t1, sizeof(brainpoolP192t1), "brainpoolP192t1"},
+    {brainpoolP224r1, sizeof(brainpoolP224r1), "brainpoolP224r1"},
+    {brainpoolP224t1, sizeof(brainpoolP224t1), "brainpoolP224t1"},
+    {brainpoolP256r1, sizeof(brainpoolP256r1), "brainpoolP256r1"},
+    {brainpoolP256t1, sizeof(brainpoolP256t1), "brainpoolP256t1"},
+    {brainpoolP320r1, sizeof(brainpoolP320r1), "brainpoolP320r1"},
+    {brainpoolP320t1, sizeof(brainpoolP320t1), "brainpoolP320t1"},
+    {brainpoolP384r1, sizeof(brainpoolP384r1), "brainpoolP384r1"},
+    {brainpoolP384t1, sizeof(brainpoolP384t1), "brainpoolP384t1"},
+    {brainpoolP512r1, sizeof(brainpoolP512r1), "brainpoolP512r1"},
+    {brainpoolP512t1, sizeof(brainpoolP512t1), "brainpoolP512t1"},
+    {prime192v1, sizeof(prime192v1), "prime192v1"},
+    {secp224r1, sizeof(secp224r1), "secp224r1"},
+    {prime256v1, sizeof(prime256v1), "prime256v1"},
+    {secp384r1, sizeof(secp384r1), "secp384r1"},
+    {secp521r1, sizeof(secp521r1), "secp521r1"},
+    {secp256k1, sizeof(secp256k1), "secp256k1"},
+    {curve25519, sizeof(curve25519), "curve25519"},
+    {curve448, sizeof(curve448), "curve448"},
+    {ed25519, sizeof(ed25519), "ed25519"},
+    {ed448, sizeof(ed448), "ed448"},
+    {0, 0, 0}
+};
+
+static CK_RV cca_ecc_export_import_tests(void)
+{
+    CK_RV rc = CKR_OK;
+    CK_FLAGS flags;
+    CK_SESSION_HANDLE session;
+    CK_BYTE user_pin[PKCS11_MAX_PIN_LEN];
+    CK_ULONG user_pin_len;
+    CK_OBJECT_HANDLE publ_key, priv_key;
+    CK_OBJECT_HANDLE imp_priv_key, imp_publ_key;
+    CK_BYTE msg[32], sig[256];
+    CK_ULONG msglen, siglen;
+    CK_MECHANISM mech = { CKM_ECDSA, 0, 0};
+    CK_BYTE *priv_opaquekey = NULL, *publ_opaquekey = NULL;
+    CK_ULONG priv_opaquekeylen, publ_opaquekeylen;
+    char label[80];
+    int i;
+
+    testcase_rw_session();
+    testcase_user_login();
+
+    for (i = 0; ec_curves[i].curve; i++) {
+
+	testcase_begin("CCA export/import test with public/private ECC curve %s keys",
+		       ec_curves[i].name);
+
+	if (!is_cca_token(SLOT_ID)) {
+	    testcase_skip("this slot is not a CCA token");
+	    goto out;
+	}
+
+	// create ock ecc keypair
+
+	rc = generate_EC_KeyPair(session,
+				 ec_curves[i].curve, ec_curves[i].size,
+				 &publ_key, &priv_key);
+	if (rc == CKR_CURVE_NOT_SUPPORTED) {
+	    testcase_skip("ECC curve %s not supported yet by CCA token", ec_curves[i].name);
+	    goto error;
+	}
+	if (rc != CKR_OK) {
+	    testcase_error("generate_EC_KeyPair() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+
+	testcase_new_assertion();
+
+	// sign with original private key
+
+	rc = funcs->C_SignInit(session, &mech, priv_key);
+	if (rc != CKR_OK) {
+	    testcase_error("C_SignInit() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+	msglen = sizeof(msg);
+	siglen = sizeof(sig);
+	rc = funcs->C_Sign(session, msg, msglen, sig, &siglen);
+	if (rc != CKR_OK) {
+	    testcase_error("C_Sign() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// verify with original public key
+
+	rc = funcs->C_VerifyInit(session, &mech, publ_key);
+	if (rc != CKR_OK) {
+	    testcase_error("C_VerifyInit() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+	rc = funcs->C_Verify(session, msg, msglen, sig, siglen);
+	if (rc == CKR_OK) {
+	    ;
+	} else if (rc == CKR_SIGNATURE_INVALID || rc == CKR_SIGNATURE_LEN_RANGE) {
+	    testcase_fail("signature verify failed");
+	    goto error;
+	} else {
+	    testcase_error("C_Verify() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// export original private key's cca token
+
+	rc = export_ibm_opaque(session, priv_key, &priv_opaquekey, &priv_opaquekeylen);
+	if (rc != CKR_OK) {
+	    testcase_fail("export_ibm_opaque on private key failed rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+#if 0
+	printf("priv_opaquekey (%lu bytes):\n", priv_opaquekeylen);
+	print_hex(priv_opaquekey, priv_opaquekeylen);
+#endif
+
+	// re-import this cca private ecc key token as new private ecc key
+
+	snprintf(label, sizeof(label), "re-imported_ecc_%s_private_key", ec_curves[i].name);
+	rc = import_ecc_priv_key(session, label, priv_opaquekey, priv_opaquekeylen, &imp_priv_key);
+	if (rc != CKR_OK) {
+	    testcase_fail("import_ecc_priv_key on exported cca ecc key token failed rc=%s",
+			  p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// export original public key's cca token
+
+	rc = export_ibm_opaque(session, publ_key, &publ_opaquekey, &publ_opaquekeylen);
+	if (rc != CKR_OK) {
+	    testcase_fail("export_ibm_opaque on public key failed rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+#if 0
+	printf("publ_opaquekey (%lu bytes):\n", publ_opaquekeylen);
+	print_hex(publ_opaquekey, publ_opaquekeylen);
+#endif
+
+	// re-import this cca public ecc key token as new public ecc key
+
+	snprintf(label, sizeof(label), "re-imported_ecc_%s_public_key", ec_curves[i].name);
+	rc = import_ecc_publ_key(session, label, publ_opaquekey, publ_opaquekeylen, &imp_publ_key);
+	if (rc != CKR_OK) {
+	    testcase_fail("import_ecc_publ_key on exported cca ecc key token failed rc=%s",
+			  p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// sign with re-imported private key
+
+	rc = funcs->C_SignInit(session, &mech, imp_priv_key);
+	if (rc != CKR_OK) {
+	    testcase_error("C_SignInit() with re-imported priv key failed, rc=%s",
+			   p11_get_ckr(rc));
+	    goto error;
+	}
+	msglen = sizeof(msg);
+	siglen = sizeof(sig);
+	rc = funcs->C_Sign(session, msg, msglen, sig, &siglen);
+	if (rc != CKR_OK) {
+	    testcase_error("C_Sign() with re-imported priv key failed, rc=%s",
+			   p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// verify with original public key
+
+	rc = funcs->C_VerifyInit(session, &mech, publ_key);
+	if (rc != CKR_OK) {
+	    testcase_error("C_VerifyInit() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+	rc = funcs->C_Verify(session, msg, msglen, sig, siglen);
+	if (rc == CKR_OK) {
+	    ;
+	} else if (rc == CKR_SIGNATURE_INVALID || rc == CKR_SIGNATURE_LEN_RANGE) {
+	    testcase_fail("signature verify on signature generated with re-imported priv key failed, rc=%s",
+			  p11_get_ckr(rc));
+	    goto error;
+	} else {
+	    testcase_error("C_Verify() on signature generated with re-imported priv key failed, rc=%s",
+			   p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// sign with original private key
+
+	rc = funcs->C_SignInit(session, &mech, priv_key);
+	if (rc != CKR_OK) {
+	    testcase_error("C_SignInit() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+	msglen = sizeof(msg);
+	siglen = sizeof(sig);
+	rc = funcs->C_Sign(session, msg, msglen, sig, &siglen);
+	if (rc != CKR_OK) {
+	    testcase_error("C_Sign() rc=%s", p11_get_ckr(rc));
+	    goto error;
+	}
+
+	// verify with re-imported public key
+
+	rc = funcs->C_VerifyInit(session, &mech, imp_publ_key);
+	if (rc != CKR_OK) {
+	    testcase_error("C_VerifyInit() with re-imported pub key failed, rc=%s",
+			   p11_get_ckr(rc));
+	    goto error;
+	}
+	rc = funcs->C_Verify(session, msg, msglen, sig, siglen);
+	if (rc == CKR_OK) {
+	    ;
+	} else if (rc == CKR_SIGNATURE_INVALID || rc == CKR_SIGNATURE_LEN_RANGE) {
+	    testcase_fail("signature verify with re-imported pub key on signature failed");
+	    goto error;
+	} else {
+	    testcase_error("C_Verify() with re-imported pub key on signature failed, rc=%s",
+			   p11_get_ckr(rc));
+	    goto error;
+	}
+
+	testcase_pass("CCA export/import test with public/private ECC curve %s keys: ok",
+		      ec_curves[i].name);
+
+error:
+	free(priv_opaquekey);
+	priv_opaquekey = NULL;
+	free(publ_opaquekey);
+	publ_opaquekey = NULL;
+    }
+
+testcase_cleanup:
+    testcase_close_session();
+out:
+    return rc;
+}
+
+static CK_RV cca_export_import_tests(void)
+{
+    CK_RV rc = CKR_OK, rv = CKR_OK;
+
+    testsuite_begin("CCA export/import tests");
+
+    rc = cca_des_data_export_import_tests();
+    if (rc != CKR_OK && rv == CKR_OK)
+	rv = rc;
+
+    rc = cca_des3_data_export_import_tests();
+    if (rc != CKR_OK && rv == CKR_OK)
+	rv = rc;
+
+    rc = cca_aes_data_export_import_tests();
+    if (rc != CKR_OK && rv == CKR_OK)
+	rv = rc;
+
+    rc = cca_hmac_data_export_import_tests();
+    if (rc != CKR_OK && rv == CKR_OK)
+	rv = rc;
+
+    rc = cca_rsa_export_import_tests();
+    if (rc != CKR_OK && rv == CKR_OK)
+	rv = rc;
+
+    rc = cca_ecc_export_import_tests();
+    if (rc != CKR_OK && rv == CKR_OK)
+	rv = rc;
+
+#if CCA_AES_CIPHER_KEY_SUPPORTED
+    rc = cca_aes_cipher_import_tests();
+    if (rc != CKR_OK && rv == CKR_OK)
+	rv = rc;
+#endif
+
+    return rv;
+}
+
+int main(int argc, char **argv)
+{
+    CK_C_INITIALIZE_ARGS cinit_args;
+    int rc;
+    CK_RV rv;
+
+    rc = do_ParseArgs(argc, argv);
+    if (rc != 1)
+	return rc;
+
+    printf("Using slot #%lu...\n", SLOT_ID);
+
+    rc = do_GetFunctionList();
+    if (!rc) {
+	testcase_error("do_getFunctionList(), rc=%s", p11_get_ckr(rc));
+	return rc;
+    }
+
+    memset(&cinit_args, 0x0, sizeof(cinit_args));
+    cinit_args.flags = CKF_OS_LOCKING_OK;
+
+    // SAB Add calls to ALL functions before the C_Initialize gets hit
+
+    funcs->C_Initialize(&cinit_args);
+
+    {
+	CK_SESSION_HANDLE hsess = 0;
+
+	rc = funcs->C_GetFunctionStatus(hsess);
+	if (rc != CKR_FUNCTION_NOT_PARALLEL)
+	    return rc;
+
+	rc = funcs->C_CancelFunction(hsess);
+	if (rc != CKR_FUNCTION_NOT_PARALLEL)
+	    return rc;
+
+    }
+
+    testcase_setup(0);
+    rv = cca_export_import_tests();
+    testcase_print_result();
+
+    funcs->C_Finalize(NULL);
+
+    /* make sure we return non-zero if rv is non-zero */
+    return ((rv == 0) || (rv % 256) ? (int)rv : -1);
+}

--- a/testcases/misc_tests/misc_tests.mk
+++ b/testcases/misc_tests/misc_tests.mk
@@ -6,7 +6,8 @@ noinst_PROGRAMS +=							\
 	testcases/misc_tests/tok_des					\
 	testcases/misc_tests/fork testcases/misc_tests/multi_instance   \
 	testcases/misc_tests/obj_lock testcases/misc_tests/tok2tok_transport \
-	testcases/misc_tests/obj_lock testcases/misc_tests/reencrypt
+	testcases/misc_tests/obj_lock testcases/misc_tests/reencrypt    \
+	testcases/misc_tests/cca_export_import_test
 
 testcases_misc_tests_obj_mgmt_tests_CFLAGS = ${testcases_inc}
 testcases_misc_tests_obj_mgmt_tests_LDADD =				\
@@ -61,8 +62,14 @@ testcases_misc_tests_tok2tok_transport_CFLAGS = ${testcases_inc}
 testcases_misc_tests_tok2tok_transport_LDADD = testcases/common/libcommon.la
 testcases_misc_tests_tok2tok_transport_SOURCES = 			\
 	testcases/misc_tests/tok2tok_transport.c
-	
+
 testcases_misc_tests_reencrypt_CFLAGS = ${testcases_inc}
 testcases_misc_tests_reencrypt_LDADD = testcases/common/libcommon.la
 testcases_misc_tests_reencrypt_SOURCES = 			\
 	testcases/misc_tests/reencrypt.c
+
+testcases_misc_tests_cca_export_import_test_CFLAGS = ${testcases_inc}
+testcases_misc_tests_cca_export_import_test_LDADD =			\
+	testcases/common/libcommon.la
+testcases_misc_tests_cca_export_import_test_SOURCES =			\
+	testcases/misc_tests/cca_export_import_test.c

--- a/usr/lib/cca_stdll/cca_stdll.h
+++ b/usr/lib/cca_stdll/cca_stdll.h
@@ -67,10 +67,14 @@
 /* Offset into an RSA key area of the total length */
 #define CCA_RSA_INTTOK_PRIVKEY_LENGTH_OFFSET 2
 #define CCA_RSA_INTTOK_PUBKEY_LENGTH_OFFSET 2
-/* Offset into an RSA private key area of the length of n, the modulus */
-#define CCA_RSA_INTTOK_PRIVKEY_N_LENGTH_OFFSET 62
-/* Offset into an RSA private key area of n, the modulus */
-#define CCA_RSA_INTTOK_PRIVKEY_N_OFFSET 134
+/* Offset into an RSA private key (4096 bits, ME format) area of the length of n, the modulus */
+#define CCA_RSA_INTTOK_PRIVKEY_ME_N_LENGTH_OFFSET 52
+/* Offset into an RSA private key (4096 bits, ME format) area of n, the modulus */
+#define CCA_RSA_INTTOK_PRIVKEY_ME_N_OFFSET 122
+/* Offset into an RSA private key (4096 bits, CRT format) area of the length of n, the modulus */
+#define CCA_RSA_INTTOK_PRIVKEY_CRT_N_LENGTH_OFFSET 62
+/* Offset into an RSA private key (4096 bits, CRT format) area of n, the modulus */
+#define CCA_RSA_INTTOK_PRIVKEY_CRT_N_OFFSET 134
 /* Offset into an RSA public key area of the length of e, the public exponent */
 #define CCA_RSA_INTTOK_PUBKEY_E_LENGTH_OFFSET 6
 /* Offset into an RSA public key area of the value of e, the public exponent */
@@ -81,6 +85,13 @@
 /* Offset into the rule_array returned by the STATCCAE command for the
  * Current Asymmetric Master Key register status */
 #define CCA_STATCCAE_ASYM_CMK_OFFSET  56
+/* Offset to start of public RSA key section for an external public RSA key token */
+#define CCA_RSA_EXTTOK_PUBKEY_OFFSET  8
+/* Offset to length of n within an public RSA key section in an ext public RSA key token */
+#define CCA_RSA_EXTTOK_PUBKEY_N_LENGTH_OFFSET 10
+
+/* CCA internal HMAC token payload bit length field offset */
+#define CCA_HMAC_INTTOK_PAYLOAD_LENGTH_OFFSET 38
 
 /* CCA STDLL constants */
 

--- a/usr/lib/common/attributes.c
+++ b/usr/lib/common/attributes.c
@@ -326,3 +326,36 @@ CK_BBOOL compare_attribute_array(CK_ATTRIBUTE_PTR a1, CK_ULONG a1_len,
 
     return TRUE;
 }
+
+#ifdef DEBUG
+void dump_attr(CK_ATTRIBUTE_PTR a)
+{
+    const char *typestr = p11_get_cka(a->type);
+
+    switch (a->ulValueLen) {
+    case 0:
+        TRACE_DEBUG("  %s: len=0 pValue=%p\n", typestr, a->pValue);
+        break;
+    case 1:
+        TRACE_DEBUG("  %s: len=%lu value=0x%02hhx\n",
+                    typestr, a->ulValueLen, *((uint8_t *)(a->pValue)));
+        break;
+    case 2:
+        TRACE_DEBUG("  %s: len=%lu value=0x%04hx\n",
+                    typestr, a->ulValueLen, *((uint16_t *)(a->pValue)));
+        break;
+    case 4:
+        TRACE_DEBUG("  %s: len=%lu value=0x%08x\n",
+                    typestr, a->ulValueLen, *((uint32_t *)(a->pValue)));
+        break;
+    case 8:
+        TRACE_DEBUG("  %s: len=%lu value=0x%016lx\n",
+                    typestr, a->ulValueLen, *((uint64_t *)(a->pValue)));
+        break;
+    default:
+        TRACE_DEBUG("  %s: len=%lu value:\n", typestr, a->ulValueLen);
+        TRACE_DEBUG_DUMP("  ", a->pValue, a->ulValueLen);
+        break;
+    }
+}
+#endif

--- a/usr/lib/common/attributes.h
+++ b/usr/lib/common/attributes.h
@@ -52,4 +52,13 @@ CK_BBOOL compare_attribute(CK_ATTRIBUTE_PTR a1, CK_ATTRIBUTE_PTR a2);
 
 CK_BBOOL compare_attribute_array(CK_ATTRIBUTE_PTR a1, CK_ULONG a1_len,
                                  CK_ATTRIBUTE_PTR a2, CK_ULONG a2_len);
+
+#ifdef DEBUG
+/* Debug function: dump one attribute */
+void dump_attr(CK_ATTRIBUTE_PTR a);
+#define TRACE_DEBUG_DUMPATTR(x) dump_attr(x)
+#else
+#define TRACE_DEBUG_DUMPATTR(...)
+#endif
+
 #endif

--- a/usr/lib/common/h_extern.h
+++ b/usr/lib/common/h_extern.h
@@ -2316,7 +2316,12 @@ CK_RV template_validate_attributes(STDLL_TokData_t *tokdata,
 
 CK_RV template_validate_base_attribute(TEMPLATE *tmpl,
                                        CK_ATTRIBUTE *attr, CK_ULONG mode);
-
+#ifdef DEBUG
+void dump_template(TEMPLATE *tmpl);
+#define TRACE_DEBUG_DUMPTEMPL(x) dump_template(x)
+#else
+#define TRACE_DEBUG_DUMPTEMPL(...)
+#endif
 
 
 // DATA OBJECT ROUTINES

--- a/usr/lib/common/key.c
+++ b/usr/lib/common/key.c
@@ -1842,6 +1842,16 @@ CK_RV rsa_publ_check_required_attributes(TEMPLATE *tmpl, CK_ULONG mode)
     CK_ULONG val;
     CK_RV rc;
 
+    if (mode == MODE_CREATE &&
+        token_specific.secure_key_token == TRUE &&
+        template_attribute_get_non_empty(tmpl, CKA_IBM_OPAQUE, &attr) == CKR_OK) {
+        /*
+         * Import of an already existing secure key. Only
+         * do the base checks for public key templates.
+         */
+        return publ_key_check_required_attributes(tmpl, mode);
+    }
+
     found = template_attribute_find(tmpl, CKA_MODULUS, &attr);
     if (!found) {
         if (mode == MODE_CREATE) {
@@ -2052,6 +2062,15 @@ CK_RV rsa_priv_check_required_attributes(TEMPLATE *tmpl, CK_ULONG mode)
     CK_ATTRIBUTE *attr = NULL;
     CK_BBOOL found;
 
+    if (mode == MODE_CREATE &&
+        token_specific.secure_key_token == TRUE &&
+        template_attribute_get_non_empty(tmpl, CKA_IBM_OPAQUE, &attr) == CKR_OK) {
+        /*
+         * Import of an already existing secure key. Only
+         * do the base checks for private key templates.
+         */
+        return priv_key_check_required_attributes(tmpl, mode);
+    }
 
     found = template_attribute_find(tmpl, CKA_MODULUS, &attr);
     if (!found) {
@@ -3453,6 +3472,16 @@ CK_RV ecdsa_publ_check_required_attributes(TEMPLATE *tmpl, CK_ULONG mode)
     CK_ATTRIBUTE *attr = NULL;
     CK_RV rc;
 
+    if (mode == MODE_CREATE &&
+        token_specific.secure_key_token == TRUE &&
+        template_attribute_get_non_empty(tmpl, CKA_IBM_OPAQUE, &attr) == CKR_OK) {
+	    /*
+         * Import of an already existing secure key. Only
+         * do the base checks for a public key templates.
+         */
+        return publ_key_check_required_attributes(tmpl, mode);
+    }
+
     rc = template_attribute_get_non_empty(tmpl, CKA_ECDSA_PARAMS, &attr);
     if (rc != CKR_OK) {
         if (mode == MODE_CREATE || mode == MODE_KEYGEN) {
@@ -3649,6 +3678,16 @@ CK_RV ecdsa_priv_check_required_attributes(TEMPLATE *tmpl, CK_ULONG mode)
     CK_ATTRIBUTE *attr = NULL;
     CK_BBOOL found;
     CK_RV rc;
+
+    if (mode == MODE_CREATE &&
+        token_specific.secure_key_token == TRUE &&
+        template_attribute_get_non_empty(tmpl, CKA_IBM_OPAQUE, &attr) == CKR_OK) {
+        /*
+         * Import of an already existing secure key. Only
+         * do the base checks for private key templates.
+         */
+        return priv_key_check_required_attributes(tmpl, mode);
+    }
 
     rc = template_attribute_get_non_empty(tmpl, CKA_ECDSA_PARAMS, &attr);
     if (rc != CKR_OK) {
@@ -6211,6 +6250,16 @@ CK_RV des_check_required_attributes(TEMPLATE *tmpl, CK_ULONG mode)
     CK_ATTRIBUTE *attr = NULL;
     CK_BBOOL found;
 
+    if (mode == MODE_CREATE &&
+        token_specific.secure_key_token == TRUE &&
+        template_attribute_get_non_empty(tmpl, CKA_IBM_OPAQUE, &attr) == CKR_OK) {
+        /*
+         * Import of an already existing secure key. Only
+         * do the base checks for des key templates.
+         */
+        return secret_key_check_required_attributes(tmpl, mode);
+    }
+
     found = template_attribute_find(tmpl, CKA_VALUE, &attr);
     if (!found) {
         if (mode == MODE_CREATE) {
@@ -6604,6 +6653,16 @@ CK_RV des3_check_required_attributes(TEMPLATE *tmpl, CK_ULONG mode)
 {
     CK_ATTRIBUTE *attr = NULL;
     CK_BBOOL found;
+
+    if (mode == MODE_CREATE &&
+        token_specific.secure_key_token == TRUE &&
+        template_attribute_get_non_empty(tmpl, CKA_IBM_OPAQUE, &attr) == CKR_OK) {
+        /*
+         * Import of an already existing secure key. Only
+         * do the base checks for des3 key templates.
+         */
+        return secret_key_check_required_attributes(tmpl, mode);
+    }
 
     found = template_attribute_find(tmpl, CKA_VALUE, &attr);
     if (!found) {
@@ -7840,6 +7899,16 @@ CK_RV aes_check_required_attributes(TEMPLATE *tmpl, CK_ULONG mode)
 {
     CK_ATTRIBUTE *attr = NULL;
     CK_BBOOL found;
+
+    if (mode == MODE_CREATE &&
+        token_specific.secure_key_token == TRUE &&
+        template_attribute_get_non_empty(tmpl, CKA_IBM_OPAQUE, &attr) == CKR_OK) {
+        /*
+         * Import of an already existing secure key. Only
+         * do the base checks for aes key templates.
+         */
+        return secret_key_check_required_attributes(tmpl, mode);
+    }
 
     found = template_attribute_find(tmpl, CKA_VALUE, &attr);
     if (!found) {

--- a/usr/lib/common/new_host.c
+++ b/usr/lib/common/new_host.c
@@ -46,6 +46,7 @@
 #include "pkcs32.h"
 #include "trace.h"
 #include "slotmgr.h"
+#include "attributes.h"
 
 #include "../api/apiproto.h"
 
@@ -3613,8 +3614,7 @@ done:
         session_mgr_put(tokdata, sess);
 
 #ifdef DEBUG
-    CK_ATTRIBUTE *attr = NULL;
-    CK_BYTE val[4];
+    CK_ATTRIBUTE *attr;
     CK_ULONG i;
 
     if (rc == CKR_OK) {
@@ -3625,31 +3625,13 @@ done:
     TRACE_DEBUG("Public Template:\n");
     attr = pPublicKeyTemplate;
     for (i = 0; i < ulPublicKeyAttributeCount; i++, attr++) {
-        TRACE_DEBUG("%lu: Attribute type: 0x%08lx, Value Length: %lu\n",
-                    i, attr->type, attr->ulValueLen);
-
-        if (attr->ulValueLen >= sizeof(val) && attr->pValue != NULL) {
-            memset(val, 0, sizeof(val));
-            memcpy(val, attr->pValue, attr->ulValueLen > sizeof(val) ?
-                                            sizeof(val) : attr->ulValueLen);
-            TRACE_DEBUG("First 4 bytes: %02x %02x %02x %02x\n",
-                        val[0], val[1], val[2], val[3]);
-        }
+        TRACE_DEBUG_DUMPATTR(attr);
     }
 
     TRACE_DEBUG("Private Template:\n");
     attr = pPublicKeyTemplate;
     for (i = 0; i < ulPrivateKeyAttributeCount; i++, attr++) {
-        TRACE_DEBUG("%lu: Attribute type: 0x%08lx, Value Length: %lu\n",
-                    i, attr->type, attr->ulValueLen);
-
-        if (attr->ulValueLen >= sizeof(val) && attr->pValue != NULL) {
-            memset(val, 0, sizeof(val));
-            memcpy(val, attr->pValue, attr->ulValueLen > sizeof(val) ?
-                                            sizeof(val) : attr->ulValueLen);
-            TRACE_DEBUG("First 4 bytes: %02x %02x %02x %02x\n",
-                        val[0], val[1], val[2], val[3]);
-        }
+        TRACE_DEBUG_DUMPATTR(attr);
     }
 #endif
 

--- a/usr/lib/common/new_host.c
+++ b/usr/lib/common/new_host.c
@@ -3629,7 +3629,7 @@ done:
     }
 
     TRACE_DEBUG("Private Template:\n");
-    attr = pPublicKeyTemplate;
+    attr = pPrivateKeyTemplate;
     for (i = 0; i < ulPrivateKeyAttributeCount; i++, attr++) {
         TRACE_DEBUG_DUMPATTR(attr);
     }

--- a/usr/lib/common/p11util.c
+++ b/usr/lib/common/p11util.c
@@ -19,7 +19,7 @@
 // p11_get_ckr - return textual interpretation of a CKR_ error code
 // @rc is the CKR_.. error
 //
-char *p11_get_ckr(CK_RV rc)
+const char *p11_get_ckr(CK_RV rc)
 {
     switch (rc) {
         _sym2str(CKR_OK);
@@ -119,6 +119,106 @@ char *p11_get_ckr(CK_RV rc)
         _sym2str(CKR_PUBLIC_KEY_INVALID);
     default:
         return "UNKNOWN";
+    }
+}
+
+//
+// p11_get_cka - return textual interpretation of an attribute type
+// only simple types - no arrays. For unknown a ptr to a static
+// buffer is returned. So be carefull this is not thread safe then.
+//
+const char *p11_get_cka(CK_ATTRIBUTE_TYPE atype)
+{
+    static char buf[40];
+
+    switch (atype) {
+        _sym2str(CKA_CLASS);
+        _sym2str(CKA_TOKEN);
+        _sym2str(CKA_PRIVATE);
+        _sym2str(CKA_LABEL);
+        _sym2str(CKA_UNIQUE_ID);
+        _sym2str(CKA_VALUE);
+        _sym2str(CKA_OBJECT_ID);
+        _sym2str(CKA_CERTIFICATE_TYPE);
+        _sym2str(CKA_ISSUER);
+        _sym2str(CKA_SERIAL_NUMBER);
+        _sym2str(CKA_ATTR_TYPES);
+        _sym2str(CKA_TRUSTED);
+        _sym2str(CKA_KEY_TYPE);
+        _sym2str(CKA_SUBJECT);
+        _sym2str(CKA_CERTIFICATE_CATEGORY);
+        _sym2str(CKA_JAVA_MIDP_SECURITY_DOMAIN);
+        _sym2str(CKA_URL);
+        _sym2str(CKA_HASH_OF_SUBJECT_PUBLIC_KEY);
+        _sym2str(CKA_HASH_OF_ISSUER_PUBLIC_KEY);
+        _sym2str(CKA_NAME_HASH_ALGORITHM);
+        _sym2str(CKA_CHECK_VALUE);
+        _sym2str(CKA_ID);
+        _sym2str(CKA_SENSITIVE);
+        _sym2str(CKA_ENCRYPT);
+        _sym2str(CKA_DECRYPT);
+        _sym2str(CKA_WRAP);
+        _sym2str(CKA_UNWRAP);
+        _sym2str(CKA_SIGN);
+        _sym2str(CKA_SIGN_RECOVER);
+        _sym2str(CKA_VERIFY);
+        _sym2str(CKA_VERIFY_RECOVER);
+        _sym2str(CKA_DERIVE);
+        _sym2str(CKA_START_DATE);
+        _sym2str(CKA_END_DATE);
+        _sym2str(CKA_MODULUS);
+        _sym2str(CKA_MODULUS_BITS);
+        _sym2str(CKA_PUBLIC_EXPONENT);
+        _sym2str(CKA_PRIVATE_EXPONENT);
+        _sym2str(CKA_PRIME_1);
+        _sym2str(CKA_PRIME_2);
+        _sym2str(CKA_EXPONENT_1);
+        _sym2str(CKA_EXPONENT_2);
+        _sym2str(CKA_COEFFICIENT);
+        _sym2str(CKA_PUBLIC_KEY_INFO);
+        _sym2str(CKA_PRIME);
+        _sym2str(CKA_SUBPRIME);
+        _sym2str(CKA_BASE);
+        _sym2str(CKA_PRIME_BITS);
+        _sym2str(CKA_SUBPRIME_BITS);
+        _sym2str(CKA_VALUE_BITS);
+        _sym2str(CKA_VALUE_LEN);
+        _sym2str(CKA_EXTRACTABLE);
+        _sym2str(CKA_LOCAL);
+        _sym2str(CKA_NEVER_EXTRACTABLE);
+        _sym2str(CKA_ALWAYS_SENSITIVE);
+        _sym2str(CKA_KEY_GEN_MECHANISM);
+        _sym2str(CKA_MODIFIABLE);
+        _sym2str(CKA_COPYABLE);
+        _sym2str(CKA_DESTROYABLE);
+        _sym2str(CKA_EC_PARAMS);
+        _sym2str(CKA_EC_POINT);
+        _sym2str(CKA_SECONDARY_AUTH);
+        _sym2str(CKA_AUTH_PIN_FLAGS);
+        _sym2str(CKA_ALWAYS_AUTHENTICATE);
+        _sym2str(CKA_WRAP_WITH_TRUSTED);
+        _sym2str(CKA_HW_FEATURE_TYPE);
+        _sym2str(CKA_RESET_ON_INIT);
+        _sym2str(CKA_HAS_RESET);
+        _sym2str(CKA_WRAP_TEMPLATE);
+        _sym2str(CKA_UNWRAP_TEMPLATE);
+        _sym2str(CKA_DERIVE_TEMPLATE);
+        _sym2str(CKA_ALLOWED_MECHANISMS);
+        _sym2str(CKA_PROFILE_ID);
+        _sym2str(CKA_IBM_OPAQUE);
+        _sym2str(CKA_IBM_RESTRICTABLE);
+        _sym2str(CKA_IBM_NEVER_MODIFIABLE);
+        _sym2str(CKA_IBM_RETAINKEY);
+        _sym2str(CKA_IBM_ATTRBOUND);
+        _sym2str(CKA_IBM_KEYTYPE);
+        _sym2str(CKA_IBM_CV);
+        _sym2str(CKA_IBM_MACKEY);
+        _sym2str(CKA_IBM_USE_AS_DATA);
+        _sym2str(CKA_IBM_STRUCT_PARAMS);
+        _sym2str(CKA_IBM_STD_COMPLIANCE1);
+    default:
+        sprintf(buf, "unknown attribute type 0x%08lx", atype);
+        return buf;
     }
 }
 
@@ -248,7 +348,7 @@ CK_BBOOL is_attribute_attr_array(CK_ATTRIBUTE_TYPE type)
 }
 
 
-char *p11_get_ckm(CK_ULONG mechanism)
+const char *p11_get_ckm(CK_ULONG mechanism)
 {
     switch (mechanism) {
         _sym2str(CKM_RSA_PKCS_KEY_PAIR_GEN);

--- a/usr/lib/common/p11util.h
+++ b/usr/lib/common/p11util.h
@@ -18,12 +18,19 @@
 // p11_get_ckr - return textual interpretation of a CKR_ error code
 // @rc is the CKR_.. error
 //
-char *p11_get_ckr(CK_RV rc);
+const char *p11_get_ckr(CK_RV rc);
 //
 // p11_get_ckm - return textual interpretation of a CKM_ mechanism code
 // @rc is the CKM_.. as a string
 //
-char *p11_get_ckm(CK_ULONG);
+const char *p11_get_ckm(CK_ULONG);
+
+//
+// p11_get_cka - return textual interpretation of an attribute type
+// only simple types - no arrays. For unknown a ptr to a static
+// buffer is returned. So be carefull this is not thread safe then.
+//
+const char *p11_get_cka(CK_ATTRIBUTE_TYPE atype);
 
 // is_attribute_defined()
 //

--- a/usr/lib/common/template.c
+++ b/usr/lib/common/template.c
@@ -1902,3 +1902,19 @@ CK_RV template_validate_base_attribute(TEMPLATE *tmpl, CK_ATTRIBUTE *attr,
 
     return CKR_ATTRIBUTE_READ_ONLY;
 }
+
+#ifdef DEBUG
+/* Debug function: dump list of attribues from a template */
+void dump_template(TEMPLATE *tmpl)
+{
+    DL_NODE *node = NULL;
+    CK_ATTRIBUTE *a = NULL;
+
+    node = tmpl->attribute_list;
+    while (node) {
+        a = (CK_ATTRIBUTE *) node->data;
+	TRACE_DEBUG_DUMPATTR(a);
+        node = node->next;
+    }
+}
+#endif

--- a/usr/lib/common/template.c
+++ b/usr/lib/common/template.c
@@ -1859,7 +1859,7 @@ CK_RV template_validate_base_attribute(TEMPLATE *tmpl, CK_ATTRIBUTE *attr,
         /* Allow this attribute to be modified in order to support
          * migratable keys on secure key tokens.
          */
-        if ((mode & (MODE_COPY | MODE_MODIFY)) != 0)
+        if ((mode & (MODE_CREATE | MODE_COPY | MODE_MODIFY)) != 0)
             return CKR_OK;
         break;
     case CKA_MODIFIABLE:

--- a/usr/lib/common/trace.c
+++ b/usr/lib/common/trace.c
@@ -9,6 +9,7 @@
  */
 
 #define _GNU_SOURCE
+#include <ctype.h>
 #include <errno.h>
 #include <grp.h>
 #include <pthread.h>
@@ -300,3 +301,37 @@ const char *ock_err(int num)
 
     return ock_err_msg[num];
 }
+
+#ifdef DEBUG
+
+/* a simple function for dumping out a memory area */
+void hexdump(const char *prestr, void *buf, size_t buflen)
+{
+    /*           1         2         3         4         5         6
+       0123456789012345678901234567890123456789012345678901234567890123456789
+       xx xx xx xx xx xx xx xx xx xx xx xx xx xx xx xx    ................
+     */
+
+    size_t i, j;
+    char line[68];
+    for (i = 0; i < buflen; i += 16) {
+        for (j = 0; j < 16; j++) {
+            if (i + j < buflen) {
+                unsigned char b = ((unsigned char *) buf)[i + j];
+                sprintf(line + j * 3, "%02hhx ", b);
+                line[51 + j] = (isalnum(b) ? b : '.');
+            } else {
+                sprintf(line + j * 3, "   ");
+                line[51 + j] = ' ';
+            }
+        }
+        line[47] = line[48] = line[49] = line[50] = ' ';
+        line[67] = '\0';
+	if (prestr)
+            TRACE_DEBUG("%s%s\n", prestr, line);
+        else
+            TRACE_DEBUG("%s\n", line);
+    }
+}
+
+#endif /* DEBUG */

--- a/usr/lib/common/trace.h
+++ b/usr/lib/common/trace.h
@@ -151,4 +151,12 @@ void dump_shm(LW_SHM_TYPE *, const char *);
 #define DUMP_SHM(x,y)
 #endif
 
+#ifdef DEBUG
+/* a simple function for dumping out a memory area */
+void hexdump(const char *prestr, void *buf, size_t buflen);
+#define TRACE_DEBUG_DUMP(_prestr, _buf, _buflen) hexdump(_prestr, _buf, _buflen)
+#else
+#define TRACE_DEBUG_DUMP(...)
+#endif
+
 #endif

--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -138,39 +138,6 @@ static xcpa_internal_rv_t dll_xcpa_internal_rv;
 
 static m_get_xcp_info_t dll_m_get_xcp_info;
 
-#ifdef DEBUG
-
-/* a simple function for dumping out a memory area */
-static inline void hexdump(void *buf, size_t buflen)
-{
-    /*           1         2         3         4         5         6
-       0123456789012345678901234567890123456789012345678901234567890123456789
-       xx xx xx xx xx xx xx xx xx xx xx xx xx xx xx xx    ................
-     */
-
-    size_t i, j;
-    char line[68];
-    for (i = 0; i < buflen; i += 16) {
-        for (j = 0; j < 16; j++) {
-            if (i + j < buflen) {
-                unsigned char b = ((unsigned char *) buf)[i + j];
-                sprintf(line + j * 3, "%02hhx ", b);
-                line[51 + j] = (isalnum(b) ? b : '.');
-            } else {
-                sprintf(line + j * 3, "   ");
-                line[51 + j] = ' ';
-            }
-        }
-        line[47] = line[48] = line[49] = line[50] = ' ';
-        line[67] = '\0';
-        TRACE_DEBUG("%s\n", line);
-    }
-}
-
-#define TRACE_DEBUG_DUMP(_buf, _buflen) hexdump(_buf, _buflen)
-
-#endif                          /* DEBUG */
-
 const char manuf[] = "IBM";
 const char model[] = "EP11";
 const char descr[] = "IBM EP11 token";
@@ -4113,9 +4080,9 @@ static CK_RV dh_generate_keypair(STDLL_TokData_t * tokdata,
 
 #ifdef DEBUG
     TRACE_DEBUG("%s P:\n", __func__);
-    TRACE_DEBUG_DUMP(&dh_pgs.pg[0], p_len);
+    TRACE_DEBUG_DUMP("    ", &dh_pgs.pg[0], p_len);
     TRACE_DEBUG("%s G:\n", __func__);
-    TRACE_DEBUG_DUMP(&dh_pgs.pg[p_len], p_len);
+    TRACE_DEBUG_DUMP("    ", &dh_pgs.pg[p_len], p_len);
 #endif
 
     /* add special attribute, do not add it to ock's pPublicKeyTemplate */
@@ -4218,7 +4185,7 @@ static CK_RV dh_generate_keypair(STDLL_TokData_t * tokdata,
     }
 #ifdef DEBUG
     TRACE_DEBUG("%s DH SPKI\n", __func__);
-    TRACE_DEBUG_DUMP(publblob, publblobsize);
+    TRACE_DEBUG_DUMP("   ", publblob, publblobsize);
 #endif
 
     /* CKA_VALUE of the public key must hold 'y' */
@@ -4436,11 +4403,11 @@ static CK_RV dsa_generate_keypair(STDLL_TokData_t * tokdata,
 
 #ifdef DEBUG
     TRACE_DEBUG("%s P:\n", __func__);
-    TRACE_DEBUG_DUMP(&dsa_pqgs.pqg[0], p_len);
+    TRACE_DEBUG_DUMP("    ", &dsa_pqgs.pqg[0], p_len);
     TRACE_DEBUG("%s Q:\n", __func__);
-    TRACE_DEBUG_DUMP(&dsa_pqgs.pqg[p_len], p_len);
+    TRACE_DEBUG_DUMP("    ", &dsa_pqgs.pqg[p_len], p_len);
     TRACE_DEBUG("%s G:\n", __func__);
-    TRACE_DEBUG_DUMP(&dsa_pqgs.pqg[2 * p_len], p_len);
+    TRACE_DEBUG_DUMP("    ", &dsa_pqgs.pqg[2 * p_len], p_len);
 #endif
 
     CK_ATTRIBUTE pqgs[] = { {CKA_IBM_STRUCT_PARAMS,
@@ -4563,7 +4530,7 @@ static CK_RV dsa_generate_keypair(STDLL_TokData_t * tokdata,
     }
 #ifdef DEBUG
     TRACE_DEBUG("%s dsa_generate_keypair public key:\n", __func__);
-    TRACE_DEBUG_DUMP(data, data_len);
+    TRACE_DEBUG_DUMP("    ", data, data_len);
 #endif
 
     rc = build_attribute(CKA_VALUE, data, data_len, &value_attr);
@@ -4770,7 +4737,7 @@ static CK_RV rsa_ec_generate_keypair(STDLL_TokData_t * tokdata,
 
 #ifdef DEBUG
         TRACE_DEBUG("%s ec_generate_keypair spki:\n", __func__);
-        TRACE_DEBUG_DUMP(spki, spki_len);
+        TRACE_DEBUG_DUMP("    ", spki, spki_len);
 #endif
         rc = ber_decode_SPKI(spki, &oid, &oid_len, &parm, &parm_len,
                              &key, &bit_str_len);
@@ -4797,7 +4764,7 @@ static CK_RV rsa_ec_generate_keypair(STDLL_TokData_t * tokdata,
 
 #ifdef DEBUG
         TRACE_DEBUG("%s ec_generate_keypair ecpoint:\n", __func__);
-        TRACE_DEBUG_DUMP(data, data_len);
+        TRACE_DEBUG_DUMP("    ", data, data_len);
 #endif
 
         /* build and add CKA_EC_POINT as BER encoded OCTET STRING */
@@ -4895,7 +4862,7 @@ static CK_RV rsa_ec_generate_keypair(STDLL_TokData_t * tokdata,
         }
 #ifdef DEBUG
         TRACE_DEBUG("%s rsa_generate_keypair modulus:\n", __func__);
-        TRACE_DEBUG_DUMP(data, data_len);
+        TRACE_DEBUG_DUMP("    ", data, data_len);
 #endif
 
         /* build and add CKA_MODULUS */
@@ -4923,7 +4890,7 @@ static CK_RV rsa_ec_generate_keypair(STDLL_TokData_t * tokdata,
         }
 #ifdef DEBUG
         TRACE_DEBUG("%s rsa_generate_keypair public exponent:\n", __func__);
-        TRACE_DEBUG_DUMP(data, data_len);
+        TRACE_DEBUG_DUMP("    ", data, data_len);
 #endif
 
         /* build and add CKA_PUBLIC_EXPONENT */
@@ -5127,7 +5094,7 @@ static CK_RV ibm_dilithium_generate_keypair(STDLL_TokData_t * tokdata,
     data_len--;
 #ifdef DEBUG
     TRACE_DEBUG("%s dilithium_generate_keypair (rho):\n", __func__);
-    TRACE_DEBUG_DUMP(data, data_len);
+    TRACE_DEBUG_DUMP("    ", data, data_len);
 #endif
 
     /* build and add CKA_IBM_DILITHIUM_RHO */
@@ -5156,7 +5123,7 @@ static CK_RV ibm_dilithium_generate_keypair(STDLL_TokData_t * tokdata,
     data_len--;
 #ifdef DEBUG
     TRACE_DEBUG("%s dilithium_generate_keypair (t1):\n", __func__);
-    TRACE_DEBUG_DUMP(data, data_len);
+    TRACE_DEBUG_DUMP("    ", data, data_len);
 #endif
 
     /* build and add CKA_IBM_DILITHIUM_T1 */
@@ -8246,7 +8213,7 @@ static CK_RV control_point_handler(uint_32 adapter, uint_32 domain,
     }
 #ifdef DEBUG
     TRACE_DEBUG("Control points from adapter %02X.%04X\n", adapter, domain);
-    TRACE_DEBUG_DUMP(cp, cp_len);
+    TRACE_DEBUG_DUMP("    ", cp, cp_len);
 #endif
 
     if (data->first) {
@@ -8329,7 +8296,7 @@ static CK_RV get_control_points(STDLL_TokData_t * tokdata,
 #ifdef DEBUG
     TRACE_DEBUG("Combined control points from all cards (%lu CPs):\n",
                 data.max_cp_index);
-    TRACE_DEBUG_DUMP(cp, *cp_len);
+    TRACE_DEBUG_DUMP("    ", cp, *cp_len);
     print_control_points(cp, *cp_len, data.max_cp_index);
 #endif
 
@@ -8563,7 +8530,7 @@ static CK_RV ep11_login_handler(uint_32 adapter, uint_32 domain,
         }
 #ifdef DEBUG
         TRACE_DEBUG("EP11 VHSM Pin blob (size: %lu):\n", XCP_PINBLOB_BYTES);
-        TRACE_DEBUG_DUMP(pin_blob, XCP_PINBLOB_BYTES);
+        TRACE_DEBUG_DUMP("    ", pin_blob, XCP_PINBLOB_BYTES);
 #endif
 
         if (ep11_session->flags & EP11_VHSM_PINBLOB_VALID) {
@@ -8603,7 +8570,7 @@ strict_mode:
         }
 #ifdef DEBUG
         TRACE_DEBUG("EP11 Session Pin blob (size: %lu):\n", XCP_PINBLOB_BYTES);
-        TRACE_DEBUG_DUMP(pin_blob, XCP_PINBLOB_BYTES);
+        TRACE_DEBUG_DUMP("    ", pin_blob, XCP_PINBLOB_BYTES);
 #endif
 
         if (ep11_session->flags & EP11_SESS_PINBLOB_VALID) {
@@ -8646,7 +8613,7 @@ static CK_RV ep11_logout_handler(uint_32 adapter, uint_32 domain,
     if (ep11_session->flags & EP11_SESS_PINBLOB_VALID) {
 #ifdef DEBUG
         TRACE_DEBUG("EP11 Session Pin blob (size: %lu):\n", XCP_PINBLOB_BYTES);
-        TRACE_DEBUG_DUMP(ep11_session->session_pin_blob, XCP_PINBLOB_BYTES);
+        TRACE_DEBUG_DUMP("    ", ep11_session->session_pin_blob, XCP_PINBLOB_BYTES);
 #endif
 
         rc = dll_m_Logout(ep11_session->session_pin_blob, XCP_PINBLOB_BYTES,
@@ -8661,7 +8628,7 @@ static CK_RV ep11_logout_handler(uint_32 adapter, uint_32 domain,
     if (ep11_session->flags & EP11_VHSM_PINBLOB_VALID) {
 #ifdef DEBUG
         TRACE_DEBUG("EP11 VHSM Pin blob (size: %lu):\n", XCP_PINBLOB_BYTES);
-        TRACE_DEBUG_DUMP(ep11_session->vhsm_pin_blob, XCP_PINBLOB_BYTES);
+        TRACE_DEBUG_DUMP("    ", ep11_session->vhsm_pin_blob, XCP_PINBLOB_BYTES);
 #endif
 
         rc = dll_m_Logout(ep11_session->vhsm_pin_blob, XCP_PINBLOB_BYTES,
@@ -8739,7 +8706,7 @@ CK_RV ep11tok_login_session(STDLL_TokData_t * tokdata, SESSION * session)
     }
 #ifdef DEBUG
     TRACE_DEBUG("EP11 Session-ID for PKCS#11 session %lu:\n", session->handle);
-    TRACE_DEBUG_DUMP(ep11_session->session_id,
+    TRACE_DEBUG_DUMP("    ", ep11_session->session_id,
                      sizeof(ep11_session->session_id));
 #endif
 

--- a/usr/lib/ep11_stdll/new_host.c
+++ b/usr/lib/ep11_stdll/new_host.c
@@ -35,6 +35,7 @@
 #include "pkcs32.h"
 #include "trace.h"
 #include "slotmgr.h"
+#include "attributes.h"
 #include "ep11_specific.h"
 
 #include "../api/apiproto.h"
@@ -3830,8 +3831,7 @@ done:
         session_mgr_put(tokdata, sess);
 
 #ifdef DEBUG
-    CK_ATTRIBUTE *attr = NULL;
-    CK_BYTE val[4];
+    CK_ATTRIBUTE *attr;
     CK_ULONG i;
 
     if (rc == CKR_OK) {
@@ -3842,31 +3842,13 @@ done:
     TRACE_DEBUG("Public Template:\n");
     attr = pPublicKeyTemplate;
     for (i = 0; i < ulPublicKeyAttributeCount; i++, attr++) {
-        TRACE_DEBUG("%lu: Attribute type: 0x%08lx, Value Length: %lu\n",
-                    i, attr->type, attr->ulValueLen);
-
-        if (attr->ulValueLen >= sizeof(val) && attr->pValue != NULL) {
-            memset(val, 0, sizeof(val));
-            memcpy(val, attr->pValue, attr->ulValueLen > sizeof(val) ?
-                                            sizeof(val) : attr->ulValueLen);
-            TRACE_DEBUG("First 4 bytes: %02x %02x %02x %02x\n",
-                        val[0], val[1], val[2], val[3]);
-        }
+        TRACE_DEBUG_DUMPATTR(attr);
     }
 
     TRACE_DEBUG("Private Template:\n");
     attr = pPublicKeyTemplate;
     for (i = 0; i < ulPrivateKeyAttributeCount; i++, attr++) {
-        TRACE_DEBUG("%lu: Attribute type: 0x%08lx, Value Length: %lu\n",
-                    i, attr->type, attr->ulValueLen);
-
-        if (attr->ulValueLen >= sizeof(val) && attr->pValue != NULL) {
-            memset(val, 0, sizeof(val));
-            memcpy(val, attr->pValue, attr->ulValueLen > sizeof(val) ?
-                                            sizeof(val) : attr->ulValueLen);
-            TRACE_DEBUG("First 4 bytes: %02x %02x %02x %02x\n",
-                        val[0], val[1], val[2], val[3]);
-        }
+        TRACE_DEBUG_DUMPATTR(attr);
     }
 #endif
 

--- a/usr/lib/ep11_stdll/new_host.c
+++ b/usr/lib/ep11_stdll/new_host.c
@@ -3846,7 +3846,7 @@ done:
     }
 
     TRACE_DEBUG("Private Template:\n");
-    attr = pPublicKeyTemplate;
+    attr = pPrivateKeyTemplate;
     for (i = 0; i < ulPrivateKeyAttributeCount; i++, attr++) {
         TRACE_DEBUG_DUMPATTR(attr);
     }

--- a/usr/lib/icsf_stdll/new_host.c
+++ b/usr/lib/icsf_stdll/new_host.c
@@ -33,6 +33,7 @@
 #include "pkcs32.h"
 #include "trace.h"
 #include "slotmgr.h"
+#include "attributes.h"
 #include "icsf_specific.h"
 #include "../api/apiproto.h"
 
@@ -2900,8 +2901,7 @@ done:
         session_mgr_put(tokdata, sess);
 
 #ifdef DEBUG
-    CK_ATTRIBUTE *attr = NULL;
-    CK_BYTE val[4];
+    CK_ATTRIBUTE *attr;
     CK_ULONG i;
 
     if (rc == CKR_OK) {
@@ -2912,31 +2912,13 @@ done:
     TRACE_DEBUG("Public Template:\n");
     attr = pPublicKeyTemplate;
     for (i = 0; i < ulPublicKeyAttributeCount; i++, attr++) {
-        TRACE_DEBUG("%lu: Attribute type: 0x%08lx, Value Length: %lu\n",
-                    i, attr->type, attr->ulValueLen);
-
-        if (attr->ulValueLen >= sizeof(val) && attr->pValue != NULL) {
-            memset(val, 0, sizeof(val));
-            memcpy(val, attr->pValue, attr->ulValueLen > sizeof(val) ?
-                                            sizeof(val) : attr->ulValueLen);
-            TRACE_DEBUG("First 4 bytes: %02x %02x %02x %02x\n",
-                        val[0], val[1], val[2], val[3]);
-        }
+        TRACE_DEBUG_DUMPATTR(attr);
     }
 
     TRACE_DEBUG("Private Template:\n");
     attr = pPublicKeyTemplate;
     for (i = 0; i < ulPrivateKeyAttributeCount; i++, attr++) {
-        TRACE_DEBUG("%lu: Attribute type: 0x%08lx, Value Length: %lu\n",
-                    i, attr->type, attr->ulValueLen);
-
-        if (attr->ulValueLen >= sizeof(val) && attr->pValue != NULL) {
-            memset(val, 0, sizeof(val));
-            memcpy(val, attr->pValue, attr->ulValueLen > sizeof(val) ?
-                                            sizeof(val) : attr->ulValueLen);
-            TRACE_DEBUG("First 4 bytes: %02x %02x %02x %02x\n",
-                        val[0], val[1], val[2], val[3]);
-        }
+        TRACE_DEBUG_DUMPATTR(attr);
     }
 #endif
 

--- a/usr/lib/icsf_stdll/new_host.c
+++ b/usr/lib/icsf_stdll/new_host.c
@@ -2916,7 +2916,7 @@ done:
     }
 
     TRACE_DEBUG("Private Template:\n");
-    attr = pPublicKeyTemplate;
+    attr = pPrivateKeyTemplate;
     for (i = 0; i < ulPrivateKeyAttributeCount; i++, attr++) {
         TRACE_DEBUG_DUMPATTR(attr);
     }


### PR DESCRIPTION
3 commits:
- TESTCASES: new testcase to test CCA opaque key token export and import
- CCA: support import of raw cca tokens with C_ObjectCreate via CKA_IBM_OPAQUE
- CCA: store only public token in IBM_OPAQUE attribute
for more details pleas see header of each commit
