### PR TITLE
ICA: Fix libica return code handling for unsupported curves

### DIFF
--- a/usr/lib/ica_s390_stdll/ica_specific.c
+++ b/usr/lib/ica_s390_stdll/ica_specific.c
@@ -4261,8 +4261,8 @@ CK_RV token_specific_ec_generate_keypair(STDLL_TokData_t *tokdata,
     /* Generate key data for this key object */
     rc = p_ica_ec_key_generate(ica_data->adapter_handle, eckey);
     if (rc != 0) {
-        if (rc == EINVAL) {
-            TRACE_ERROR("ica_ec_key_generate() failed with rc=EINVAL, probably curve not supported by openssl.\n");
+        if (rc == EPERM) {
+            TRACE_ERROR("ica_ec_key_generate() failed with rc=EPERM, probably curve not supported by openssl.\n");
             ret = CKR_CURVE_NOT_SUPPORTED;
         } else {
             TRACE_ERROR("ica_ec_key_generate() failed with rc=%d.\n", rc);
@@ -4775,8 +4775,8 @@ CK_RV token_specific_ecdh_pkcs_derive(STDLL_TokData_t *tokdata,
     rc = p_ica_ecdh_derive_secret(ica_data->adapter_handle, privkey,
                                   pubkey, secret_value, privlen);
     if (rc != 0) {
-        if (rc == EINVAL) {
-            TRACE_ERROR("ica_ecdh_derive_secret() failed with rc=EINVAL, probably curve not supported by openssl.\n");
+        if (rc == EPERM) {
+            TRACE_ERROR("ica_ecdh_derive_secret() failed with rc=EPERM, probably curve not supported by openssl.\n");
             ret = CKR_CURVE_NOT_SUPPORTED;
         } else {
             TRACE_ERROR("ica_ecdh_derive_secret() failed with rc = %d. \n", rc);


### PR DESCRIPTION
With commit "Fix checking if curve supported in key generate, init, derive",
libica returns EPERM, if a key is generated, initialized, or derived, and
the EC curve is not supported.

Signed-off-by: Joerg Schmidbauer <jschmidb@de.ibm.com>