### PR TITLE
COMMON: Add dependency between lexer and parser.

### DIFF
--- a/usr/lib/common/common.mk
+++ b/usr/lib/common/common.mk
@@ -6,3 +6,5 @@ noinst_HEADERS +=							\
 	usr/lib/common/sw_crypt.h usr/lib/common/defs.h			\
 	usr/lib/common/p11util.h					\
 	usr/lib/common/list.h usr/lib/common/tok_specific.h
+
+usr/lib/common/lexer.c: usr/lib/common/parser.h


### PR DESCRIPTION
Missing dependency caused build errors in some parallel builds.

Signed-off-by: Juergen Christ <jchrist@linux.ibm.com>