### PR TITLE
Fix detection of DER encoded or raw ECDH public data (2)

### DIFF
--- a/testcases/misc_tests/obj_lock.c
+++ b/testcases/misc_tests/obj_lock.c
@@ -336,7 +336,7 @@ int main(int argc, char **argv)
          * before using this test option.
          */
         if (!is_ep11_token(SLOT_ID)) {
-            testcase_notice("Slot %u doesn't support protected keys.", SLOT_ID);
+            testcase_notice("Slot %lu doesn't support protected keys.", SLOT_ID);
             goto close_session;
         } else {
             testcase_notice("Check your token config file.");

--- a/usr/lib/common/h_extern.h
+++ b/usr/lib/common/h_extern.h
@@ -1754,6 +1754,11 @@ CK_RV ec_point_from_priv_key(CK_BYTE *parms, CK_ULONG parms_len,
                              CK_BYTE *d, CK_ULONG d_len,
                              CK_BYTE **point, CK_ULONG *point_len);
 
+int ec_point_from_public_data(const CK_BYTE *data, CK_ULONG data_len,
+                              CK_ULONG prime_len, CK_BBOOL allow_raw,
+                              CK_BBOOL *allocated, CK_BYTE **ec_point,
+                              CK_ULONG *ec_point_len);
+
 // linked-list routines
 //
 DL_NODE *dlist_add_as_first(DL_NODE *list, void *data);


### PR DESCRIPTION
The previous commit did not completely fix the detection of the ECDH public data format.

When a raw ECPoint starts with 0x04 followed by a byte who's value is 2 less than the length of the public data, followed by a byte that is a valid point conversion indicator (e.g. 0x02 - compressed, 0x04 - uncompressed, or 0x06 - hybrid) then it would have still been detected as an DER encoded EC Point, resulting in a wrong EC Point.

The detection logic is corrected and is now moved into a separate function, and is used at all 3 places, i.e. in th soft token, the ICA token, and the EP11 token.