### PR TITLE
Fix cpp_test

### DIFF
--- a/testcases/build/cpp_test.cpp
+++ b/testcases/build/cpp_test.cpp
@@ -12,9 +12,11 @@
  * Test if our public header files can be savely included from C++.
  */
 
+// pkcs11.h:
 #include "apiclient.h"
 #include "pkcs11types.h"
-#include "pkcs11.h"
+
+// Additional ECC stuff:
 #include "ec_curves.h"
 
 int main(void)


### PR DESCRIPTION
pkcs11.h just includes other openCryptoki headers from
system locations.

Signed-off-by: Patrick Steuer <patrick.steuer@de.ibm.com>