### PR TITLE
Fix: Some attributes can not be modified after object creation

### DIFF
--- a/testcases/crypto/digest_func.c
+++ b/testcases/crypto/digest_func.c
@@ -1360,6 +1360,12 @@ CK_RV do_SignVerify_HMAC_Update(struct HMAC_TEST_SUITE_INFO * tsuite)
                     goto error;
                 }
             }
+        } else {
+            rc = funcs->C_SignUpdate(session, NULL, 0);
+            if (rc != CKR_OK) {
+                testcase_error("C_SignUpdate rc=%s", p11_get_ckr(rc));
+                goto error;
+            }
         }
         rc = funcs->C_SignFinal(session, actual, &actual_len);
         if (rc != CKR_OK) {
@@ -1388,6 +1394,12 @@ CK_RV do_SignVerify_HMAC_Update(struct HMAC_TEST_SUITE_INFO * tsuite)
                     testcase_error("C_VerifyUpdate rc=%s", p11_get_ckr(rc));
                     goto error;
                 }
+            }
+        } else {
+            rc = funcs->C_VerifyUpdate(session, NULL, 0);
+            if (rc != CKR_OK) {
+                testcase_error("C_VerifyUpdate rc=%s", p11_get_ckr(rc));
+                goto error;
             }
         }
         rc = funcs->C_VerifyFinal(session, actual, actual_len);

