### PR TITLE
Bug Fix and added Error handling

### DIFF
--- a/usr/sbin/p11sak/p11sak.c
+++ b/usr/sbin/p11sak/p11sak.c
@@ -2230,7 +2230,6 @@ static CK_RV finalize_destroy_object(char *label, CK_SESSION_HANDLE *session,
             goto done;
         }
         *boolDestroyFlag = CK_TRUE;
-        printf("DONE - Destroy Object with Label: %s\n", label);
     } else if (strncmp(user_input, "n", 1) == 0) {
         printf("Skip deleting Key\n");
         *boolDestroyFlag = CK_FALSE;


### PR DESCRIPTION
Fixes bug in delete-key command when CTRL+D is user input. 
Added comment that key with a certain label was not found and deleted if it was not found.

Signed-off-by: matthias.reumann1@ibm.com