### PR TITLE
Change PIDFile to use a non-deprecated directory

### DIFF
--- a/misc/pkcsslotd.service.in
+++ b/misc/pkcsslotd.service.in
@@ -4,7 +4,7 @@ After=local-fs.target
 
 [Service]
 Type=forking
-PIDFile=/var/run/pkcsslotd.pid
+PIDFile=/run/pkcsslotd.pid
 ExecStart=@sbindir@/pkcsslotd
 
 [Install]


### PR DESCRIPTION
The usage of /var/run is deprecated. Use /run for the PIDFile instead.