### PR TITLE
Improve CI coverage

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -201,6 +201,14 @@ endif
 if ENABLE_TESTCASES
 PKCS11_SO_PIN ?= 76543210
 PKCS11_USER_PIN ?= 01234567
+PKCS11_VHSM_PIN ?= 1234567890
+
+ci-prepare:
+	killall -HUP pkcsslotd || true
+	${srcdir}/testcases/ciconfig.sh "$(sysconfdir)/opencryptoki" "$(sysconfdir)/opencryptoki"
+	@sbindir@/pkcsslotd
+	cd ${srcdir}/testcases && ./init_token.sh 42 && ./init_vhsm.exp 42
+	echo "VHSM_MODE" >> "$(sysconfdir)/opencryptoki/ep11tok42.conf"
 
 installcheck-local: all
 	killall -HUP pkcsslotd || true
@@ -215,11 +223,13 @@ installcheck-local: all
 	fi
 	killall -HUP pkcsslotd
 
-ci-installcheck: installcheck
+ci-installcheck: ci-prepare installcheck
 	killall -HUP pkcsslotd || true
 	@sbindir@/pkcsslotd
 	cd ${srcdir}/testcases && export PKCSLIB=@libdir@/opencryptoki/libopencryptoki.so && export PKCS11_USER_PIN=$(PKCS11_USER_PIN) && ./misc_tests/p11sak_test.sh | tee log-p11sak.txt
 	killall -HUP pkcsslotd
 	@echo "done"
+
+.PHONY: ci-prepare ci-installcheck
 endif
 

