### PR TITLE
[TEST] Fix setup and cleanup of slots

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -207,7 +207,8 @@ ci-prepare:
 	killall -HUP pkcsslotd || true
 	${srcdir}/testcases/ciconfig.sh "$(sysconfdir)/opencryptoki" "$(sysconfdir)/opencryptoki"
 	@sbindir@/pkcsslotd
-	cd ${srcdir}/testcases && ./init_token.sh 42 && ./init_vhsm.exp 42
+	if @sbindir@/pkcsconf -c 42 -t | grep "Flags:" | grep -v -q TOKEN_INITIALIZED; then cd ${srcdir}/testcases && ./init_token.sh 42; fi
+	cd ${srcdir}/testcases && ./init_vhsm.exp 42
 	echo "VHSM_MODE" >> "$(sysconfdir)/opencryptoki/ep11tok42.conf"
 
 installcheck-local: all
@@ -230,6 +231,12 @@ ci-installcheck: ci-prepare installcheck
 	killall -HUP pkcsslotd
 	@echo "done"
 
-.PHONY: ci-prepare ci-installcheck
+ci-uninstall: uninstall
+	rm -f $(sysconfdir)/opencryptoki/ep11tok*.conf
+	rm -rf $(localstatedir)/lib/opencryptoki/*
+	rm -rf $(lockdir)/*
+	rm -rf $(logdir)/*
+
+.PHONY: ci-prepare ci-installcheck ci-uninstall
 endif
 

--- a/testcases/ciconfig.sh
+++ b/testcases/ciconfig.sh
@@ -91,9 +91,9 @@ genep11cfg 44 "DIGEST_LIBICA OFF"
 addslot 44 libpkcs11_ep11.so ep4 ep11tok44.conf
 
 # 5:
-# PKEY_MODE DISABLED
+# PKEY_MODE ENABLE4NONEXTR
 # APQN_ANY
-genep11cfg 45 "PKEY_MODE DISABLED"
+genep11cfg 45 "PKEY_MODE ENABLE4NONEXTR"
 addslot 45 libpkcs11_ep11.so ep5 ep11tok45.conf
 
 # 6: latest

--- a/testcases/init_token.sh.in
+++ b/testcases/init_token.sh.in
@@ -8,64 +8,74 @@
 # in the file LICENSE file or at https://opensource.org/licenses/cpl1.0.php
 #
 
-set timeout 5
-
 spawn @sbindir@/pkcsconf -c [lindex $argv 0] -I
-expect "Enter the SO PIN: "
-sleep .1
-send "87654321\r"
-sleep .1
-expect "label: "
-sleep .1
-send "ibmtest\r"
-sleep .1
-expect eof {} \
-"Incorrect PIN Entered." {exit 1}
+expect {
+    "Enter the SO PIN: " { sleep .1; send "87654321\r"; }
+    default { send_user "Error sending SO PIN during initialization\r"; exit 1 }
+}
+expect {
+    "label: " { sleep .1; send "ibmtest\r"; }
+    default { send_user "Error sending label during initialization\r"; exit 1 }
+}
+expect {
+    eof {}
+    "Incorrect PIN Entered." { exit 1 }
+    timeout { send_user "Timeout during initialization\r"; exit 1 }
+}
 
 spawn @sbindir@/pkcsconf -c [lindex $argv 0] -P
-expect "Enter the SO PIN: "
-sleep .1
-send "87654321\r"
-sleep .1
-expect "Enter the new SO PIN: "
-sleep .1
-send "76543210\r"
-sleep .1
-expect "Re-enter the new SO PIN: "
-sleep .1
-send "76543210\r"
-sleep .1
-expect eof {} \
-"Incorrect PIN Entered." {exit 1}
+expect {
+    "Enter the SO PIN: " { sleep .1; send "87654321\r"; }
+    default { send_user "Error sending SO PIN during SO PIN setting\r"; exit 1 }
+}
+expect {
+    "Enter the new SO PIN: " { sleep .1; send "76543210\r"; }
+    default { send_user "Error sending new SO PIN during SO PIN setting\r"; exit 1 }
+}
+expect {
+    "Re-enter the new SO PIN: " { sleep .1; send "76543210\r"; }
+    default { send_user "Error resending new SO PIN during SO PIN setting\r"; exit 1 }
+}
+expect {
+    eof {}
+    "Incorrect PIN Entered." { exit 1 }
+    timeout { send_user "Timeout during SO PIN setting\r"; exit 1 }
+}
 
 spawn @sbindir@/pkcsconf -c [lindex $argv 0] -u
-expect "Enter the SO PIN: "
-sleep .1
-send "76543210\r"
-sleep .1
-expect "Enter the new user PIN: "
-sleep .1
-send "12345678\r"
-sleep .1
-expect "Re-enter the new user PIN: "
-sleep .1
-send "12345678\r"
-sleep .1
-expect eof {} \
-"Incorrect PIN Entered." {exit 1}
+expect {
+    "Enter the SO PIN: " { sleep .1; send "76543210\r"; }
+    default { send_user "Error sending SO PIN during user PIN initialization\r"; exit 1 }
+}
+expect {
+    "Enter the new user PIN: " { sleep .1; send "12345678\r"; }
+    default { send_user "Error sending new user PIN during user PIN initialization\r"; exit 1 }
+}
+expect {
+    "Re-enter the new user PIN: " { sleep .1; send "12345678\r"; }
+    default { send_user "Error resending new user during user PIN initialization\r"; exit 1 }
+}
+expect {
+    eof {}
+    "Incorrect PIN Entered." { exit 1 }
+    timeout { send_user "Timeout during user PIN initialization\r"; exit 1 }
+}
 
 spawn @sbindir@/pkcsconf -c [lindex $argv 0] -p
-expect "Enter user PIN: "
-sleep .1
-send "12345678\r"
-sleep .1
-expect "Enter the new user PIN: "
-sleep .1
-send "01234567\r"
-sleep .1
-expect "Re-enter the new user PIN: "
-sleep .1
-send "01234567\r"
-sleep .1
-expect eof {} \
-"Incorrect PIN Entered." {exit 1}
+expect {
+    "Enter user PIN: " { sleep .1; send "12345678\r"; }
+    default { send_user "Error sending user PIN during user PIN setting\r"; exit 1 }
+}
+expect {
+    "Enter the new user PIN: " { sleep .1; send "01234567\r"; }
+    default { send_user "Error sending new user PIN during user PIN setting\r"; exit 1 }
+}
+expect {
+    "Re-enter the new user PIN: " { sleep .1; send "01234567\r"; }
+    default { send_user "Error resending new user PIN during user PIN setting\r"; exit 1 }
+}
+expect {
+    eof {}
+    "Incorrect PIN Entered." { exit 1 }
+    timeout { send_user "Timeout during user PIN setting\r"; exit 1 }
+}


### PR DESCRIPTION
With the addition of lots of slots to our CI the initialization of slots ran
into timeouts in the expect scripts.  Unfortunately these errors were ignored
(expect standard action) which caused uninitialized slots to be tested.
Remove the 5 second timeout in preference of the default 10 seconds and treat
timeout errors in the expect script.

Also provide a cleanup target for the CI that correctly removes all token data
such that the next run starts from a clean state.

Do not attempt to reinitialize slot 42 if it is already initialized.

Switch slot 45 to use PKEYs since the default and disabled setting currently
cover the same code paths.

Signed-off-by: Juergen Christ <jchrist@linux.ibm.com>