--- a/testcases/crypto/ec_func.c
+++ b/testcases/crypto/ec_func.c
@@ -1140,8 +1140,16 @@ CK_RV run_GenerateSignVerifyECC(CK_SESSION_HANDLE session,
     }
 
     if (parts > 0) {
-        for (i = 0; i < parts && inputlen > 0; i++) {
-            rc = funcs->C_SignUpdate(session, data, inputlen);
+        if (inputlen > 0) {
+            for (i = 0; i < parts && inputlen > 0; i++) {
+                rc = funcs->C_SignUpdate(session, data, inputlen);
+                if (rc != CKR_OK) {
+                    testcase_error("C_SignUpdate rc=%s", p11_get_ckr(rc));
+                    goto testcase_cleanup;
+                }
+            }
+        } else {
+            rc = funcs->C_SignUpdate(session, NULL, 0);
             if (rc != CKR_OK) {
                 testcase_error("C_SignUpdate rc=%s", p11_get_ckr(rc));
                 goto testcase_cleanup;
@@ -1194,8 +1202,16 @@ CK_RV run_GenerateSignVerifyECC(CK_SESSION_HANDLE session,
     }
 
     if (parts > 0) {
-        for (i = 0; i < parts && inputlen > 0; i++) {
-            rc = funcs->C_VerifyUpdate(session, data, inputlen);
+        if (inputlen > 0) {
+            for (i = 0; i < parts && inputlen > 0; i++) {
+                rc = funcs->C_VerifyUpdate(session, data, inputlen);
+                if (rc != CKR_OK) {
+                    testcase_error("C_VerifyUpdate rc=%s", p11_get_ckr(rc));
+                    goto testcase_cleanup;
+                }
+            }
+        } else {
+            rc = funcs->C_VerifyUpdate(session, NULL, 0);
             if (rc != CKR_OK) {
                 testcase_error("C_VerifyUpdate rc=%s", p11_get_ckr(rc));
                 goto testcase_cleanup;
@@ -1227,8 +1243,16 @@ CK_RV run_GenerateSignVerifyECC(CK_SESSION_HANDLE session,
     }
 
     if (parts > 0) {
-        for (i = 0; i < parts && inputlen > 0; i++) {
-            rc = funcs->C_VerifyUpdate(session, data, inputlen);
+        if (inputlen > 0) {
+            for (i = 0; i < parts && inputlen > 0; i++) {
+                rc = funcs->C_VerifyUpdate(session, data, inputlen);
+                if (rc != CKR_OK) {
+                    testcase_error("C_VerifyUpdate rc=%s", p11_get_ckr(rc));
+                    goto testcase_cleanup;
+                }
+            }
+        } else {
+            rc = funcs->C_VerifyUpdate(session, NULL, 0);
             if (rc != CKR_OK) {
                 testcase_error("C_VerifyUpdate rc=%s", p11_get_ckr(rc));
                 goto testcase_cleanup;

--- a/testcases/crypto/rsaupdate_func.c
+++ b/testcases/crypto/rsaupdate_func.c
@@ -180,19 +180,27 @@ CK_RV do_SignVerifyUpdateRSA(struct GENERATED_TEST_SUITE_INFO *tsuite)
         signature_len = 0;
 
         // do SignUpdate
-        len = message_len;
-        for (count = 0; len > 0; count += inc) {
-            if (len < CHUNK)
-                inc = len;
-            else
-                inc = CHUNK;
+        if (message_len > 0) {
+            len = message_len;
+            for (count = 0; len > 0; count += inc) {
+                if (len < CHUNK)
+                    inc = len;
+                else
+                    inc = CHUNK;
 
-            rc = funcs->C_SignUpdate(session, message + count, inc);
+                rc = funcs->C_SignUpdate(session, message + count, inc);
+                if (rc != CKR_OK) {
+                    testcase_error("C_SignUpdate(), rc=%s.", p11_get_ckr(rc));
+                    goto error;
+                }
+                len -= inc;
+            }
+        } else {
+            rc = funcs->C_SignUpdate(session, NULL, 0);
             if (rc != CKR_OK) {
                 testcase_error("C_SignUpdate(), rc=%s.", p11_get_ckr(rc));
                 goto error;
             }
-            len -= inc;
         }
 
         /* get the required length */
@@ -224,18 +232,26 @@ CK_RV do_SignVerifyUpdateRSA(struct GENERATED_TEST_SUITE_INFO *tsuite)
         }
         // do VerifyUpdate
         len = message_len;
-        for (count = 0; len > 0; count += inc) {
-            if (len < CHUNK)
-                inc = len;
-            else
-                inc = CHUNK;
+        if (message_len > 0) {
+            for (count = 0; len > 0; count += inc) {
+                if (len < CHUNK)
+                    inc = len;
+                else
+                    inc = CHUNK;
 
-            rc = funcs->C_VerifyUpdate(session, message + count, inc);
+                rc = funcs->C_VerifyUpdate(session, message + count, inc);
+                if (rc != CKR_OK) {
+                    testcase_error("C_VerifyUpdate(), rc=%s.", p11_get_ckr(rc));
+                    goto error;
+                }
+                len -= inc;
+            }
+        } else {
+            rc = funcs->C_VerifyUpdate(session, NULL, 0);
             if (rc != CKR_OK) {
                 testcase_error("C_VerifyUpdate(), rc=%s.", p11_get_ckr(rc));
                 goto error;
             }
-            len -= inc;
         }
         rc = funcs->C_VerifyFinal(session, signature, signature_len);
 

--- a/usr/lib/common/key.c
+++ b/usr/lib/common/key.c
@@ -1249,9 +1249,13 @@ CK_RV priv_key_validate_attribute(STDLL_TokData_t *tokdata, TEMPLATE *tmpl,
         TRACE_ERROR("%s\n", ock_err(ERR_ATTRIBUTE_READ_ONLY));
         return CKR_ATTRIBUTE_READ_ONLY;
     case CKA_PUBLIC_KEY_INFO:
-        if (mode == MODE_CREATE || mode == MODE_UNWRAP)
-            return CKR_OK;
-        return CKR_ATTRIBUTE_READ_ONLY;
+        /*
+         * PKCS#11: A token MAY choose not to support the CKA_PUBLIC_KEY_INFO
+         * attribute for commands which create new private keys. If it does not
+         * support the attribute, the command SHALL return
+         * CKR_ATTRIBUTE_TYPE_INVALID.
+         */
+        return CKR_ATTRIBUTE_TYPE_INVALID;
     case CKA_UNWRAP_TEMPLATE:
         if ((attr->ulValueLen > 0 && attr->pValue == NULL) ||
             attr->ulValueLen % sizeof(CK_ATTRIBUTE)) {

--- a/usr/lib/common/key.c
+++ b/usr/lib/common/key.c
@@ -316,7 +316,11 @@ CK_RV key_object_validate_attribute(TEMPLATE *tmpl, CK_ATTRIBUTE *attr,
             TRACE_ERROR("%s\n", ock_err(ERR_ATTRIBUTE_VALUE_INVALID));
             return CKR_ATTRIBUTE_VALUE_INVALID;
         }
-        return CKR_OK;
+        if (mode == MODE_CREATE || mode == MODE_KEYGEN ||
+            mode == MODE_DERIVE || mode == MODE_UNWRAP)
+            return CKR_OK;
+        TRACE_ERROR("%s\n", ock_err(ERR_ATTRIBUTE_READ_ONLY));
+        return CKR_ATTRIBUTE_READ_ONLY;
     case CKA_DERIVE:
         if (attr->ulValueLen != sizeof(CK_BBOOL) || attr->pValue == NULL) {
             TRACE_ERROR("%s\n", ock_err(ERR_ATTRIBUTE_VALUE_INVALID));
@@ -672,7 +676,11 @@ CK_RV publ_key_validate_attribute(STDLL_TokData_t *tokdata, TEMPLATE *tmpl,
             TRACE_ERROR("%s\n", ock_err(ERR_ATTRIBUTE_VALUE_INVALID));
             return CKR_ATTRIBUTE_VALUE_INVALID;
         }
-        return CKR_OK;
+        if (mode == MODE_CREATE || mode == MODE_KEYGEN ||
+            mode == MODE_DERIVE || mode == MODE_UNWRAP)
+            return CKR_OK;
+        TRACE_ERROR("%s\n", ock_err(ERR_ATTRIBUTE_READ_ONLY));
+        return CKR_ATTRIBUTE_READ_ONLY;
     default:
         return key_object_validate_attribute(tmpl, attr, mode);
     }
@@ -1250,7 +1258,11 @@ CK_RV priv_key_validate_attribute(STDLL_TokData_t *tokdata, TEMPLATE *tmpl,
             TRACE_ERROR("%s\n", ock_err(ERR_ATTRIBUTE_VALUE_INVALID));
             return CKR_ATTRIBUTE_VALUE_INVALID;
         }
-        return CKR_OK;
+        if (mode == MODE_CREATE || mode == MODE_KEYGEN ||
+            mode == MODE_DERIVE || mode == MODE_UNWRAP)
+            return CKR_OK;
+        TRACE_ERROR("%s\n", ock_err(ERR_ATTRIBUTE_READ_ONLY));
+        return CKR_ATTRIBUTE_READ_ONLY;
 
     default:
         return key_object_validate_attribute(tmpl, attr, mode);
@@ -1808,7 +1820,11 @@ CK_RV secret_key_validate_attribute(STDLL_TokData_t *tokdata, TEMPLATE *tmpl,
             TRACE_ERROR("%s\n", ock_err(ERR_ATTRIBUTE_VALUE_INVALID));
             return CKR_ATTRIBUTE_VALUE_INVALID;
         }
-        return CKR_OK;
+        if (mode == MODE_CREATE || mode == MODE_KEYGEN ||
+            mode == MODE_DERIVE || mode == MODE_UNWRAP)
+            return CKR_OK;
+        TRACE_ERROR("%s\n", ock_err(ERR_ATTRIBUTE_READ_ONLY));
+        return CKR_ATTRIBUTE_READ_ONLY;
     default:
         return key_object_validate_attribute(tmpl, attr, mode);
     }

--- a/usr/lib/common/sign_mgr.c
+++ b/usr/lib/common/sign_mgr.c
@@ -1084,11 +1084,7 @@ CK_RV sign_mgr_sign_final(STDLL_TokData_t *tokdata,
         TRACE_ERROR("%s\n", ock_err(ERR_OPERATION_NOT_INITIALIZED));
         return CKR_OPERATION_NOT_INITIALIZED;
     }
-    if (ctx->multi_init == FALSE) {
-        ctx->multi = TRUE;
-        ctx->multi_init = TRUE;
-    }
-    if (ctx->multi == FALSE) {
+    if (ctx->multi_init == FALSE || ctx->multi == FALSE) {
         TRACE_ERROR("%s\n", ock_err(ERR_OPERATION_ACTIVE));
         return CKR_OPERATION_ACTIVE;
     }

--- a/usr/lib/common/template.c
+++ b/usr/lib/common/template.c
@@ -1849,6 +1849,10 @@ CK_RV template_validate_base_attribute(TEMPLATE *tmpl, CK_ATTRIBUTE *attr,
             TRACE_ERROR("%s\n", ock_err(ERR_ATTRIBUTE_VALUE_INVALID));
             return CKR_ATTRIBUTE_VALUE_INVALID;
         }
+        if (mode != MODE_CREATE) {
+            TRACE_ERROR("%s\n", ock_err(ERR_ATTRIBUTE_READ_ONLY));
+            return CKR_ATTRIBUTE_READ_ONLY;
+        }
         if (*(CK_BBOOL *)attr->pValue == FALSE)
             return CKR_OK;
         TRACE_ERROR("%s\n", ock_err(ERR_ATTRIBUTE_VALUE_INVALID));

--- a/usr/lib/common/verify_mgr.c
+++ b/usr/lib/common/verify_mgr.c
@@ -1074,11 +1074,7 @@ CK_RV verify_mgr_verify_final(STDLL_TokData_t *tokdata,
         TRACE_ERROR("%s\n", ock_err(ERR_OPERATION_NOT_INITIALIZED));
         return CKR_OPERATION_NOT_INITIALIZED;
     }
-    if (ctx->multi_init == FALSE) {
-        ctx->multi = TRUE;
-        ctx->multi_init = TRUE;
-    }
-    if (ctx->multi == FALSE) {
+    if (ctx->multi_init == FALSE || ctx->multi == FALSE) {
         TRACE_ERROR("%s\n", ock_err(ERR_OPERATION_ACTIVE));
         return CKR_OPERATION_ACTIVE;
     }


### PR DESCRIPTION
The following attributes can not be modified after object creation:
CKA_ALLOWED_MECHANISMS, CKA_WRAP_TEMPLATE, CKA_UNWRAP_TEMPLATE, and
CKA_ALWAYS_AUTHENTICATE. Return CKR_ATTRIBUTE_READ_ONLY if those
attributes are being modified.