### PR TITLE
Serialize token initialization

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -207,7 +207,7 @@ ci-prepare:
 	killall -HUP pkcsslotd || true
 	${srcdir}/testcases/ciconfig.sh "$(sysconfdir)/opencryptoki" "$(sysconfdir)/opencryptoki"
 	@sbindir@/pkcsslotd
-	if @sbindir@/pkcsconf -c 42 -t | grep "Flags:" | grep -v -q TOKEN_INITIALIZED; then cd ${srcdir}/testcases && ./init_token.sh 42; fi
+	for slot in `awk '/slot (.*)/ { print $$2; }' $(sysconfdir)/opencryptoki/opencryptoki.conf`; do @sbindir@/pkcsconf -c $$slot -t | grep "Flags:" | grep -q TOKEN_INITIALIZED || ${srcdir}/testcases/init_token.sh $$slot; done
 	cd ${srcdir}/testcases && ./init_vhsm.exp 42
 	echo "VHSM_MODE" >> "$(sysconfdir)/opencryptoki/ep11tok42.conf"
 

--- a/testcases/init_token.sh.in
+++ b/testcases/init_token.sh.in
@@ -11,71 +11,71 @@
 spawn @sbindir@/pkcsconf -c [lindex $argv 0] -I
 expect {
     "Enter the SO PIN: " { sleep .1; send "87654321\r"; }
-    default { send_user "Error sending SO PIN during initialization\r"; exit 1 }
+    default { send_user "Error sending SO PIN during initialization\n"; exit 1 }
 }
 expect {
     "label: " { sleep .1; send "ibmtest\r"; }
-    default { send_user "Error sending label during initialization\r"; exit 1 }
+    default { send_user "Error sending label during initialization\n"; exit 1 }
 }
 expect {
     eof {}
     "Incorrect PIN Entered." { exit 1 }
-    timeout { send_user "Timeout during initialization\r"; exit 1 }
+    timeout { send_user "Timeout during initialization\n"; exit 1 }
 }
 
 spawn @sbindir@/pkcsconf -c [lindex $argv 0] -P
 expect {
     "Enter the SO PIN: " { sleep .1; send "87654321\r"; }
-    default { send_user "Error sending SO PIN during SO PIN setting\r"; exit 1 }
+    default { send_user "Error sending SO PIN during SO PIN setting\n"; exit 1 }
 }
 expect {
     "Enter the new SO PIN: " { sleep .1; send "76543210\r"; }
-    default { send_user "Error sending new SO PIN during SO PIN setting\r"; exit 1 }
+    default { send_user "Error sending new SO PIN during SO PIN setting\n"; exit 1 }
 }
 expect {
     "Re-enter the new SO PIN: " { sleep .1; send "76543210\r"; }
-    default { send_user "Error resending new SO PIN during SO PIN setting\r"; exit 1 }
+    default { send_user "Error resending new SO PIN during SO PIN setting\n"; exit 1 }
 }
 expect {
     eof {}
     "Incorrect PIN Entered." { exit 1 }
-    timeout { send_user "Timeout during SO PIN setting\r"; exit 1 }
+    timeout { send_user "Timeout during SO PIN setting\n"; exit 1 }
 }
 
 spawn @sbindir@/pkcsconf -c [lindex $argv 0] -u
 expect {
     "Enter the SO PIN: " { sleep .1; send "76543210\r"; }
-    default { send_user "Error sending SO PIN during user PIN initialization\r"; exit 1 }
+    default { send_user "Error sending SO PIN during user PIN initialization\n"; exit 1 }
 }
 expect {
     "Enter the new user PIN: " { sleep .1; send "12345678\r"; }
-    default { send_user "Error sending new user PIN during user PIN initialization\r"; exit 1 }
+    default { send_user "Error sending new user PIN during user PIN initialization\n"; exit 1 }
 }
 expect {
     "Re-enter the new user PIN: " { sleep .1; send "12345678\r"; }
-    default { send_user "Error resending new user during user PIN initialization\r"; exit 1 }
+    default { send_user "Error resending new user during user PIN initialization\n"; exit 1 }
 }
 expect {
     eof {}
     "Incorrect PIN Entered." { exit 1 }
-    timeout { send_user "Timeout during user PIN initialization\r"; exit 1 }
+    timeout { send_user "Timeout during user PIN initialization\n"; exit 1 }
 }
 
 spawn @sbindir@/pkcsconf -c [lindex $argv 0] -p
 expect {
     "Enter user PIN: " { sleep .1; send "12345678\r"; }
-    default { send_user "Error sending user PIN during user PIN setting\r"; exit 1 }
+    default { send_user "Error sending user PIN during user PIN setting\n"; exit 1 }
 }
 expect {
     "Enter the new user PIN: " { sleep .1; send "01234567\r"; }
-    default { send_user "Error sending new user PIN during user PIN setting\r"; exit 1 }
+    default { send_user "Error sending new user PIN during user PIN setting\n"; exit 1 }
 }
 expect {
     "Re-enter the new user PIN: " { sleep .1; send "01234567\r"; }
-    default { send_user "Error resending new user PIN during user PIN setting\r"; exit 1 }
+    default { send_user "Error resending new user PIN during user PIN setting\n"; exit 1 }
 }
 expect {
     eof {}
     "Incorrect PIN Entered." { exit 1 }
-    timeout { send_user "Timeout during user PIN setting\r"; exit 1 }
+    timeout { send_user "Timeout during user PIN setting\n"; exit 1 }
 }

--- a/testcases/init_vhsm.exp.in
+++ b/testcases/init_vhsm.exp.in
@@ -8,21 +8,19 @@
 # in the file LICENSE file or at https://opensource.org/licenses/cpl1.0.php
 #
 
-set timeout 5
-
 spawn @sbindir@/pkcsep11_session vhsmpin -slot [lindex $argv 0]
 expect {
     "Enter the USER PIN:" { sleep .1; send "01234567\r"; }
-    eof { exit 1 }
-    timeout { exit 1 }
+    eof { send_user "Unexpected EOF on user pin\n"; exit 1 }
+    timeout { send_user "Timeout on user pin\n"; exit 1 }
 }
 expect {
     "Enter the new VHSM PIN:" { sleep .1; send "0123456789\r"; }
-    eof { exit 1 }
-    timeout { exit 1 }
+    eof { send_user "Unexpected EOF on VHSM pin\n"; exit 1 }
+    timeout { send_user "Timeout on VHSM pin\n"; exit 1 }
 }
 expect {
     "VHSM-pin successfully set." { exit 0 }
-    eof { exit 1 }
-    timeout { exit 1 }
+    eof { send_user "Unexpected EOF at the end\n"; exit 1 }
+    timeout { send_user "Unexpected timeout at the end\n"; exit 1 }
 }


### PR DESCRIPTION
Initializing 12 tokens in parallel causes some random bugs in our CI.  To
prevent these, initialize the tokens in sequence such that in the log output
the errors and commands can be identified without interleaving of other
commands and stray newline characters.

Signed-off-by: Juergen Christ <jchrist@linux.ibm.com>