### PR TITLE
Fix potential deadlock situation with double read-locks

### DIFF
--- a/usr/lib/common/decr_mgr.c
+++ b/usr/lib/common/decr_mgr.c
@@ -540,6 +540,10 @@ CK_RV decr_mgr_init(STDLL_TokData_t *tokdata,
         }
         memset(ctx->context, 0x0, sizeof(AES_GCM_CONTEXT));
 
+        /* Release obj lock, token specific aes-gcm may re-acquire the lock */
+        object_put(tokdata, key_obj, TRUE);
+        key_obj = NULL;
+
         rc = aes_gcm_init(tokdata, sess, ctx, mech, key_handle, 0);
         if (rc) {
             TRACE_ERROR("Could not initialize AES_GCM parms.\n");

--- a/usr/lib/common/encr_mgr.c
+++ b/usr/lib/common/encr_mgr.c
@@ -537,6 +537,10 @@ CK_RV encr_mgr_init(STDLL_TokData_t *tokdata,
         }
         memset(ctx->context, 0x0, sizeof(AES_GCM_CONTEXT));
 
+        /* Release obj lock, token specific aes-gcm may re-acquire the lock */
+        object_put(tokdata, key_obj, TRUE);
+        key_obj = NULL;
+
         rc = aes_gcm_init(tokdata, sess, ctx, mech, key_handle, 1);
         if (rc != CKR_OK) {
             TRACE_ERROR("Could not initialize AES_GCM parms.\n");

--- a/usr/lib/common/mech_rsa.c
+++ b/usr/lib/common/mech_rsa.c
@@ -602,6 +602,10 @@ CK_RV rsa_oaep_crypt(STDLL_TokData_t *tokdata, SESSION *sess,
             goto done;
         }
 
+        /* Release obj lock, token specific rsa-oaep may re-acquire the lock */
+        object_put(tokdata, key_obj, TRUE);
+        key_obj = NULL;
+
         rc = token_specific.t_rsa_oaep_encrypt(tokdata, ctx, in_data,
                                                in_data_len, out_data,
                                                out_data_len, hash, hlen);
@@ -624,6 +628,10 @@ CK_RV rsa_oaep_crypt(STDLL_TokData_t *tokdata, SESSION *sess,
             rc = CKR_MECHANISM_INVALID;
             goto done;
         }
+
+        /* Release obj lock, token specific rsa-oaep may re-acquire the lock */
+        object_put(tokdata, key_obj, TRUE);
+        key_obj = NULL;
 
         rc = token_specific.t_rsa_oaep_decrypt(tokdata, ctx, in_data,
                                                in_data_len, out_data,
@@ -1331,6 +1339,10 @@ CK_RV rsa_pss_sign(STDLL_TokData_t *tokdata, SESSION *sess,
         goto done;
     }
 
+    /* Release obj lock, token specific rsa_pss may re-acquire the lock */
+    object_put(tokdata, key_obj, TRUE);
+    key_obj = NULL;
+
     rc = token_specific.t_rsa_pss_sign(tokdata, sess, ctx, in_data, in_data_len,
                                        out_data, out_data_len);
     if (rc != CKR_OK)
@@ -1388,6 +1400,10 @@ CK_RV rsa_pss_verify(STDLL_TokData_t *tokdata, SESSION *sess,
         rc = CKR_MECHANISM_INVALID;
         goto done;
     }
+
+    /* Release obj lock, token specific rsa_pss may re-acquire the lock */
+    object_put(tokdata, key_obj, TRUE);
+    key_obj = NULL;
 
     rc = token_specific.t_rsa_pss_verify(tokdata, sess, ctx, in_data,
                                          in_data_len, signature, sig_len);

--- a/usr/lib/common/sign_mgr.c
+++ b/usr/lib/common/sign_mgr.c
@@ -424,6 +424,10 @@ CK_RV sign_mgr_init(STDLL_TokData_t *tokdata,
         ctx->context_len = 0;
         ctx->context = NULL;
 
+        /* Release obj lock, token specific hmac-sign may re-acquire the lock */
+        object_put(tokdata, key_obj, TRUE);
+        key_obj = NULL;
+
         rc = hmac_sign_init(tokdata, sess, mech, key);
         if (rc != CKR_OK) {
             TRACE_ERROR("Failed to initialize hmac.\n");


### PR DESCRIPTION
Do not get and read-lock an object twice within the same thread via function object_mgr_find_in_map1(), as this would read-lock the object twice.

This could cause a deadlock situation, when in-between the first and the second call to object_mgr_find_in_map1() the token object is modified by another process. The second object_mgr_find_in_map1() would detect that the object has been modified (object_mgr_check_shm()), and would try to re-load the object from the disk. For re-loading, the object is unlocked once, and a write-lock is acquired instead. However, if the current thread has read-locked the object twice, but releases only one read-lock, then it will never get the write lock, because it still owns the read lock itself.

To avoid this situation, release the read-lock before calling another function that also acquires the read lock of the object. That way, only one read-lock is held by the current thread, and re-loading the object will not cause a deadlock.