### PR TITLE
ICA: handle unsupported curves correctly for openssl fallbacks

### DIFF
--- a/testcases/crypto/ec_func.c
+++ b/testcases/crypto/ec_func.c
@@ -911,7 +911,11 @@ CK_RV run_DeriveECDHKeyKAT()
                                 priv_keyA, derive_tmpl,
                                 derive_tmpl_len, &secret_keyA);
         if (rc != CKR_OK) {
-            if (is_ep11_token(SLOT_ID) &&
+            if (rc == CKR_CURVE_NOT_SUPPORTED) {
+                testcase_skip("Slot %u doesn't support this curve: %s",
+                              (unsigned int) SLOT_ID, ecdh_tv[i].name);
+                goto testcase_next;
+            } else if (is_ep11_token(SLOT_ID) &&
                 rc == CKR_MECHANISM_PARAM_INVALID &&
                 (ecdh_tv[i].kdf != CKD_NULL ||
                  ecdh_tv[i].shared_data_len > 0)) {

--- a/usr/lib/ica_s390_stdll/ica_specific.c
+++ b/usr/lib/ica_s390_stdll/ica_specific.c
@@ -4261,8 +4261,13 @@ CK_RV token_specific_ec_generate_keypair(STDLL_TokData_t *tokdata,
     /* Generate key data for this key object */
     rc = p_ica_ec_key_generate(ica_data->adapter_handle, eckey);
     if (rc != 0) {
-        TRACE_ERROR("ica_ec_key_generate() failed with rc=%d.\n", rc);
-        ret = CKR_FUNCTION_FAILED;
+        if (rc == EINVAL) {
+            TRACE_ERROR("ica_ec_key_generate() failed with rc=EINVAL, probably curve not supported by openssl.\n");
+            ret = CKR_CURVE_NOT_SUPPORTED;
+        } else {
+            TRACE_ERROR("ica_ec_key_generate() failed with rc=%d.\n", rc);
+            ret = CKR_FUNCTION_FAILED;
+        }
         goto end;
     }
 
@@ -4770,8 +4775,13 @@ CK_RV token_specific_ecdh_pkcs_derive(STDLL_TokData_t *tokdata,
     rc = p_ica_ecdh_derive_secret(ica_data->adapter_handle, privkey,
                                   pubkey, secret_value, privlen);
     if (rc != 0) {
-        TRACE_ERROR("ica_ecdh_derive_secret() failed with rc = %d. \n", rc);
-        ret = CKR_FUNCTION_FAILED;
+        if (rc == EINVAL) {
+            TRACE_ERROR("ica_ecdh_derive_secret() failed with rc=EINVAL, probably curve not supported by openssl.\n");
+            ret = CKR_CURVE_NOT_SUPPORTED;
+        } else {
+            TRACE_ERROR("ica_ecdh_derive_secret() failed with rc = %d. \n", rc);
+            ret = CKR_FUNCTION_FAILED;
+        }
         goto end;
     }
 


### PR DESCRIPTION
This pr fixes issue #404. 
When libica has no crypto cards, the set of supported EC curves depends on openssl.
If openssl is e.g. in FIPS mode, very few curves are supported. This was not handled
correctly in icatoken and the EC tests. 
As libica itself does not provide sign update, I added the check for unsupported curves
only for sign and sign final to keep changes small. We may discuss this. 