### PR TITLE
SOFT: Check the EC Key on C_CreateObject and C_DeriveKey

### DIFF
--- a/usr/lib/soft_stdll/soft_specific.c
+++ b/usr/lib/soft_stdll/soft_specific.c
@@ -4365,6 +4365,12 @@ static CK_RV fill_ec_key_from_pubkey(EC_KEY *ec_key, const CK_BYTE *data,
         goto out;
     }
 
+    if (!EC_KEY_check_key(ec_key)) {
+        TRACE_ERROR("EC_KEY_check_key failed\n");
+        rc = CKR_PUBLIC_KEY_INVALID;
+        goto out;
+    }
+
 out:
     if (allocated && ecpoint != NULL)
         free(ecpoint);
@@ -4400,6 +4406,12 @@ static CK_RV fill_ec_key_from_privkey(EC_KEY *ec_key, const CK_BYTE *data,
 
     if (!EC_KEY_set_public_key(ec_key, point)) {
         TRACE_ERROR("EC_KEY_set_public_key failed\n");
+        rc = CKR_FUNCTION_FAILED;
+        goto out;
+    }
+
+    if (!EC_KEY_check_key(ec_key)) {
+        TRACE_ERROR("EC_KEY_check_key failed\n");
         rc = CKR_FUNCTION_FAILED;
         goto out;
     }


### PR DESCRIPTION
When constructing an OpenSSL EC public or private key from PKCS#11 attributes or ECDH public data, check that the key is valid, i.e. that the point is on the curve.

This prevents one from creating an EC key object via C_CreateObject with invalid key data. It also prevents C_DeriveKey to derive a secret using ECDH with an EC public key (public data) that uses a different curve
or is invalid by other means.