### PR TITLE
Bugfix and comment

### DIFF
--- a/usr/lib/common/template.c
+++ b/usr/lib/common/template.c
@@ -1599,7 +1599,7 @@ error:
  *
  * modifies an existing attribute or adds a new attribute to the template
  *
- * Returns:  TRUE on success, FALSE on failure
+ * Returns:  CKR_OK on success, other CKR error on failure
  */
 CK_RV template_update_attribute(TEMPLATE *tmpl, CK_ATTRIBUTE *new_attr)
 {
@@ -1608,7 +1608,7 @@ CK_RV template_update_attribute(TEMPLATE *tmpl, CK_ATTRIBUTE *new_attr)
 
     if (!tmpl || !new_attr) {
         TRACE_ERROR("Invalid function arguments.\n");
-        return CKR_FUNCTION_FAILED;
+        return CKR_ARGUMENTS_BAD;
     }
     node = tmpl->attribute_list;
 

--- a/usr/lib/ep11_stdll/new_host.c
+++ b/usr/lib/ep11_stdll/new_host.c
@@ -2058,10 +2058,21 @@ CK_RV SC_EncryptInit(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
         sess->encr_ctx.key = hKey;
 
         sess->encr_ctx.mech.mechanism = pMechanism->mechanism;
-        sess->encr_ctx.mech.pParameter = malloc(pMechanism->ulParameterLen);
-        memcpy(sess->encr_ctx.mech.pParameter, pMechanism->pParameter,
-               pMechanism->ulParameterLen);
-        sess->encr_ctx.mech.ulParameterLen = pMechanism->ulParameterLen;
+        if (pMechanism->pParameter && pMechanism->ulParameterLen > 0) {
+            sess->encr_ctx.mech.pParameter = malloc(pMechanism->ulParameterLen);
+            if (sess->encr_ctx.mech.pParameter) {
+                memcpy(sess->encr_ctx.mech.pParameter, pMechanism->pParameter,
+                       pMechanism->ulParameterLen);
+                sess->encr_ctx.mech.ulParameterLen = pMechanism->ulParameterLen;
+            } else {
+                TRACE_ERROR("%s Memory allocation failed\n", __func__);
+                rc = CKR_HOST_MEMORY;
+                goto done;
+            }
+        } else {
+            sess->encr_ctx.mech.pParameter = NULL;
+            sess->encr_ctx.mech.ulParameterLen = 0;
+        }
     } else {
         rc = ep11tok_encrypt_init(tokdata, sess, pMechanism, hKey);
         if (rc != CKR_OK)
@@ -2363,10 +2374,21 @@ CK_RV SC_DecryptInit(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
         sess->decr_ctx.key = hKey;
 
         sess->decr_ctx.mech.mechanism = pMechanism->mechanism;
-        sess->decr_ctx.mech.pParameter = malloc(pMechanism->ulParameterLen);
-        memcpy(sess->decr_ctx.mech.pParameter, pMechanism->pParameter,
-               pMechanism->ulParameterLen);
-        sess->decr_ctx.mech.ulParameterLen = pMechanism->ulParameterLen;
+        if (pMechanism->pParameter && pMechanism->ulParameterLen > 0) {
+            sess->decr_ctx.mech.pParameter = malloc(pMechanism->ulParameterLen);
+            if (sess->decr_ctx.mech.pParameter) {
+                memcpy(sess->decr_ctx.mech.pParameter, pMechanism->pParameter,
+                       pMechanism->ulParameterLen);
+                sess->decr_ctx.mech.ulParameterLen = pMechanism->ulParameterLen;
+            } else {
+                TRACE_ERROR("%s Memory allocation failed\n", __func__);
+                rc = CKR_HOST_MEMORY;
+                goto done;
+            }
+        } else {
+            sess->decr_ctx.mech.pParameter = NULL;
+            sess->decr_ctx.mech.ulParameterLen = 0;
+        }
     } else {
         rc = ep11tok_decrypt_init(tokdata, sess, pMechanism, hKey);
         if (rc != CKR_OK)
@@ -2885,10 +2907,21 @@ CK_RV SC_SignInit(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
         sess->sign_ctx.key = hKey;
 
         sess->sign_ctx.mech.mechanism = pMechanism->mechanism;
-        sess->sign_ctx.mech.pParameter = malloc(pMechanism->ulParameterLen);
-        memcpy(sess->sign_ctx.mech.pParameter, pMechanism->pParameter,
-              pMechanism->ulParameterLen);
-        sess->sign_ctx.mech.ulParameterLen = pMechanism->ulParameterLen;
+        if (pMechanism->pParameter && pMechanism->ulParameterLen > 0) {
+            sess->sign_ctx.mech.pParameter = malloc(pMechanism->ulParameterLen);
+            if (sess->sign_ctx.mech.pParameter) {
+                memcpy(sess->sign_ctx.mech.pParameter, pMechanism->pParameter,
+                       pMechanism->ulParameterLen);
+                sess->sign_ctx.mech.ulParameterLen = pMechanism->ulParameterLen;
+            } else {
+                TRACE_ERROR("%s Memory allocation failed\n", __func__);
+                rc = CKR_HOST_MEMORY;
+                goto done;
+            }
+        } else {
+            sess->sign_ctx.mech.pParameter = NULL;
+            sess->sign_ctx.mech.ulParameterLen = 0;
+        }
     } else {
         rc = ep11tok_sign_init(tokdata, sess, pMechanism, FALSE, hKey);
         if (rc != CKR_OK)
@@ -3261,10 +3294,21 @@ CK_RV SC_VerifyInit(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
         sess->verify_ctx.key = hKey;
 
         sess->verify_ctx.mech.mechanism = pMechanism->mechanism;
-        sess->verify_ctx.mech.pParameter = malloc(pMechanism->ulParameterLen);
-        memcpy(sess->verify_ctx.mech.pParameter, pMechanism->pParameter,
-               pMechanism->ulParameterLen);
-        sess->verify_ctx.mech.ulParameterLen = pMechanism->ulParameterLen;
+        if (pMechanism->pParameter && pMechanism->ulParameterLen > 0) {
+            sess->verify_ctx.mech.pParameter = malloc(pMechanism->ulParameterLen);
+            if (sess->verify_ctx.mech.pParameter) {
+                memcpy(sess->verify_ctx.mech.pParameter, pMechanism->pParameter,
+                       pMechanism->ulParameterLen);
+                sess->verify_ctx.mech.ulParameterLen = pMechanism->ulParameterLen;
+            } else {
+                TRACE_ERROR("%s Memory allocation failed\n", __func__);
+                rc = CKR_HOST_MEMORY;
+                goto done;
+            }
+        } else {
+            sess->verify_ctx.mech.pParameter = NULL;
+            sess->verify_ctx.mech.ulParameterLen = 0;
+        }
     } else {
         rc = ep11tok_verify_init(tokdata, sess, pMechanism, FALSE, hKey);
         if (rc != CKR_OK)


### PR DESCRIPTION
Just two small fixes:

- The wrong comment in template_update_attribute was obvious, but Ingo also suggested to change the return code from "function failed" to arguments bad", because this fits better.
- The malloc() in the four init functions for encr/decr/sign/verify caused a problem in aes_cmac_sign where the mac_len is calculated, because malloc(0) returned some undefined value, which got assigned to mech.pParameter. Therefore let's do the malloc only if a mech param is given.