--- a/testcases/ciconfig.sh
+++ b/testcases/ciconfig.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+OCKCONFDIR="$1"
+EPCONFDIR="$2"
+
+LATESTCEXP="CEX7P"
+
+# Usage: addslot slot-num stdll slot-name [confname]
+function addslot() {
+    cat <<EOF >> "${OCKCONFDIR}/opencryptoki.conf"
+slot $1
+{
+stdll = $2
+tokname = $3
+EOF
+    if [ "x$4" != "x" ]; then
+       echo "confname = $4" >> "${OCKCONFDIR}/opencryptoki.conf"
+    fi
+    echo "}" >> "${OCKCONFDIR}/opencryptoki.conf"
+}
+
+# Usage: genep11cfg num configline
+function genep11cfg() {
+    cat <<EOF > "${EPCONFDIR}/ep11tok${1}.conf"
+${2}
+APQN_ANY
+EOF
+}
+
+# Usage: genlatestep11cfg num
+# Return: 0 if successful
+function genlatestep11cfg() {
+    local res=1
+    
+    lszcrypt | grep "$LATESTCEXP" | perl -ne '/(\d+)\.(\d+)\s.*/ && print "0x$1 0x$2\n"' > tmp.apqns
+    if test -s tmp.apqns; then
+	echo "APQN_WHITELIST" > "${EPCONFDIR}/ep11tok${1}.conf"
+	cat tmp.apqns >> "${EPCONFDIR}/ep11tok${1}.conf"
+	echo "END" >> "${EPCONFDIR}/ep11tok${1}.conf"
+	res=0
+    fi
+    rm -f tmp.apqns
+    return $res
+}
+
+# initialize opencryptoki.conf
+echo "version opencryptoki-3.16" > "${OCKCONFDIR}/opencryptoki.conf"
+
+# ICA token
+addslot 10 libpkcs11_ica.so ica0
+addslot 11 libpkcs11_ica.so ica1
+
+# CCA token
+addslot 20 libpkcs11_cca.so cca0
+addslot 21 libpkcs11_cca.so cca1
+
+# SW token
+addslot 30 libpkcs11_sw.so sw0
+addslot 31 libpkcs11_sw.so sw1
+
+# EP11 token
+# 0:
+# APQN_ANY
+genep11cfg 40 ""
+addslot 40 libpkcs11_ep11.so ep0 ep11tok40.conf
+
+# 1:
+# FORCE_SENSITIVE
+# APQN_ANY
+genep11cfg 41 "FORCE_SENSITIVE"
+addslot 41 libpkcs11_ep11.so ep1 ep11tok41.conf
+
+# 2:
+# STRICT_MODE
+# APQN_ANY
+# later appended: VHSM_MODE
+
+genep11cfg 42 "STRICT_MODE"
+addslot 42 libpkcs11_ep11.so ep2 ep11tok42.conf
+
+# 3:
+# OPTIMIZE_SINGLE_PART_OPERATIONS
+# APQN_ANY
+genep11cfg 43 "OPTIMIZE_SINGLE_PART_OPERATIONS"
+addslot 43 libpkcs11_ep11.so ep3 ep11tok43.conf
+
+# 4:
+# DIGEST_LIBICA OFF
+# APQN_ANY
+genep11cfg 44 "DIGEST_LIBICA OFF"
+addslot 44 libpkcs11_ep11.so ep4 ep11tok44.conf
+
+# 5:
+# PKEY_MODE DISABLED
+# APQN_ANY
+genep11cfg 45 "PKEY_MODE DISABLED"
+addslot 45 libpkcs11_ep11.so ep5 ep11tok45.conf
+
+# 6: latest
+if genlatestep11cfg 46; then
+    addslot 46 libpkcs11_ep11.so ep6 ep11tok46.conf
+fi

--- a/testcases/init_vhsm.exp.in
+++ b/testcases/init_vhsm.exp.in
@@ -1,0 +1,28 @@
+#!/usr/bin/expect -f
+#
+# COPYRIGHT (c) International Business Machines Corp. 2001-2017
+#
+# This program is provided under the terms of the Common Public License,
+# version 1.0 (CPL-1.0). Any use, reproduction or distribution for this software
+# constitutes recipient's acceptance of CPL-1.0 terms which can be found
+# in the file LICENSE file or at https://opensource.org/licenses/cpl1.0.php
+#
+
+set timeout 5
+
+spawn @sbindir@/pkcsep11_session vhsmpin -slot [lindex $argv 0]
+expect {
+    "Enter the USER PIN:" { sleep .1; send "01234567\r"; }
+    eof { exit 1 }
+    timeout { exit 1 }
+}
+expect {
+    "Enter the new VHSM PIN:" { sleep .1; send "0123456789\r"; }
+    eof { exit 1 }
+    timeout { exit 1 }
+}
+expect {
+    "VHSM-pin successfully set." { exit 0 }
+    eof { exit 1 }
+    timeout { exit 1 }
+}

--- a/testcases/misc_tests/p11sak_test.sh
+++ b/testcases/misc_tests/p11sak_test.sh
@@ -34,9 +34,9 @@ P11SAK_EC_POST=p11sak-ec-post.out
 echo "** Setting SLOT=3 to the Softtoken unless otherwise set - 'p11sak_test.sh'"
 
 
-# setting SLOT=3 to the Softtoken
+# setting SLOT=30 to the Softtoken
 
-SLOT=${SLOT:-3}
+SLOT=${SLOT:-30}
 
 echo "** Using Slot $SLOT with PKCS11_USER_PIN $PKCS11_USER_PIN and PKCSLIB $PKCSLIB - 'p11sak_test.sh'"
 

--- a/testcases/ock_tests.sh.in
+++ b/testcases/ock_tests.sh.in
@@ -175,7 +175,7 @@ check_slot()
             return 1
         esac
 
-        # Check if Tokem is initialized and set $NONEED_TOKEN_INIT if so
+        # Check if token is initialized and set $NONEED_TOKEN_INIT if so
         NONEED_TOKEN_INIT=`echo "$TOKDESCR" | grep "Flags:" | grep TOKEN_INITIALIZED | wc -l`
 }
 
@@ -284,11 +284,8 @@ main_script()
 
     # where to run
     if [ -z $SLOT ]; then
-        NUMSLOT=$(grep '^slot' $PKCONF | wc -l)
-        for ((i=0; i<$NUMSLOT; i++)); do
-            SLOT="$SLOT $i"
-            LOGFILE=1
-        done
+	SLOT="`awk '/slot (.*)/ { print $2; }' $PKCONF`"
+        LOGFILE=1
     fi
 
     for i in $SLOT; do (

--- a/testcases/testcases.mk
+++ b/testcases/testcases.mk
@@ -12,9 +12,9 @@ include testcases/misc_tests/misc_tests.mk
 include testcases/pkcs11/pkcs11.mk
 include testcases/build/build.mk
 
-noinst_SCRIPTS += testcases/ock_tests.sh testcases/init_token.sh
-CLEANFILES += testcases/ock_tests.sh testcases/init_token.sh
-EXTRA_DIST += testcases/ock_tests.sh.in testcases/init_token.sh.in
+noinst_SCRIPTS += testcases/ock_tests.sh testcases/init_token.sh testcases/init_vhsm.exp
+CLEANFILES += testcases/ock_tests.sh testcases/init_token.sh testcases/init_vhsm.exp
+EXTRA_DIST += testcases/ock_tests.sh.in testcases/init_token.sh.in testcases/init_vhsm.exp.in
 
 testcases/ock_tests.sh: testcases/ock_tests.sh.in
 	@SED@	-e s!\@sysconfdir\@!"@sysconfdir@"!g			\
@@ -24,6 +24,13 @@ testcases/ock_tests.sh: testcases/ock_tests.sh.in
 	mv $@-t $@
 
 testcases/init_token.sh: testcases/init_token.sh.in
+	@SED@	-e s!\@localstatedir\@!"@localstatedir@"!g		\
+		-e s!\@sbindir\@!"@sbindir@"!g				\
+		-e s!\@libdir\@!"@libdir@"!g < $< > $@-t
+	@CHMOD@ a+x $@-t
+	mv $@-t $@
+
+testcases/init_vhsm.exp: testcases/init_vhsm.exp.in
 	@SED@	-e s!\@localstatedir\@!"@localstatedir@"!g		\
 		-e s!\@sbindir\@!"@sbindir@"!g				\
 		-e s!\@libdir\@!"@libdir@"!g < $< > $@-t


### PR DESCRIPTION
Change our CI code such that we test more paths.  For every token we now test
multi tenant support by instantiating at least two tokens.  New token naming
scheme for the CI is:

Token numbers: <typenum><count>
where <typename> is
ICA:  1
CCA:  2
SW:   3
EP11: 4

For all except EP11 we have as tokname the lowercase type followed by a
0-based count (similar to token numbers).  For EP11 the token is called "ep"
followed by the 0-based count.  Furthermore, for EP11 the token configuration
file differs between the tokens:

0: Default with only APQN_ANY
1: FORCE_SENSITIVE and APQN_ANY
2: STRICT_MODE, VHSM_MODE, and APQN_ANY
3: OPTIMIZE_SINGLE_OPERATIONS and APQN_ANY
4: DIGEST_LIBICA OFF and APQN_ANY
5: PKEY_MODE DISABLED and APQN_ANY
6: AQPN_WHITELIST selecting the latest CEXP as defined in testcaes/ciconfig.sh
variable LATESTCEXP

Note the count 6 for EP11 is only generated if a corresponding card is found
on the machine.  Otherwise this slot will be skipped.

Preparation for the CI is built into the makefile.  The current implementation
does not allow for parallel make since then preparation and the installcheck
would run in parallel.  But this is not a problem since the installcheck
itself is already highly parallelized (one process per slot to test running in
parallel).

Signed-off-by: Juergen Christ <jchrist@linux.ibm.com>