### PR TITLE
Openssl 3.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -277,27 +277,23 @@ if test "x$with_openssl" != "xno"; then
 	old_libs="$LIBS"
 	CFLAGS="$CFLAGS $OPENSSL_CFLAGS"
 	LIBS="$LIBS $OPENSSL_LIBS"
-	AC_CHECK_HEADER([openssl/ssl.h], [], [
-		if test "x$with_openssl" != "xcheck"; then
-			AC_MSG_ERROR([Build with OpenSSL requested but OpenSSL headers couldn't be found])
-		fi
-		with_openssl=no
+	AC_CHECK_HEADER([openssl/evp.h], [], [
+		AC_MSG_ERROR([OpenSSL 1.1.1 or later is required but OpenSSL headers couldn't be found])
 	])
 	if test "x$with_openssl" != "xno"; then
-		AC_CHECK_LIB([crypto], [RSA_generate_key], [
+		AC_CHECK_LIB([crypto], [EVP_sha3_256], [
 			OPENSSL_LIBS="$OPENSSL_LIBS -lcrypto"
-			with_openssl=yes
-			], [
-				if test "x$with_openssl" != "xcheck"; then
-					AC_MSG_ERROR([Build with OpenSSL requested but OpenSSL libraries couldn't be found])
-				fi
-				with_openssl=no
+			with_openssl=yes], [
+			AC_MSG_ERROR([OpenSSL 1.1.1 or later is required but OpenSSL libraries version 1.1.1 or later couldn't be found])
 		])
 	fi
 	if test "x$with_openssl" = "xno"; then
 		CFLAGS="$old_cflags"
 		LIBS="$old_libs"
 	fi
+fi
+if test "x$with_openssl" != "xyes"; then
+	AC_MSG_ERROR([OpenSSL 1.1.1 or later is required but build without OpenSSL was requested])
 fi
 AC_SUBST([OPENSSL_CFLAGS])
 AC_SUBST([OPENSSL_LIBS])

--- a/configure.ac
+++ b/configure.ac
@@ -39,10 +39,8 @@ dnl Checks for library functions.
 AC_FUNC_ALLOCA
 AC_FUNC_CHOWN
 AC_FUNC_FORK
-AC_FUNC_MALLOC
 AC_FUNC_MKTIME
 AC_FUNC_MMAP
-AC_FUNC_REALLOC
 AC_FUNC_STRERROR_R
 AC_CHECK_FUNCS([atexit ftruncate gettimeofday localtime_r memchr memmove \
 		memset mkdir munmap regcomp select socket strchr strcspn \

--- a/configure.ac
+++ b/configure.ac
@@ -272,7 +272,7 @@ OPENSSL_CFLAGS=
 OPENSSL_LIBS=
 if test "x$with_openssl" != "xno"; then
 	if test "x$with_openssl" != "xyes" -a "x$with_openssl" != "xcheck"; then
-		OPENSSL_CFLAGS="-I$with_openssl"
+		OPENSSL_CFLAGS="-I$with_openssl/include"
 		OPENSSL_LIBS="-L$with_openssl"
 	fi
 	old_cflags="$CFLAGS"

--- a/testcases/common/common.c
+++ b/testcases/common/common.c
@@ -876,6 +876,16 @@ int is_valid_cca_pubexp(CK_BYTE pubexp[], CK_ULONG pubexp_len)
         || (pubexp_len == 3 && (!memcmp(pubexp, exp65537, 3)));
 }
 
+/** Returns true if pubexp is valid for Soft Tokens **/
+int is_valid_soft_pubexp(CK_BYTE pubexp[], CK_ULONG pubexp_len)
+{
+    CK_BYTE exp3[] = { 0x03 };  // 3
+    CK_BYTE exp65537[] = { 0x01, 0x00, 0x01 };  // 65537
+
+    return (pubexp_len == 1 && (!memcmp(pubexp, exp3, 1)))
+        || (pubexp_len == 3 && (!memcmp(pubexp, exp65537, 3)));
+}
+
 /** Returns true if slot_id is an ICSF token
  ** ICSF token info is not necessarily hard-coded like the other tokens
  ** so there is no single identifying attribute. So, instead just

--- a/testcases/crypto/rsa_func.c
+++ b/testcases/crypto/rsa_func.c
@@ -102,8 +102,8 @@ CK_RV do_EncryptDecryptRSA(struct GENERATED_TEST_SUITE_INFO *tsuite)
 
         if (!keysize_supported(slot_id, tsuite->mech.mechanism,
                                tsuite->tv[i].modbits)) {
-            testcase_skip("Token in slot %ld cannot be used with "
-                          "modbits.='%ld'", SLOT_ID, tsuite->tv[i].modbits);
+            testcase_skip("Token in slot %ld cannot be used with modbits.='%ld'",
+                          SLOT_ID, tsuite->tv[i].modbits);
             free(s);
             continue;
         }
@@ -111,8 +111,7 @@ CK_RV do_EncryptDecryptRSA(struct GENERATED_TEST_SUITE_INFO *tsuite)
         if (is_ep11_token(slot_id)) {
             if (!is_valid_ep11_pubexp(tsuite->tv[i].publ_exp,
                                       tsuite->tv[i].publ_exp_len)) {
-                testcase_skip("EP11 Token cannot "
-                              "be used with publ_exp.='%s'", s);
+                testcase_skip("EP11 Token cannot be used with publ_exp.='%s'", s);
                 free(s);
                 continue;
             }
@@ -124,8 +123,7 @@ CK_RV do_EncryptDecryptRSA(struct GENERATED_TEST_SUITE_INFO *tsuite)
         if (is_cca_token(slot_id)) {
             if (!is_valid_cca_pubexp(tsuite->tv[i].publ_exp,
                                      tsuite->tv[i].publ_exp_len)) {
-                testcase_skip("CCA Token cannot "
-                              "be used with publ_exp.='%s'", s);
+                testcase_skip("CCA Token cannot be used with publ_exp.='%s'", s);
                 free(s);
                 continue;
             }
@@ -148,6 +146,16 @@ CK_RV do_EncryptDecryptRSA(struct GENERATED_TEST_SUITE_INFO *tsuite)
                  continue;
              }
         }
+
+        if (is_soft_token(slot_id)) {
+            if (!is_valid_soft_pubexp(tsuite->tv[i].publ_exp,
+                                      tsuite->tv[i].publ_exp_len)) {
+                testcase_skip("Soft Token cannot be used with publ_exp.='%s'",
+                              s);
+                free(s);
+                continue;
+            }
+        }
         // tpm special cases:
         // tpm token can only use public exponent 0x010001 (65537)
         // so skip test if invalid public exponent is used
@@ -155,8 +163,7 @@ CK_RV do_EncryptDecryptRSA(struct GENERATED_TEST_SUITE_INFO *tsuite)
             if ((!is_valid_tpm_pubexp(tsuite->tv[i].publ_exp,
                                       tsuite->tv[i].publ_exp_len))
                 || (!is_valid_tpm_modbits(tsuite->tv[i].modbits))) {
-                testcase_skip("TPM Token cannot " "be used with publ_exp.='%s'",
-                              s);
+                testcase_skip("TPM Token cannot be used with publ_exp.='%s'", s);
                 free(s);
                 continue;
             }
@@ -166,8 +173,7 @@ CK_RV do_EncryptDecryptRSA(struct GENERATED_TEST_SUITE_INFO *tsuite)
             if (!is_valid_icsf_pubexp(tsuite->tv[i].publ_exp,
                                       tsuite->tv[i].publ_exp_len) ||
                 (tsuite->tv[i].modbits < 1024)) {
-                testcase_skip("ICSF Token cannot be used with "
-                              "publ_exp='%s'.", s);
+                testcase_skip("ICSF Token cannot be used with publ_exp='%s'.", s);
                 free(s);
                 continue;
             }
@@ -376,8 +382,8 @@ CK_RV do_EncryptDecryptImportRSA(struct PUBLISHED_TEST_SUITE_INFO *tsuite)
 
         if (!keysize_supported(slot_id, tsuite->mech.mechanism,
                                tsuite->tv[i].mod_len * 8)) {
-            testcase_skip("Token in slot %ld cannot be used with "
-                          "modbits.='%ld'", SLOT_ID, tsuite->tv[i].mod_len * 8);
+            testcase_skip("Token in slot %ld cannot be used with modbits.='%ld'",
+                          SLOT_ID, tsuite->tv[i].mod_len * 8);
             free(s);
             continue;
         }
@@ -385,16 +391,14 @@ CK_RV do_EncryptDecryptImportRSA(struct PUBLISHED_TEST_SUITE_INFO *tsuite)
         if (is_ep11_token(slot_id)) {
             if (!is_valid_ep11_pubexp(tsuite->tv[i].pub_exp,
                                       tsuite->tv[i].pubexp_len)) {
-                testcase_skip("EP11 Token cannot "
-                              "be used with publ_exp.='%s'", s);
+                testcase_skip("EP11 Token cannot be used with publ_exp.='%s'", s);
                 free(s);
                 continue;
             }
             // modulus length must be multiple of 128 byte
             // skip test if modulus length has unsuported size
             if ((tsuite->tv[i].mod_len % 128) != 0) {
-                testcase_skip("EP11 Token cannot be used with "
-                              "this test vector.");
+                testcase_skip("EP11 Token cannot be used with this test vector.");
                 free(s);
                 continue;
             }
@@ -416,8 +420,7 @@ CK_RV do_EncryptDecryptImportRSA(struct PUBLISHED_TEST_SUITE_INFO *tsuite)
                 (tsuite->tv[i].exp2_len >
                  (tsuite->tv[i].mod_len / 2)) ||
                 (tsuite->tv[i].coef_len > (tsuite->tv[i].mod_len / 2))) {
-                testcase_skip("ICA Token cannot be used with "
-                              "this test vector.");
+                testcase_skip("ICA Token cannot be used with this test vector.");
                 free(s);
                 continue;
             }
@@ -431,12 +434,21 @@ CK_RV do_EncryptDecryptImportRSA(struct PUBLISHED_TEST_SUITE_INFO *tsuite)
         if (is_cca_token(slot_id)) {
             if (!is_valid_cca_pubexp(tsuite->tv[i].pub_exp,
                                      tsuite->tv[i].pubexp_len)) {
-                testcase_skip("CCA Token cannot "
-                              "be used with publ_exp.='%s'", s);
+                testcase_skip("CCA Token cannot be used with publ_exp.='%s'", s);
                 free(s);
                 continue;
             }
         }
+
+        if (is_soft_token(slot_id)) {
+            if (!is_valid_soft_pubexp(tsuite->tv[i].pub_exp,
+                                      tsuite->tv[i].pubexp_len)) {
+                testcase_skip("Soft Token cannot be used with publ_exp.='%s'", s);
+                free(s);
+                continue;
+            }
+        }
+
         // tpm special cases:
         // tpm token can only use public exponent 0x010001 (65537)
         // so skip test if invalid public exponent is used
@@ -444,8 +456,7 @@ CK_RV do_EncryptDecryptImportRSA(struct PUBLISHED_TEST_SUITE_INFO *tsuite)
             if ((!is_valid_tpm_pubexp(tsuite->tv[i].pub_exp,
                                       tsuite->tv[i].pubexp_len))
                 || (!is_valid_tpm_modbits(tsuite->tv[i].mod_len * 8))) {
-                testcase_skip("TPM Token cannot " "be used with publ_exp.='%s'",
-                              s);
+                testcase_skip("TPM Token cannot be used with publ_exp.='%s'", s);
                 free(s);
                 continue;
             }
@@ -455,8 +466,7 @@ CK_RV do_EncryptDecryptImportRSA(struct PUBLISHED_TEST_SUITE_INFO *tsuite)
             if (!is_valid_icsf_pubexp(tsuite->tv[i].pub_exp,
                                       tsuite->tv[i].pubexp_len) ||
                 (tsuite->tv[i].mod_len * 8 < 1024)) {
-                testcase_skip("ICSF Token cannot be used with "
-                              "publ_exp='%s'.", s);
+                testcase_skip("ICSF Token cannot be used with publ_exp='%s'.", s);
                 free(s);
                 continue;
             }
@@ -691,8 +701,8 @@ CK_RV do_SignVerifyRSA(struct GENERATED_TEST_SUITE_INFO * tsuite,
 
         if (!keysize_supported(slot_id, tsuite->mech.mechanism,
                                tsuite->tv[i].modbits)) {
-            testcase_skip("Token in slot %ld cannot be used with "
-                          "modbits.='%ld'", SLOT_ID, tsuite->tv[i].modbits);
+            testcase_skip("Token in slot %ld cannot be used with modbits.='%ld'",
+                          SLOT_ID, tsuite->tv[i].modbits);
             free(s);
             continue;
         }
@@ -700,8 +710,7 @@ CK_RV do_SignVerifyRSA(struct GENERATED_TEST_SUITE_INFO * tsuite,
         if (is_ep11_token(slot_id)) {
             if (!is_valid_ep11_pubexp(tsuite->tv[i].publ_exp,
                                       tsuite->tv[i].publ_exp_len)) {
-                testcase_skip("EP11 Token cannot "
-                              "be used with publ_exp.='%s'", s);
+                testcase_skip("EP11 Token cannot be used with publ_exp.='%s'", s);
                 free(s);
                 continue;
             }
@@ -710,8 +719,16 @@ CK_RV do_SignVerifyRSA(struct GENERATED_TEST_SUITE_INFO * tsuite,
         if (is_cca_token(slot_id)) {
             if (!is_valid_cca_pubexp(tsuite->tv[i].publ_exp,
                                      tsuite->tv[i].publ_exp_len)) {
-                testcase_skip("CCA Token cannot "
-                              "be used with publ_exp='%s'.", s);
+                testcase_skip("CCA Token cannot be used with publ_exp='%s'.", s);
+                free(s);
+                continue;
+            }
+        }
+
+        if (is_soft_token(slot_id)) {
+            if (!is_valid_soft_pubexp(tsuite->tv[i].publ_exp,
+                                      tsuite->tv[i].publ_exp_len)) {
+                testcase_skip("Soft Token cannot be used with publ_exp='%s'.", s);
                 free(s);
                 continue;
             }
@@ -721,8 +738,7 @@ CK_RV do_SignVerifyRSA(struct GENERATED_TEST_SUITE_INFO * tsuite,
             if ((!is_valid_tpm_pubexp(tsuite->tv[i].publ_exp,
                                       tsuite->tv[i].publ_exp_len))
                 || (!is_valid_tpm_modbits(tsuite->tv[i].modbits))) {
-                testcase_skip("TPM Token cannot " "be used with publ_exp='%s'.",
-                              s);
+                testcase_skip("TPM Token cannot be used with publ_exp='%s'.", s);
                 free(s);
                 continue;
             }
@@ -732,8 +748,7 @@ CK_RV do_SignVerifyRSA(struct GENERATED_TEST_SUITE_INFO * tsuite,
             if (!is_valid_icsf_pubexp(tsuite->tv[i].publ_exp,
                                       tsuite->tv[i].publ_exp_len) ||
                 (tsuite->tv[i].modbits < 1024)) {
-                testcase_skip("ICSF Token cannot be used with "
-                              "publ_exp='%s'.", s);
+                testcase_skip("ICSF Token cannot be used with publ_exp='%s'.", s);
                 free(s);
                 continue;
             }
@@ -944,16 +959,23 @@ CK_RV do_SignVerify_RSAPSS(struct GENERATED_TEST_SUITE_INFO * tsuite)
 
         if (!keysize_supported(slot_id, tsuite->mech.mechanism,
                                tsuite->tv[i].modbits)) {
-            testcase_skip("Token in slot %ld cannot be used with "
-                          "modbits.='%ld'", SLOT_ID, tsuite->tv[i].modbits);
+            testcase_skip("Token in slot %ld cannot be used with modbits.='%ld'",
+                          SLOT_ID, tsuite->tv[i].modbits);
             free(s);
             continue;
         }
         if (is_cca_token(slot_id)) {
             if (!is_valid_cca_pubexp(tsuite->tv[i].publ_exp,
                                      tsuite->tv[i].publ_exp_len)) {
-                testcase_skip("CCA Token cannot "
-                              "be used with publ_exp='%s'.", s);
+                testcase_skip("CCA Token cannot be used with publ_exp='%s'.", s);
+                free(s);
+                continue;
+            }
+        }
+        if (is_soft_token(slot_id)) {
+            if (!is_valid_soft_pubexp(tsuite->tv[i].publ_exp,
+                                      tsuite->tv[i].publ_exp_len)) {
+                testcase_skip("Soft Token cannot be used with publ_exp='%s'.", s);
                 free(s);
                 continue;
             }
@@ -1154,8 +1176,8 @@ CK_RV do_WrapUnwrapRSA(struct GENERATED_TEST_SUITE_INFO * tsuite)
 
         if (!keysize_supported(slot_id, tsuite->mech.mechanism,
                                tsuite->tv[i].modbits)) {
-            testcase_skip("Token in slot %ld cannot be used with "
-                          "modbits.='%ld'", SLOT_ID, tsuite->tv[i].modbits);
+            testcase_skip("Token in slot %ld cannot be used with modbits.='%ld'",
+                          SLOT_ID, tsuite->tv[i].modbits);
             continue;
         }
         // get public exponent from test vector
@@ -1169,8 +1191,7 @@ CK_RV do_WrapUnwrapRSA(struct GENERATED_TEST_SUITE_INFO * tsuite)
         if (is_ep11_token(slot_id)) {
             if (!is_valid_ep11_pubexp(tsuite->tv[i].publ_exp,
                                       tsuite->tv[i].publ_exp_len)) {
-                testcase_skip("EP11 Token cannot "
-                              "be used with publ_exp.='%s'", s);
+                testcase_skip("EP11 Token cannot be used with publ_exp.='%s'", s);
                 free(s);
                 continue;
             }
@@ -1179,8 +1200,7 @@ CK_RV do_WrapUnwrapRSA(struct GENERATED_TEST_SUITE_INFO * tsuite)
             if (!is_valid_icsf_pubexp(tsuite->tv[i].publ_exp,
                                       tsuite->tv[i].publ_exp_len) ||
                 (tsuite->tv[i].modbits < 1024)) {
-                testcase_skip("ICSF Token cannot be used with "
-                              "publ_exp='%s'.", s);
+                testcase_skip("ICSF Token cannot be used with publ_exp='%s'.", s);
                 free(s);
                 continue;
             }
@@ -1189,8 +1209,7 @@ CK_RV do_WrapUnwrapRSA(struct GENERATED_TEST_SUITE_INFO * tsuite)
             if ((!is_valid_tpm_pubexp(tsuite->tv[i].publ_exp,
                                       tsuite->tv[i].publ_exp_len)) ||
                 (!is_valid_tpm_modbits(tsuite->tv[i].modbits))) {
-                testcase_skip("TPM Token cannot " "be used with publ_exp.='%s'",
-                              s);
+                testcase_skip("TPM Token cannot be used with publ_exp.='%s'", s);
                 free(s);
                 continue;
            }
@@ -1198,8 +1217,7 @@ CK_RV do_WrapUnwrapRSA(struct GENERATED_TEST_SUITE_INFO * tsuite)
         if (is_cca_token(slot_id)) {
             if (!is_valid_cca_pubexp(tsuite->tv[i].publ_exp,
                                      tsuite->tv[i].publ_exp_len)) {
-                testcase_skip("CCA Token cannot "
-                              "be used with publ_exp='%s'.", s);
+                testcase_skip("CCA Token cannot be used with publ_exp='%s'.", s);
                 free(s);
                 continue;
             }
@@ -1227,6 +1245,14 @@ CK_RV do_WrapUnwrapRSA(struct GENERATED_TEST_SUITE_INFO * tsuite)
                  free(s);
                  continue;
              }
+        }
+        if (is_soft_token(slot_id)) {
+            if (!is_valid_soft_pubexp(tsuite->tv[i].publ_exp,
+                                      tsuite->tv[i].publ_exp_len)) {
+                testcase_skip("Soft Token cannot be used with publ_exp='%s'.", s);
+                free(s);
+                continue;
+            }
         }
 
         // begin test
@@ -1554,8 +1580,7 @@ CK_RV do_SignRSA(struct PUBLISHED_TEST_SUITE_INFO * tsuite)
                 (tsuite->tv[i].exp2_len >
                  (tsuite->tv[i].mod_len / 2)) ||
                 (tsuite->tv[i].coef_len > (tsuite->tv[i].mod_len / 2))) {
-                testcase_skip("ICA Token cannot be used with "
-                              "this test vector.");
+                testcase_skip("ICA Token cannot be used with this test vector.");
                 continue;
             }
 
@@ -1565,8 +1590,7 @@ CK_RV do_SignRSA(struct PUBLISHED_TEST_SUITE_INFO * tsuite)
         // skip test if modulus length has unsuported size
         if (is_ep11_token(slot_id)) {
             if ((tsuite->tv[i].mod_len % 128) != 0) {
-                testcase_skip("EP11 Token cannot be used with "
-                              "this test vector.");
+                testcase_skip("EP11 Token cannot be used with this test vector.");
                 continue;
             }
         }
@@ -1575,8 +1599,7 @@ CK_RV do_SignRSA(struct PUBLISHED_TEST_SUITE_INFO * tsuite)
             if ((!is_valid_tpm_pubexp(tsuite->tv[i].pub_exp,
                                       tsuite->tv[i].pubexp_len))
                 || (!is_valid_tpm_modbits(tsuite->tv[i].mod_len))) {
-                testcase_skip("TPM Token cannot "
-                              "be used with this test vector.");
+                testcase_skip("TPM Token cannot be used with this test vector.");
                 continue;
             }
         }
@@ -1584,8 +1607,15 @@ CK_RV do_SignRSA(struct PUBLISHED_TEST_SUITE_INFO * tsuite)
         if (is_cca_token(slot_id)) {
             if (!is_valid_cca_pubexp(tsuite->tv[i].pub_exp,
                                      tsuite->tv[i].pubexp_len)) {
-                testcase_skip("CCA Token cannot "
-                              "be used with this test vector.");
+                testcase_skip("CCA Token cannot be used with this test vector.");
+                continue;
+            }
+        }
+
+        if (is_soft_token(slot_id)) {
+            if (!is_valid_soft_pubexp(tsuite->tv[i].pub_exp,
+                                      tsuite->tv[i].pubexp_len)) {
+                testcase_skip("Soft Token cannot be used with this test vector.");
                 continue;
             }
         }
@@ -1735,8 +1765,7 @@ CK_RV do_VerifyRSA(struct PUBLISHED_TEST_SUITE_INFO * tsuite)
         // skip test if modulus length has unsuported size
         if (is_ep11_token(slot_id)) {
             if ((tsuite->tv[i].mod_len % 128) != 0) {
-                testcase_skip("EP11 Token cannot be used with "
-                              "this test vector.");
+                testcase_skip("EP11 Token cannot be used with this test vector.");
                 continue;
             }
         }
@@ -1745,8 +1774,7 @@ CK_RV do_VerifyRSA(struct PUBLISHED_TEST_SUITE_INFO * tsuite)
             if ((!is_valid_tpm_pubexp(tsuite->tv[i].pub_exp,
                                       tsuite->tv[i].pubexp_len))
                 || (!is_valid_tpm_modbits(tsuite->tv[i].mod_len))) {
-                testcase_skip("TPM Token cannot "
-                              "be used with this test vector.");
+                testcase_skip("TPM Token cannot be used with this test vector.");
                 continue;
             }
         }
@@ -1754,8 +1782,15 @@ CK_RV do_VerifyRSA(struct PUBLISHED_TEST_SUITE_INFO * tsuite)
         if (is_cca_token(slot_id)) {
             if (!is_valid_cca_pubexp(tsuite->tv[i].pub_exp,
                                      tsuite->tv[i].pubexp_len)) {
-                testcase_skip("CCA Token cannot "
-                              "be used with this test vector.");
+                testcase_skip("CCA Token cannot be used with this test vector.");
+                continue;
+            }
+        }
+
+        if (is_soft_token(slot_id)) {
+            if (!is_valid_soft_pubexp(tsuite->tv[i].pub_exp,
+                                      tsuite->tv[i].pubexp_len)) {
+                testcase_skip("Soft Token cannot be used with this test vector.");
                 continue;
             }
         }

--- a/testcases/crypto/rsaupdate_func.c
+++ b/testcases/crypto/rsaupdate_func.c
@@ -96,8 +96,8 @@ CK_RV do_SignVerifyUpdateRSA(struct GENERATED_TEST_SUITE_INFO *tsuite)
 
         if (!keysize_supported(slot_id, tsuite->mech.mechanism,
                                tsuite->tv[i].modbits)) {
-            testcase_skip("Token in slot %ld cannot be used with "
-                          "modbits.='%ld'", SLOT_ID, tsuite->tv[i].modbits);
+            testcase_skip("Token in slot %ld cannot be used with modbits.='%ld'",
+                          SLOT_ID, tsuite->tv[i].modbits);
             free(s);
             continue;
         }
@@ -105,8 +105,7 @@ CK_RV do_SignVerifyUpdateRSA(struct GENERATED_TEST_SUITE_INFO *tsuite)
         if (is_ep11_token(slot_id)) {
             if (!is_valid_ep11_pubexp(tsuite->tv[i].publ_exp,
                                       tsuite->tv[i].publ_exp_len)) {
-                testcase_skip("EP11 Token cannot "
-                              "be used with publ_exp.='%s'", s);
+                testcase_skip("EP11 Token cannot be used with publ_exp.='%s'", s);
                 free(s);
                 continue;
             }
@@ -115,19 +114,27 @@ CK_RV do_SignVerifyUpdateRSA(struct GENERATED_TEST_SUITE_INFO *tsuite)
         if (is_cca_token(slot_id)) {
             if (!is_valid_cca_pubexp(tsuite->tv[i].publ_exp,
                                      tsuite->tv[i].publ_exp_len)) {
-                testcase_skip("CCA Token cannot "
-                              "be used with publ_exp='%s'.", s);
+                testcase_skip("CCA Token cannot be used with publ_exp='%s'.", s);
                 free(s);
                 continue;
             }
         }
 
+        if (is_soft_token(slot_id)) {
+            if (!is_valid_soft_pubexp(tsuite->tv[i].publ_exp,
+                                      tsuite->tv[i].publ_exp_len)) {
+                testcase_skip("Soft Token cannot be used with publ_exp='%s'.", s);
+                free(s);
+                continue;
+            }
+        }
+
+
         if (is_tpm_token(slot_id)) {
             if ((!is_valid_tpm_pubexp(tsuite->tv[i].publ_exp,
                                       tsuite->tv[i].publ_exp_len))
                 || (!is_valid_tpm_modbits(tsuite->tv[i].modbits))) {
-                testcase_skip("TPM Token cannot " "be used with publ_exp='%s'.",
-                              s);
+                testcase_skip("TPM Token cannot be used with publ_exp='%s'.", s);
                 free(s);
                 continue;
             }
@@ -137,8 +144,7 @@ CK_RV do_SignVerifyUpdateRSA(struct GENERATED_TEST_SUITE_INFO *tsuite)
             if (!is_valid_icsf_pubexp(tsuite->tv[i].publ_exp,
                                       tsuite->tv[i].publ_exp_len) ||
                 (tsuite->tv[i].modbits < 1024)) {
-                testcase_skip("ICSF Token cannot "
-                              "be used with publ_exp='%s'.", s);
+                testcase_skip("ICSF Token cannot be used with publ_exp='%s'.", s);
                 free(s);
                 continue;
             }
@@ -162,8 +168,7 @@ CK_RV do_SignVerifyUpdateRSA(struct GENERATED_TEST_SUITE_INFO *tsuite)
                                        tsuite->tv[i].publ_exp_len,
                                        &publ_key, &priv_key);
         if (rc != CKR_OK) {
-            testcase_error("generate_RSA_PKCS_KeyPair(), "
-                           "rc=%s", p11_get_ckr(rc));
+            testcase_error("generate_RSA_PKCS_KeyPair(), rc=%s", p11_get_ckr(rc));
             goto testcase_cleanup;
         }
 
@@ -367,8 +372,8 @@ CK_RV do_SignVerifyUpdate_RSAPSS(struct GENERATED_TEST_SUITE_INFO * tsuite)
 
         if (!keysize_supported(slot_id, tsuite->mech.mechanism,
                                tsuite->tv[i].modbits)) {
-            testcase_skip("Token in slot %ld cannot be used with "
-                          "modbits.='%ld'", SLOT_ID, tsuite->tv[i].modbits);
+            testcase_skip("Token in slot %ld cannot be used with modbits.='%ld'",
+                          SLOT_ID, tsuite->tv[i].modbits);
             free(s);
             continue;
         }
@@ -376,8 +381,7 @@ CK_RV do_SignVerifyUpdate_RSAPSS(struct GENERATED_TEST_SUITE_INFO * tsuite)
         if (is_ep11_token(slot_id)) {
             if (!is_valid_ep11_pubexp(tsuite->tv[i].publ_exp,
                                       tsuite->tv[i].publ_exp_len)) {
-                testcase_skip("EP11 Token cannot "
-                              "be used with publ_exp.='%s'", s);
+                testcase_skip("EP11 Token cannot be used with publ_exp.='%s'", s);
                 free(s);
                 continue;
             }
@@ -386,8 +390,16 @@ CK_RV do_SignVerifyUpdate_RSAPSS(struct GENERATED_TEST_SUITE_INFO * tsuite)
         if (is_cca_token(slot_id)) {
             if (!is_valid_cca_pubexp(tsuite->tv[i].publ_exp,
                                      tsuite->tv[i].publ_exp_len)) {
-                testcase_skip("CCA Token cannot "
-                              "be used with publ_exp='%s'.", s);
+                testcase_skip("CCA Token cannot be used with publ_exp='%s'.", s);
+                free(s);
+                continue;
+            }
+        }
+
+        if (is_soft_token(slot_id)) {
+            if (!is_valid_soft_pubexp(tsuite->tv[i].publ_exp,
+                                      tsuite->tv[i].publ_exp_len)) {
+                testcase_skip("Soft Token cannot be used with publ_exp='%s'.", s);
                 free(s);
                 continue;
             }
@@ -412,8 +424,7 @@ CK_RV do_SignVerifyUpdate_RSAPSS(struct GENERATED_TEST_SUITE_INFO * tsuite)
                                        tsuite->tv[i].publ_exp_len,
                                        &publ_key, &priv_key);
         if (rc != CKR_OK) {
-            testcase_error("generate_RSA_PKCS_KeyPair(), "
-                           "rc=%s", p11_get_ckr(rc));
+            testcase_error("generate_RSA_PKCS_KeyPair(), rc=%s", p11_get_ckr(rc));
             goto error;
         }
         // generate message
@@ -639,8 +650,7 @@ CK_RV do_VerifyUpdateRSA(struct PUBLISHED_TEST_SUITE_INFO * tsuite)
         if (is_ep11_token(slot_id)) {
             if (!is_valid_ep11_pubexp(tsuite->tv[i].pub_exp,
                                       tsuite->tv[i].pubexp_len)) {
-                testcase_skip("EP11 Token cannot "
-                              "be used with pub_exp.='%s'", s);
+                testcase_skip("EP11 Token cannot be used with pub_exp.='%s'", s);
                 free(s);
                 continue;
             }
@@ -650,8 +660,7 @@ CK_RV do_VerifyUpdateRSA(struct PUBLISHED_TEST_SUITE_INFO * tsuite)
             if ((!is_valid_tpm_pubexp(tsuite->tv[i].pub_exp,
                                       tsuite->tv[i].pubexp_len)) ||
                 (!is_valid_tpm_modbits(tsuite->tv[i].mod_len))) {
-                testcase_skip("TPM Token cannot "
-                              "be used with pub_exp='%s'.", s);
+                testcase_skip("TPM Token cannot be used with pub_exp='%s'.", s);
                 free(s);
                 continue;
             }
@@ -660,8 +669,16 @@ CK_RV do_VerifyUpdateRSA(struct PUBLISHED_TEST_SUITE_INFO * tsuite)
         if (is_cca_token(slot_id)) {
             if (!is_valid_cca_pubexp(tsuite->tv[i].pub_exp,
                                      tsuite->tv[i].pubexp_len)) {
-                testcase_skip("CCA Token cannot "
-                              "be used with publ_exp='%s'.", s);
+                testcase_skip("CCA Token cannot be used with publ_exp='%s'.", s);
+                free(s);
+                continue;
+            }
+        }
+
+        if (is_soft_token(slot_id)) {
+            if (!is_valid_soft_pubexp(tsuite->tv[i].pub_exp,
+                                      tsuite->tv[i].pubexp_len)) {
+                testcase_skip("Soft Token cannot be used with publ_exp='%s'.", s);
                 free(s);
                 continue;
             }
@@ -826,8 +843,7 @@ CK_RV do_SignUpdateRSA(struct PUBLISHED_TEST_SUITE_INFO * tsuite)
                 (tsuite->tv[i].exp2_len >
                  (tsuite->tv[i].mod_len / 2)) ||
                 (tsuite->tv[i].coef_len > (tsuite->tv[i].mod_len / 2))) {
-                testcase_skip("ICA Token cannot be used with "
-                              "this test vector.");
+                testcase_skip("ICA Token cannot be used with this test vector.");
                 free(s);
                 continue;
             }
@@ -848,8 +864,7 @@ CK_RV do_SignUpdateRSA(struct PUBLISHED_TEST_SUITE_INFO * tsuite)
         if (is_ep11_token(slot_id)) {
             if (!is_valid_ep11_pubexp(tsuite->tv[i].pub_exp,
                                       tsuite->tv[i].pubexp_len)) {
-                testcase_skip("EP11 Token cannot "
-                              "be used with publ_exp.='%s'", s);
+                testcase_skip("EP11 Token cannot be used with publ_exp.='%s'", s);
                 free(s);
                 continue;
             }
@@ -859,8 +874,7 @@ CK_RV do_SignUpdateRSA(struct PUBLISHED_TEST_SUITE_INFO * tsuite)
             if ((!is_valid_tpm_pubexp(tsuite->tv[i].pub_exp,
                                       tsuite->tv[i].pubexp_len)) ||
                 (!is_valid_tpm_modbits(tsuite->tv[i].mod_len))) {
-                testcase_skip("TPM Token cannot "
-                              "be used with pub_exp='%s'.", s);
+                testcase_skip("TPM Token cannot be used with pub_exp='%s'.", s);
                 free(s);
                 continue;
             }
@@ -869,8 +883,16 @@ CK_RV do_SignUpdateRSA(struct PUBLISHED_TEST_SUITE_INFO * tsuite)
         if (is_cca_token(slot_id)) {
             if (!is_valid_cca_pubexp(tsuite->tv[i].pub_exp,
                                      tsuite->tv[i].pubexp_len)) {
-                testcase_skip("CCA Token cannot "
-                              "be used with publ_exp='%s'.", s);
+                testcase_skip("CCA Token cannot be used with publ_exp='%s'.", s);
+                free(s);
+                continue;
+            }
+        }
+
+        if (is_soft_token(slot_id)) {
+            if (!is_valid_soft_pubexp(tsuite->tv[i].pub_exp,
+                                      tsuite->tv[i].pubexp_len)) {
+                testcase_skip("Soft Token cannot be used with publ_exp='%s'.", s);
                 free(s);
                 continue;
             }

--- a/testcases/misc_tests/reencrypt.c
+++ b/testcases/misc_tests/reencrypt.c
@@ -361,24 +361,29 @@ CK_RV do_reencrypt(struct mech_info *mech1, struct mech_info *mech2)
 
         if (!keysize_supported(slot_id, mech2->key_gen_mech.mechanism,
                                mech2->rsa_modbits)) {
-            testcase_skip("Token in slot %ld cannot be used with "
-                          "modbits.='%ld'", slot_id, mech2->rsa_modbits);
+            testcase_skip("Token in slot %ld cannot be used with modbits.='%ld'",
+                          slot_id, mech2->rsa_modbits);
             goto testcase_cleanup;
         }
 
         if (is_ep11_token(slot_id)) {
             if (!is_valid_ep11_pubexp(mech2->rsa_publ_exp,
                                       mech2->rsa_publ_exp_len)) {
-                testcase_skip("EP11 Token in cannot be used with "
-                             "publ_exp.='%s'", s);
+                testcase_skip("EP11 Token in cannot be used with publ_exp.='%s'", s);
                 goto testcase_cleanup;
             }
         }
         if (is_cca_token(slot_id)) {
             if (!is_valid_cca_pubexp(mech2->rsa_publ_exp,
                                      mech2->rsa_publ_exp_len)) {
-                testcase_skip("CCA Token in cannot be used with "
-                        "     publ_exp.='%s'", s);
+                testcase_skip("CCA Token in cannot be used with publ_exp.='%s'", s);
+                goto testcase_cleanup;
+            }
+        }
+        if (is_soft_token(slot_id)) {
+            if (!is_valid_soft_pubexp(mech2->rsa_publ_exp,
+                                      mech2->rsa_publ_exp_len)) {
+                testcase_skip("Soft Token in cannot be used with publ_exp.='%s'", s);
                 goto testcase_cleanup;
             }
         }
@@ -386,8 +391,7 @@ CK_RV do_reencrypt(struct mech_info *mech1, struct mech_info *mech2)
             if (!is_valid_tpm_pubexp(mech2->rsa_publ_exp,
                                      mech2->rsa_publ_exp_len) ||
                 !is_valid_tpm_modbits(mech2->rsa_modbits)) {
-                testcase_skip("TPM Token cannot be used with "
-                              "publ_exp.='%s'", s);
+                testcase_skip("TPM Token cannot be used with publ_exp.='%s'", s);
                 goto testcase_cleanup;
             }
         }
@@ -395,8 +399,7 @@ CK_RV do_reencrypt(struct mech_info *mech1, struct mech_info *mech2)
             if (!is_valid_icsf_pubexp(mech2->rsa_publ_exp,
                                       mech2->rsa_publ_exp_len) ||
                 mech2->rsa_modbits < 1024) {
-                testcase_skip("ICSF Token cannot be used with "
-                              "publ_exp='%s'.", s);
+                testcase_skip("ICSF Token cannot be used with publ_exp='%s'.", s);
                 goto testcase_cleanup;
             }
         }
@@ -615,6 +618,14 @@ CK_RV do_encrypt_reencrypt(struct mech_info *mech1)
             if (!is_valid_cca_pubexp(mech1->rsa_publ_exp,
                                      mech1->rsa_publ_exp_len)) {
                 testsuite_skip(NUM_REENCRYPT_TESTS, "CCA Token cannot be "
+                               "used with publ_exp.='%s'", s);
+                goto testcase_cleanup;
+            }
+        }
+        if (is_soft_token(slot_id)) {
+            if (!is_valid_soft_pubexp(mech1->rsa_publ_exp,
+                                      mech1->rsa_publ_exp_len)) {
+                testsuite_skip(NUM_REENCRYPT_TESTS, "Soft Token cannot be "
                                "used with publ_exp.='%s'", s);
                 goto testcase_cleanup;
             }

--- a/testcases/misc_tests/tok2tok_transport.c
+++ b/testcases/misc_tests/tok2tok_transport.c
@@ -581,30 +581,35 @@ CK_RV do_wrap_key_test(struct wrapped_mech_info *tsuite,
 
         if (!keysize_supported(slot_id1, tsuite->wrapped_key_gen_mech.mechanism,
                                tsuite->rsa_modbits)) {
-            testcase_skip("Token in slot %lu cannot be used with "
-                          "modbits.='%ld'", slot_id1, tsuite->rsa_modbits);
+            testcase_skip("Token in slot %lu cannot be used with modbits.='%ld'",
+                          slot_id1, tsuite->rsa_modbits);
             goto testcase_cleanup;
         }
         if (!keysize_supported(slot_id2, tsuite->wrapped_key_gen_mech.mechanism,
                                tsuite->rsa_modbits)) {
-            testcase_skip("Token in slot %lu cannot be used with "
-                          "modbits.='%ld'", slot_id2, tsuite->rsa_modbits);
+            testcase_skip("Token in slot %lu cannot be used with modbits.='%ld'",
+                          slot_id2, tsuite->rsa_modbits);
             goto testcase_cleanup;
         }
 
         if (is_ep11_token(slot_id1) || is_ep11_token(slot_id2)) {
             if (!is_valid_ep11_pubexp(tsuite->rsa_publ_exp,
                                       tsuite->rsa_publ_exp_len)) {
-                testcase_skip("EP11 Token in cannot be used with "
-                             "publ_exp.='%s'", s);
+                testcase_skip("EP11 Token in cannot be used with publ_exp.='%s'", s);
                 goto testcase_cleanup;
             }
         }
         if (is_cca_token(slot_id1) || is_cca_token(slot_id2)) {
             if (!is_valid_cca_pubexp(tsuite->rsa_publ_exp,
                                      tsuite->rsa_publ_exp_len)) {
-                testcase_skip("CCA Token in scannot be used with "
-                              "publ_exp.='%s'", s);
+                testcase_skip("CCA Token in scannot be used with publ_exp.='%s'", s);
+                goto testcase_cleanup;
+            }
+        }
+        if (is_soft_token(slot_id1) || is_cca_token(slot_id2)) {
+            if (!is_valid_soft_pubexp(tsuite->rsa_publ_exp,
+                                      tsuite->rsa_publ_exp_len)) {
+                testcase_skip("Soft Token in scannot be used with publ_exp.='%s'", s);
                 goto testcase_cleanup;
             }
         }
@@ -612,8 +617,7 @@ CK_RV do_wrap_key_test(struct wrapped_mech_info *tsuite,
             if (!is_valid_tpm_pubexp(tsuite->rsa_publ_exp,
                                      tsuite->rsa_publ_exp_len) ||
                 !is_valid_tpm_modbits(tsuite->rsa_modbits)) {
-                testcase_skip("TPM Token cannot " "be used with "
-                              "publ_exp.='%s'", s);
+                testcase_skip("TPM Token cannot " "be used with publ_exp.='%s'", s);
                 goto testcase_cleanup;
             }
         }
@@ -621,8 +625,7 @@ CK_RV do_wrap_key_test(struct wrapped_mech_info *tsuite,
             if (!is_valid_icsf_pubexp(tsuite->rsa_publ_exp,
                                       tsuite->rsa_publ_exp_len) ||
                 tsuite->rsa_modbits < 1024) {
-                testcase_skip("ICSF Token cannot be used with "
-                              "publ_exp='%s'.", s);
+                testcase_skip("ICSF Token cannot be used with publ_exp='%s'.", s);
                 goto testcase_cleanup;
             }
         }
@@ -967,31 +970,36 @@ CK_RV do_wrapping_test(struct wrapping_mech_info *tsuite)
         if (!keysize_supported(slot_id1,
                                tsuite->wrapping_key_gen_mech.mechanism,
                                tsuite->rsa_modbits)) {
-            testcase_skip("Token in slot %ld cannot be used with "
-                          "modbits.='%ld'", slot_id1, tsuite->rsa_modbits);
+            testcase_skip("Token in slot %ld cannot be used with modbits.='%ld'",
+                          slot_id1, tsuite->rsa_modbits);
             goto testcase_cleanup;
         }
         if (!keysize_supported(slot_id2,
                                tsuite->wrapping_key_gen_mech.mechanism,
                                tsuite->rsa_modbits)) {
-            testcase_skip("Token in slot %ld cannot be used with "
-                          "modbits.='%ld'", slot_id2, tsuite->rsa_modbits);
+            testcase_skip("Token in slot %ld cannot be used with modbits.='%ld'",
+                          slot_id2, tsuite->rsa_modbits);
             goto testcase_cleanup;
         }
 
         if (is_ep11_token(slot_id1) || is_ep11_token(slot_id2)) {
             if (!is_valid_ep11_pubexp(tsuite->rsa_publ_exp,
                                       tsuite->rsa_publ_exp_len)) {
-                testcase_skip("EP11 Token in cannot be used with "
-                             "publ_exp.='%s'", s);
+                testcase_skip("EP11 Token in cannot be used with publ_exp.='%s'", s);
                 goto testcase_cleanup;
             }
         }
         if (is_cca_token(slot_id1) || is_cca_token(slot_id2)) {
             if (!is_valid_cca_pubexp(tsuite->rsa_publ_exp,
                                      tsuite->rsa_publ_exp_len)) {
-                testcase_skip("CCA Token in scannot be used with "
-                              "publ_exp.='%s'", s);
+                testcase_skip("CCA Token in scannot be used with publ_exp.='%s'", s);
+                goto testcase_cleanup;
+            }
+        }
+        if (is_soft_token(slot_id1) || is_soft_token(slot_id2)) {
+            if (!is_valid_soft_pubexp(tsuite->rsa_publ_exp,
+                                      tsuite->rsa_publ_exp_len)) {
+                testcase_skip("Soft Token in scannot be used with publ_exp.='%s'", s);
                 goto testcase_cleanup;
             }
         }
@@ -999,8 +1007,7 @@ CK_RV do_wrapping_test(struct wrapping_mech_info *tsuite)
             if (!is_valid_tpm_pubexp(tsuite->rsa_publ_exp,
                                      tsuite->rsa_publ_exp_len) ||
                 !is_valid_tpm_modbits(tsuite->rsa_modbits)) {
-                testcase_skip("TPM Token cannot " "be used with "
-                              "publ_exp.='%s'", s);
+                testcase_skip("TPM Token cannot " "be used with publ_exp.='%s'", s);
                 goto testcase_cleanup;
             }
         }
@@ -1008,8 +1015,7 @@ CK_RV do_wrapping_test(struct wrapping_mech_info *tsuite)
             if (!is_valid_icsf_pubexp(tsuite->rsa_publ_exp,
                                       tsuite->rsa_publ_exp_len) ||
                 tsuite->rsa_modbits < 1024) {
-                testcase_skip("ICSF Token cannot be used with "
-                              "publ_exp='%s'.", s);
+                testcase_skip("ICSF Token cannot be used with publ_exp='%s'.", s);
                 goto testcase_cleanup;
             }
         }

--- a/testcases/pkcs11/sess_opstate.c
+++ b/testcases/pkcs11/sess_opstate.c
@@ -123,6 +123,10 @@ int sess_opstate_funcs(int loops)
         opstatelen = 0;
         rc = funcs->C_GetOperationState(s2, NULL, &opstatelen);
         if (rc != CKR_OK) {
+            if (rc == CKR_STATE_UNSAVEABLE) {
+                testcase_skip("Get/SetOperationState digest test: state unsavable");
+                goto out;
+            }
             testcase_error("C_GetOperationState rc=%s", p11_get_ckr(rc));
             goto out;
         }
@@ -135,6 +139,10 @@ int sess_opstate_funcs(int loops)
 
         rc = funcs->C_GetOperationState(s2, opstate, &opstatelen);
         if (rc != CKR_OK) {
+            if (rc == CKR_STATE_UNSAVEABLE) {
+                testcase_skip("Get/SetOperationState digest test: state unsavable");
+                goto out;
+            }
             testcase_error("C_GetOperationState rc=%s", p11_get_ckr(rc));
             goto out;
         }

--- a/usr/include/apictl.h
+++ b/usr/include/apictl.h
@@ -13,11 +13,15 @@
 #include <local_types.h>
 #include <stdll.h>
 #include <slotmgr.h>
-
-#include "local_types.h"
+#include <defs.h>
 
 #ifndef _APILOCAL_H
 #define _APILOCAL_H
+
+#if OPENSSL_VERSION_PREREQ(3, 0)
+    #include <openssl/crypto.h>
+    #include <openssl/provider.h>
+#endif
 
 // SAB Add a linked list of STDLL's loaded to
 // only load and get list once, but let multiple slots us it.
@@ -59,6 +63,10 @@ typedef struct {
                                             // per slot
     int socketfd;
     pthread_t event_thread;
+#if OPENSSL_VERSION_PREREQ(3, 0)
+    OSSL_LIB_CTX *openssl_libctx;
+    OSSL_PROVIDER *openssl_default_provider;
+#endif
 } API_Proc_Struct_t;
 
 #endif

--- a/usr/lib/api/api.mk
+++ b/usr/lib/api/api.mk
@@ -12,7 +12,7 @@ opencryptoki_libopencryptoki_la_CFLAGS =				\
 	-DSTDLL_NAME=\"api\"
 
 opencryptoki_libopencryptoki_la_LDFLAGS =				\
-	-shared	-Wl,-z,defs,-Bsymbolic -lc -ldl -lpthread		\
+	-shared	-Wl,-z,defs,-Bsymbolic -lc -ldl -lpthread -lcrypto	\
 	-version-info $(SO_CURRENT):$(SO_REVISION):$(SO_AGE)		\
 	-Wl,--version-script=${srcdir}/opencryptoki.map
 

--- a/usr/lib/common/defs.h
+++ b/usr/lib/common/defs.h
@@ -17,6 +17,20 @@
 #ifndef _DEFS_H
 #define _DEFS_H
 
+#include <openssl/opensslv.h>
+
+#ifndef OPENSSL_VERSION_PREREQ
+    #if defined(OPENSSL_VERSION_MAJOR) && defined(OPENSSL_VERSION_MINOR)
+        #define OPENSSL_VERSION_PREREQ(maj, min)        \
+            ((OPENSSL_VERSION_MAJOR << 16) +        \
+            OPENSSL_VERSION_MINOR >= ((maj) << 16) + (min))
+    #else
+        #define OPENSSL_VERSION_PREREQ(maj, min)        \
+            (OPENSSL_VERSION_NUMBER >= (((maj) << 28) | \
+            ((min) << 20)))
+    #endif
+#endif
+
 #define MAX_SESSION_COUNT     64
 #define MAX_PIN_LEN           8
 #define MIN_PIN_LEN           4

--- a/usr/lib/common/ec_defs.h
+++ b/usr/lib/common/ec_defs.h
@@ -14,13 +14,6 @@
 #include <openssl/opensslv.h>
 #include "ec_curves.h"
 
-/* OpenSSL compat */
-#if OPENSSL_VERSION_NUMBER < 0x10101000L
-# define EC_POINT_get_affine_coordinates EC_POINT_get_affine_coordinates_GFp
-# define EC_POINT_set_compressed_coordinates \
-                                     EC_POINT_set_compressed_coordinates_GFp
-#endif
-
 // Elliptic Curve type
 //
 #define PRIME_CURVE         0x00

--- a/usr/lib/common/h_extern.h
+++ b/usr/lib/common/h_extern.h
@@ -1667,7 +1667,7 @@ CK_RV md5_hmac_verify(STDLL_TokData_t *tokdata,
                       CK_ULONG in_data_len,
                       CK_BYTE *signature, CK_ULONG sig_len);
 
-void sw_md5_init(DIGEST_CONTEXT *ctx);
+CK_RV sw_md5_init(DIGEST_CONTEXT *ctx);
 
 CK_RV sw_md5_hash(DIGEST_CONTEXT *ctx, CK_BYTE *in_data,
                   CK_ULONG in_data_len, CK_BYTE *out_data,

--- a/usr/lib/common/h_extern.h
+++ b/usr/lib/common/h_extern.h
@@ -1543,7 +1543,7 @@ CK_RV aes_cfb_decrypt_final(STDLL_TokData_t *tokdata, SESSION *sess,
 // SHA mechanisms
 //
 
-void sw_sha1_init(DIGEST_CONTEXT *ctx);
+CK_RV sw_sha1_init(DIGEST_CONTEXT *ctx);
 
 CK_RV sw_sha1_hash(DIGEST_CONTEXT *ctx, CK_BYTE *in_data,
                    CK_ULONG in_data_len, CK_BYTE *out_data,

--- a/usr/lib/common/h_extern.h
+++ b/usr/lib/common/h_extern.h
@@ -1790,7 +1790,8 @@ CK_RV encr_mgr_init(STDLL_TokData_t *tokdata,
                     CK_ULONG operation,
                     CK_MECHANISM *mech, CK_OBJECT_HANDLE key_handle);
 
-CK_RV encr_mgr_cleanup(ENCR_DECR_CONTEXT *ctx);
+CK_RV encr_mgr_cleanup(STDLL_TokData_t *tokdata, SESSION *sess,
+                       ENCR_DECR_CONTEXT *ctx);
 
 CK_RV encr_mgr_encrypt(STDLL_TokData_t *tokdata,
                        SESSION *sess, CK_BBOOL length_only,
@@ -1825,7 +1826,8 @@ CK_RV decr_mgr_init(STDLL_TokData_t *tokdata,
                     CK_ULONG operation,
                     CK_MECHANISM *mech, CK_OBJECT_HANDLE key_handle);
 
-CK_RV decr_mgr_cleanup(ENCR_DECR_CONTEXT *ctx);
+CK_RV decr_mgr_cleanup(STDLL_TokData_t *tokdata, SESSION *sess,
+                       ENCR_DECR_CONTEXT *ctx);
 
 CK_RV decr_mgr_decrypt(STDLL_TokData_t *tokdata,
                        SESSION *sess, CK_BBOOL length_only,
@@ -1866,7 +1868,8 @@ CK_RV decr_mgr_update_des3_cbc(STDLL_TokData_t *tokdata, SESSION *sess,
 
 // digest manager routines
 //
-CK_RV digest_mgr_cleanup(DIGEST_CONTEXT *ctx);
+CK_RV digest_mgr_cleanup(STDLL_TokData_t *tokdata, SESSION *sess,
+                         DIGEST_CONTEXT *ctx);
 
 CK_RV digest_mgr_init(STDLL_TokData_t *tokdata,
                       SESSION *sess,
@@ -1955,7 +1958,8 @@ CK_RV sign_mgr_init(STDLL_TokData_t *tokdata,
                     CK_MECHANISM *mech,
                     CK_BBOOL recover_mode, CK_OBJECT_HANDLE key_handle);
 
-CK_RV sign_mgr_cleanup(SIGN_VERIFY_CONTEXT *ctx);
+CK_RV sign_mgr_cleanup(STDLL_TokData_t *tokdata, SESSION *sess,
+                       SIGN_VERIFY_CONTEXT *ctx);
 
 CK_RV sign_mgr_sign(STDLL_TokData_t *tokdata,
                     SESSION *sess,
@@ -1992,7 +1996,8 @@ CK_RV verify_mgr_init(STDLL_TokData_t *tokdata,
                       CK_MECHANISM *mech,
                       CK_BBOOL recover_mode, CK_OBJECT_HANDLE key_handle);
 
-CK_RV verify_mgr_cleanup(SIGN_VERIFY_CONTEXT *ctx);
+CK_RV verify_mgr_cleanup(STDLL_TokData_t *tokdata, SESSION *sess,
+                         SIGN_VERIFY_CONTEXT *ctx);
 
 CK_RV verify_mgr_verify(STDLL_TokData_t *tokdata,
                         SESSION *sess,
@@ -2036,10 +2041,11 @@ CK_BBOOL session_mgr_so_session_exists(STDLL_TokData_t *tokdata);
 CK_BBOOL session_mgr_user_session_exists(STDLL_TokData_t *tokdata);
 CK_BBOOL session_mgr_public_session_exists(STDLL_TokData_t *tokdata);
 
-CK_RV session_mgr_get_op_state(SESSION *sess, CK_BBOOL length_only,
+CK_RV session_mgr_get_op_state(SESSION *sess,
+                               CK_BBOOL length_only,
                                CK_BYTE *data, CK_ULONG *data_len);
 
-CK_RV session_mgr_set_op_state(SESSION *sess,
+CK_RV session_mgr_set_op_state(STDLL_TokData_t *tokdata, SESSION *sess,
                                CK_OBJECT_HANDLE encr_key,
                                CK_OBJECT_HANDLE auth_key, CK_BYTE *data,
                                CK_ULONG data_len);

--- a/usr/lib/common/host_defs.h
+++ b/usr/lib/common/host_defs.h
@@ -21,27 +21,36 @@
 
 #include "local_types.h"
 
+struct _SESSION;
+
+typedef void (*context_free_func_t)(STDLL_TokData_t *tokdata, struct _SESSION *sess,
+                                    CK_BYTE *context, CK_ULONG context_len);
+
 typedef struct _ENCR_DECR_CONTEXT {
     CK_OBJECT_HANDLE key;
     CK_MECHANISM mech;
     CK_BYTE *context;
     CK_ULONG context_len;
+    context_free_func_t context_free_func;
     CK_BBOOL multi;
     CK_BBOOL active;
     CK_BBOOL init_pending;      // indicate init request pending
     CK_BBOOL multi_init;        // multi field is initialized
                                 // on first call *after* init
     CK_BBOOL pkey_active;
+    CK_BBOOL state_unsaveable;
 } ENCR_DECR_CONTEXT;
 
 typedef struct _DIGEST_CONTEXT {
     CK_MECHANISM mech;
     CK_BYTE *context;
     CK_ULONG context_len;
+    context_free_func_t context_free_func;
     CK_BBOOL multi;
     CK_BBOOL active;
     CK_BBOOL multi_init;        // multi field is initialized
                                 // on first call *after* init
+    CK_BBOOL state_unsaveable;
 } DIGEST_CONTEXT;
 
 typedef struct _SIGN_VERIFY_CONTEXT {
@@ -49,6 +58,7 @@ typedef struct _SIGN_VERIFY_CONTEXT {
     CK_MECHANISM mech;          // current sign mechanism
     CK_BYTE *context;           // temporary work area
     CK_ULONG context_len;
+    context_free_func_t context_free_func;
     CK_BBOOL multi;             // is this a multi-part operation?
     CK_BBOOL recover;           // are we in recover mode?
     CK_BBOOL active;
@@ -56,6 +66,7 @@ typedef struct _SIGN_VERIFY_CONTEXT {
     CK_BBOOL multi_init;        // multi field is initialized
                                 // on first call *after* init
     CK_BBOOL pkey_active;
+    CK_BBOOL state_unsaveable;
 } SIGN_VERIFY_CONTEXT;
 
 

--- a/usr/lib/common/key_mgr.c
+++ b/usr/lib/common/key_mgr.c
@@ -1011,7 +1011,7 @@ CK_RV key_mgr_wrap_key(STDLL_TokData_t *tokdata,
         OPENSSL_cleanse(data, data_len);
         free(data);
     }
-    encr_mgr_cleanup(ctx);
+    encr_mgr_cleanup(tokdata, sess, ctx);
     free(ctx);
 
 done:
@@ -1259,7 +1259,7 @@ CK_RV key_mgr_unwrap_key(STDLL_TokData_t *tokdata,
                           FALSE,
                           ctx, wrapped_key, wrapped_key_len, data, &data_len);
 
-    decr_mgr_cleanup(ctx);
+    decr_mgr_cleanup(tokdata, sess, ctx);
     free(ctx);
     ctx = NULL;
 
@@ -1345,7 +1345,7 @@ done:
         free(data);
     }
     if (ctx != NULL) {
-        decr_mgr_cleanup(ctx);
+        decr_mgr_cleanup(tokdata, sess, ctx);
         free(ctx);
     }
 

--- a/usr/lib/common/lock_sess_mgr.c
+++ b/usr/lib/common/lock_sess_mgr.c
@@ -276,32 +276,62 @@ CK_RV session_mgr_close_session(STDLL_TokData_t *tokdata,
     if (sess->find_list)
         free(sess->find_list);
 
-    if (sess->encr_ctx.context)
-        free(sess->encr_ctx.context);
+    if (sess->encr_ctx.context) {
+        if (sess->encr_ctx.context_free_func != NULL)
+            sess->encr_ctx.context_free_func(tokdata, sess,
+                                             sess->encr_ctx.context,
+                                             sess->encr_ctx.context_len);
+        else
+            free(sess->encr_ctx.context);
+    }
 
     if (sess->encr_ctx.mech.pParameter)
         free(sess->encr_ctx.mech.pParameter);
 
-    if (sess->decr_ctx.context)
-        free(sess->decr_ctx.context);
+    if (sess->decr_ctx.context) {
+        if (sess->decr_ctx.context_free_func != NULL)
+            sess->decr_ctx.context_free_func(tokdata, sess,
+                                             sess->decr_ctx.context,
+                                             sess->decr_ctx.context_len);
+        else
+            free(sess->decr_ctx.context);
+    }
 
     if (sess->decr_ctx.mech.pParameter)
         free(sess->decr_ctx.mech.pParameter);
 
-    if (sess->digest_ctx.context)
-        free(sess->digest_ctx.context);
+    if (sess->digest_ctx.context) {
+        if (sess->digest_ctx.context_free_func != NULL)
+            sess->digest_ctx.context_free_func(tokdata, sess,
+                                               sess->digest_ctx.context,
+                                               sess->digest_ctx.context_len);
+        else
+            free(sess->digest_ctx.context);
+    }
 
     if (sess->digest_ctx.mech.pParameter)
         free(sess->digest_ctx.mech.pParameter);
 
-    if (sess->sign_ctx.context)
-        free(sess->sign_ctx.context);
+    if (sess->sign_ctx.context) {
+        if (sess->sign_ctx.context_free_func != NULL)
+            sess->sign_ctx.context_free_func(tokdata, sess,
+                                             sess->sign_ctx.context,
+                                             sess->sign_ctx.context_len);
+        else
+            free(sess->sign_ctx.context);
+    }
 
     if (sess->sign_ctx.mech.pParameter)
         free(sess->sign_ctx.mech.pParameter);
 
-    if (sess->verify_ctx.context)
-        free(sess->verify_ctx.context);
+    if (sess->verify_ctx.context) {
+        if (sess->verify_ctx.context_free_func != NULL)
+            sess->verify_ctx.context_free_func(tokdata, sess,
+                                               sess->verify_ctx.context,
+                                               sess->verify_ctx.context_len);
+        else
+            free(sess->verify_ctx.context);
+    }
 
     if (sess->verify_ctx.mech.pParameter)
         free(sess->verify_ctx.mech.pParameter);
@@ -354,32 +384,62 @@ void session_free(STDLL_TokData_t *tokdata, void *node_value,
     if (sess->find_list)
         free(sess->find_list);
 
-    if (sess->encr_ctx.context)
-        free(sess->encr_ctx.context);
+    if (sess->encr_ctx.context) {
+        if (sess->encr_ctx.context_free_func != NULL)
+            sess->encr_ctx.context_free_func(tokdata, sess,
+                                             sess->encr_ctx.context,
+                                             sess->encr_ctx.context_len);
+        else
+            free(sess->encr_ctx.context);
+    }
 
     if (sess->encr_ctx.mech.pParameter)
         free(sess->encr_ctx.mech.pParameter);
 
-    if (sess->decr_ctx.context)
-        free(sess->decr_ctx.context);
+    if (sess->decr_ctx.context) {
+        if (sess->decr_ctx.context_free_func != NULL)
+            sess->decr_ctx.context_free_func(tokdata, sess,
+                                             sess->decr_ctx.context,
+                                             sess->decr_ctx.context_len);
+        else
+            free(sess->decr_ctx.context);
+    }
 
     if (sess->decr_ctx.mech.pParameter)
         free(sess->decr_ctx.mech.pParameter);
 
-    if (sess->digest_ctx.context)
-        free(sess->digest_ctx.context);
+    if (sess->digest_ctx.context) {
+        if (sess->digest_ctx.context_free_func != NULL)
+            sess->digest_ctx.context_free_func(tokdata, sess,
+                                               sess->digest_ctx.context,
+                                               sess->digest_ctx.context_len);
+        else
+            free(sess->digest_ctx.context);
+    }
 
     if (sess->digest_ctx.mech.pParameter)
         free(sess->digest_ctx.mech.pParameter);
 
-    if (sess->sign_ctx.context)
-        free(sess->sign_ctx.context);
+    if (sess->sign_ctx.context) {
+        if (sess->sign_ctx.context_free_func != NULL)
+            sess->sign_ctx.context_free_func(tokdata, sess,
+                                             sess->sign_ctx.context,
+                                             sess->sign_ctx.context_len);
+        else
+            free(sess->sign_ctx.context);
+    }
 
     if (sess->sign_ctx.mech.pParameter)
         free(sess->sign_ctx.mech.pParameter);
 
-    if (sess->verify_ctx.context)
-        free(sess->verify_ctx.context);
+    if (sess->verify_ctx.context) {
+        if (sess->verify_ctx.context_free_func != NULL)
+            sess->verify_ctx.context_free_func(tokdata, sess,
+                                               sess->verify_ctx.context,
+                                               sess->verify_ctx.context_len);
+        else
+            free(sess->verify_ctx.context);
+    }
 
     if (sess->verify_ctx.mech.pParameter)
         free(sess->verify_ctx.mech.pParameter);
@@ -528,6 +588,10 @@ CK_RV session_mgr_get_op_state(SESSION *sess,
     active_ops = 0;
 
     if (sess->encr_ctx.active == TRUE) {
+        if (sess->encr_ctx.state_unsaveable) {
+            TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
+            return CKR_STATE_UNSAVEABLE;
+        }
         active_ops++;
         if (op_data != NULL) {
             TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
@@ -572,6 +636,10 @@ CK_RV session_mgr_get_op_state(SESSION *sess,
     }
 
     if (sess->decr_ctx.active == TRUE) {
+        if (sess->decr_ctx.state_unsaveable) {
+            TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
+            return CKR_STATE_UNSAVEABLE;
+        }
         active_ops++;
         if (op_data != NULL) {
             TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
@@ -616,6 +684,10 @@ CK_RV session_mgr_get_op_state(SESSION *sess,
     }
 
     if (sess->digest_ctx.active == TRUE) {
+        if (sess->digest_ctx.state_unsaveable) {
+            TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
+            return CKR_STATE_UNSAVEABLE;
+        }
         active_ops++;
         if (op_data != NULL) {
             TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
@@ -660,6 +732,10 @@ CK_RV session_mgr_get_op_state(SESSION *sess,
     }
 
     if (sess->sign_ctx.active == TRUE) {
+        if (sess->sign_ctx.state_unsaveable) {
+            TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
+            return CKR_STATE_UNSAVEABLE;
+        }
         active_ops++;
         if (op_data != NULL) {
             TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
@@ -704,6 +780,10 @@ CK_RV session_mgr_get_op_state(SESSION *sess,
     }
 
     if (sess->verify_ctx.active == TRUE) {
+        if (sess->verify_ctx.state_unsaveable) {
+            TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
+            return CKR_STATE_UNSAVEABLE;
+        }
         active_ops++;
         if (op_data != NULL) {
             TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
@@ -759,7 +839,7 @@ CK_RV session_mgr_get_op_state(SESSION *sess,
 
 //
 //
-CK_RV session_mgr_set_op_state(SESSION *sess,
+CK_RV session_mgr_set_op_state(STDLL_TokData_t *tokdata, SESSION *sess,
                                CK_OBJECT_HANDLE encr_key,
                                CK_OBJECT_HANDLE auth_key,
                                CK_BYTE *data, CK_ULONG data_len)
@@ -939,19 +1019,19 @@ CK_RV session_mgr_set_op_state(SESSION *sess,
     // state information looks okay.  cleanup the current session state, first
     //
     if (sess->encr_ctx.active)
-        encr_mgr_cleanup(&sess->encr_ctx);
+        encr_mgr_cleanup(tokdata, sess, &sess->encr_ctx);
 
     if (sess->decr_ctx.active)
-        decr_mgr_cleanup(&sess->decr_ctx);
+        decr_mgr_cleanup(tokdata, sess, &sess->decr_ctx);
 
     if (sess->digest_ctx.active)
-        digest_mgr_cleanup(&sess->digest_ctx);
+        digest_mgr_cleanup(tokdata, sess, &sess->digest_ctx);
 
     if (sess->sign_ctx.active)
-        sign_mgr_cleanup(&sess->sign_ctx);
+        sign_mgr_cleanup(tokdata, sess, &sess->sign_ctx);
 
     if (sess->verify_ctx.active)
-        verify_mgr_cleanup(&sess->verify_ctx);
+        verify_mgr_cleanup(tokdata, sess, &sess->verify_ctx);
 
 
     // copy the new state information

--- a/usr/lib/common/mech_aes.c
+++ b/usr/lib/common/mech_aes.c
@@ -2359,6 +2359,8 @@ CK_RV aes_mac_sign(STDLL_TokData_t *tokdata,
         memcpy(out_data, ((AES_DATA_CONTEXT *) ctx->context)->iv, mac_len);
         *out_data_len = mac_len;
 
+        sign_mgr_cleanup(tokdata, sess, ctx);
+
         return rc;
     }
 }
@@ -2497,6 +2499,8 @@ CK_RV aes_mac_sign_final(STDLL_TokData_t *tokdata,
     memcpy(out_data, context->iv, mac_len);
     *out_data_len = mac_len;
 
+    sign_mgr_cleanup(tokdata, sess, ctx);
+
     return rc;
 }
 
@@ -2554,8 +2558,12 @@ CK_RV aes_mac_verify(STDLL_TokData_t *tokdata,
         }
 
         if (CRYPTO_memcmp(out_data, ((AES_DATA_CONTEXT *) ctx->context)->iv,
-                          out_data_len) == 0)
+                          out_data_len) == 0) {
+            verify_mgr_cleanup(tokdata, sess, ctx);
             return CKR_OK;
+        }
+
+        verify_mgr_cleanup(tokdata, sess, ctx);
 
         return CKR_SIGNATURE_INVALID;
     }
@@ -2685,8 +2693,12 @@ CK_RV aes_mac_verify_final(STDLL_TokData_t *tokdata,
         }
     }
 
-    if (CRYPTO_memcmp(signature, context->iv, signature_len) == 0) 
+    if (CRYPTO_memcmp(signature, context->iv, signature_len) == 0) {
+        verify_mgr_cleanup(tokdata, sess, ctx);
         return CKR_OK;
+    }
+
+    verify_mgr_cleanup(tokdata, sess, ctx);
 
     return CKR_SIGNATURE_INVALID;
 }
@@ -2765,6 +2777,8 @@ CK_RV aes_cmac_sign(STDLL_TokData_t *tokdata,
 
     memcpy(out_data, ((AES_CMAC_CONTEXT *) ctx->context)->iv, mac_len);
     *out_data_len = mac_len;
+
+    sign_mgr_cleanup(tokdata, sess, ctx);
 
 done:
     object_put(tokdata, key_obj, TRUE);
@@ -2913,6 +2927,8 @@ done:
     object_put(tokdata, key_obj, TRUE);
     key_obj = NULL;
 
+    sign_mgr_cleanup(tokdata, sess, ctx);
+
     return rc;
 }
 
@@ -2969,8 +2985,11 @@ CK_RV aes_cmac_verify(STDLL_TokData_t *tokdata,
 
     if (CRYPTO_memcmp(out_data, ((AES_CMAC_CONTEXT *) ctx->context)->iv,
                       out_data_len) == 0) {
+        verify_mgr_cleanup(tokdata, sess, ctx);
         return CKR_OK;
     }
+
+    verify_mgr_cleanup(tokdata, sess, ctx);
 
     return CKR_SIGNATURE_INVALID;
 }
@@ -3105,8 +3124,12 @@ CK_RV aes_cmac_verify_final(STDLL_TokData_t *tokdata,
         return rc;
     }
 
-    if (CRYPTO_memcmp(signature, context->iv, signature_len) == 0)
+    if (CRYPTO_memcmp(signature, context->iv, signature_len) == 0) {
+        verify_mgr_cleanup(tokdata, sess, ctx);
         return CKR_OK;
+    }
+
+    verify_mgr_cleanup(tokdata, sess, ctx);
 
     return CKR_SIGNATURE_INVALID;
 }

--- a/usr/lib/common/mech_aes.c
+++ b/usr/lib/common/mech_aes.c
@@ -2740,6 +2740,9 @@ CK_RV aes_cmac_sign(STDLL_TokData_t *tokdata,
         goto done;
     }
 
+    if (((AES_CMAC_CONTEXT *)ctx->context)->ctx != NULL)
+        ctx->state_unsaveable = CK_TRUE;
+
     memcpy(out_data, ((AES_CMAC_CONTEXT *) ctx->context)->iv, mac_len);
     *out_data_len = mac_len;
 
@@ -2810,6 +2813,9 @@ CK_RV aes_cmac_sign_update(STDLL_TokData_t *tokdata,
             context->len = remain;
 
             context->initialized = CK_TRUE;
+
+            if (context->ctx != NULL)
+                ctx->state_unsaveable = CK_TRUE;
         } else {
             TRACE_DEVEL("Token specific aes cmac failed.\n");
         }
@@ -2873,6 +2879,9 @@ CK_RV aes_cmac_sign_final(STDLL_TokData_t *tokdata,
         goto done;
     }
 
+    if (context->ctx != NULL)
+        ctx->state_unsaveable = CK_TRUE;
+
     memcpy(out_data, context->iv, mac_len);
     *out_data_len = mac_len;
 
@@ -2928,6 +2937,9 @@ CK_RV aes_cmac_verify(STDLL_TokData_t *tokdata,
         TRACE_DEVEL("Token specific aes cmac failed.\n");
         return rc;
     }
+
+    if (((AES_CMAC_CONTEXT *)ctx->context)->ctx != NULL)
+        ctx->state_unsaveable = CK_TRUE;
 
     if (CRYPTO_memcmp(out_data, ((AES_CMAC_CONTEXT *) ctx->context)->iv,
                       out_data_len) == 0) {
@@ -2997,6 +3009,9 @@ CK_RV aes_cmac_verify_update(STDLL_TokData_t *tokdata,
             context->len = remain;
 
             context->initialized = CK_TRUE;
+
+            if (context->ctx != NULL)
+                ctx->state_unsaveable = CK_TRUE;
         } else {
             TRACE_DEVEL("Token specific aes cmac failed.\n");
         }
@@ -3051,6 +3066,9 @@ CK_RV aes_cmac_verify_final(STDLL_TokData_t *tokdata,
 
     object_put(tokdata, key_obj, TRUE);
     key_obj = NULL;
+
+    if (context->ctx != NULL)
+        ctx->state_unsaveable = CK_TRUE;
 
     if (rc != CKR_OK) {
         TRACE_DEVEL("Token specific aes mac failed.\n");

--- a/usr/lib/common/mech_des3.c
+++ b/usr/lib/common/mech_des3.c
@@ -2380,6 +2380,9 @@ CK_RV des3_cmac_sign(STDLL_TokData_t *tokdata,
     if (rc != CKR_OK)
         TRACE_DEVEL("Token specific des3 cmac failed.\n");
 
+    if (((DES_CMAC_CONTEXT *)ctx->context)->ctx != NULL)
+        ctx->state_unsaveable = CK_TRUE;
+
     memcpy(out_data, ((DES_CMAC_CONTEXT *) ctx->context)->iv, mac_len);
 
     *out_data_len = mac_len;
@@ -2450,6 +2453,9 @@ CK_RV des3_cmac_sign_update(STDLL_TokData_t *tokdata,
             context->len = remain;
 
             context->initialized = CK_TRUE;
+
+            if (context->ctx != NULL)
+                ctx->state_unsaveable = CK_TRUE;
         } else {
             TRACE_DEVEL("Token specific des3 cmac failed.\n");
         }
@@ -2512,6 +2518,9 @@ CK_RV des3_cmac_sign_final(STDLL_TokData_t *tokdata,
         goto done;
     }
 
+    if (context->ctx != NULL)
+        ctx->state_unsaveable = CK_TRUE;
+
     memcpy(out_data, context->iv, mac_len);
 
     *out_data_len = mac_len;
@@ -2564,6 +2573,9 @@ CK_RV des3_cmac_verify(STDLL_TokData_t *tokdata,
 
     object_put(tokdata, key_obj, TRUE);
     key_obj = NULL;
+
+    if (((DES_CMAC_CONTEXT *)ctx->context)->ctx != NULL)
+        ctx->state_unsaveable = CK_TRUE;
 
     if (CRYPTO_memcmp(out_data, ((DES_CMAC_CONTEXT *) ctx->context)->iv,
                       out_data_len) == 0) {
@@ -2631,6 +2643,9 @@ CK_RV des3_cmac_verify_update(STDLL_TokData_t *tokdata,
             context->len = remain;
 
             context->initialized = CK_TRUE;
+
+            if (context->ctx != NULL)
+                ctx->state_unsaveable = CK_TRUE;
         } else {
             TRACE_DEVEL("Token specific des3 cmac failed.\n");
         }
@@ -2690,6 +2705,9 @@ CK_RV des3_cmac_verify_final(STDLL_TokData_t *tokdata,
         TRACE_DEVEL("Token specific des3 cmac failed.\n");
         return rc;
     }
+
+    if (context->ctx != NULL)
+        ctx->state_unsaveable = CK_TRUE;
 
     if (CRYPTO_memcmp(signature, context->iv, signature_len) == 0)
         return CKR_OK;

--- a/usr/lib/common/mech_des3.c
+++ b/usr/lib/common/mech_des3.c
@@ -2006,6 +2006,8 @@ CK_RV des3_mac_sign(STDLL_TokData_t *tokdata,
 
         *out_data_len = mac_len;
 
+        sign_mgr_cleanup(tokdata, sess, ctx);
+
         return rc;
     }
 }
@@ -2144,6 +2146,8 @@ CK_RV des3_mac_sign_final(STDLL_TokData_t *tokdata,
 
     *out_data_len = mac_len;
 
+    sign_mgr_cleanup(tokdata, sess, ctx);
+
     return rc;
 }
 
@@ -2197,8 +2201,12 @@ CK_RV des3_mac_verify(STDLL_TokData_t *tokdata,
         key_obj = NULL;
 
         if (CRYPTO_memcmp(out_data, ((DES_DATA_CONTEXT *) ctx->context)->iv,
-                          out_data_len) == 0)
+                          out_data_len) == 0) {
+            verify_mgr_cleanup(tokdata, sess, ctx);
             return CKR_OK;
+        }
+
+        verify_mgr_cleanup(tokdata, sess, ctx);
 
         return CKR_SIGNATURE_INVALID;
     }
@@ -2328,8 +2336,12 @@ CK_RV des3_mac_verify_final(STDLL_TokData_t *tokdata,
         }
     }
 
-    if (CRYPTO_memcmp(signature, context->iv, signature_len) == 0) 
+    if (CRYPTO_memcmp(signature, context->iv, signature_len) == 0) {
+        verify_mgr_cleanup(tokdata, sess, ctx);
         return CKR_OK;
+    }
+
+    verify_mgr_cleanup(tokdata, sess, ctx);
 
     return CKR_SIGNATURE_INVALID;
 }
@@ -2409,6 +2421,8 @@ CK_RV des3_cmac_sign(STDLL_TokData_t *tokdata,
 
     object_put(tokdata, key_obj, TRUE);
     key_obj = NULL;
+
+    sign_mgr_cleanup(tokdata, sess, ctx);
 
     return rc;
 }
@@ -2553,6 +2567,8 @@ done:
     object_put(tokdata, key_obj, TRUE);
     key_obj = NULL;
 
+   sign_mgr_cleanup(tokdata, sess, ctx);
+
     return rc;
 }
 
@@ -2605,8 +2621,12 @@ CK_RV des3_cmac_verify(STDLL_TokData_t *tokdata,
 
     if (CRYPTO_memcmp(out_data, ((DES_CMAC_CONTEXT *) ctx->context)->iv,
                       out_data_len) == 0) {
+        verify_mgr_cleanup(tokdata, sess, ctx);
         return CKR_OK;
     }
+
+    verify_mgr_cleanup(tokdata, sess, ctx);
+
     return CKR_SIGNATURE_INVALID;
 }
 
@@ -2739,8 +2759,12 @@ CK_RV des3_cmac_verify_final(STDLL_TokData_t *tokdata,
 
     ctx->context_free_func = des3_cmac_cleanup;
 
-    if (CRYPTO_memcmp(signature, context->iv, signature_len) == 0)
+    if (CRYPTO_memcmp(signature, context->iv, signature_len) == 0) {
+        verify_mgr_cleanup(tokdata, sess, ctx);
         return CKR_OK;
+    }
+
+    verify_mgr_cleanup(tokdata, sess, ctx);
 
     return CKR_SIGNATURE_INVALID;
 }

--- a/usr/lib/common/mech_ec.c
+++ b/usr/lib/common/mech_ec.c
@@ -414,7 +414,7 @@ CK_RV ec_hash_sign(STDLL_TokData_t *tokdata,
                            in_data_len, hash, &hash_len);
     if (rc != CKR_OK) {
         TRACE_DEVEL("Digest Mgr Digest failed.\n");
-        digest_mgr_cleanup(&digest_ctx);
+        digest_mgr_cleanup(tokdata, sess, &digest_ctx);
         return rc;
     }
 
@@ -434,7 +434,7 @@ CK_RV ec_hash_sign(STDLL_TokData_t *tokdata,
         TRACE_DEVEL("Sign Mgr Sign failed.\n");
 
 error:
-    sign_mgr_cleanup(&sign_ctx);
+    sign_mgr_cleanup(tokdata, sess, &sign_ctx);
 
     return rc;
 }
@@ -485,6 +485,7 @@ CK_RV ec_hash_sign_update(STDLL_TokData_t *tokdata,
             return rc;
         }
         context->flag = TRUE;
+        ctx->state_unsaveable |= context->hash_context.state_unsaveable;
     }
 
     rc = digest_mgr_digest_update(tokdata, sess, &context->hash_context,
@@ -556,12 +557,12 @@ CK_RV ec_hash_sign_final(STDLL_TokData_t *tokdata,
         TRACE_DEVEL("Sign Mgr Sign failed.\n");
 
     if (length_only == TRUE || rc == CKR_BUFFER_TOO_SMALL) {
-        sign_mgr_cleanup(&sign_ctx);
+        sign_mgr_cleanup(tokdata, sess, &sign_ctx);
         return rc;
     }
 
 done:
-    sign_mgr_cleanup(&sign_ctx);
+    sign_mgr_cleanup(tokdata, sess, &sign_ctx);
 
     return rc;
 }
@@ -627,7 +628,7 @@ CK_RV ec_hash_verify(STDLL_TokData_t *tokdata,
                            in_data_len, hash, &hash_len);
     if (rc != CKR_OK) {
         TRACE_DEVEL("Digest Mgr Digest failed.\n");
-        digest_mgr_cleanup(&digest_ctx);
+        digest_mgr_cleanup(tokdata, sess, &digest_ctx);
         return rc;
     }
     // Verify the Signed BER-encoded Data block
@@ -649,7 +650,7 @@ CK_RV ec_hash_verify(STDLL_TokData_t *tokdata,
     if (rc != CKR_OK)
         TRACE_DEVEL("Verify Mgr Verify failed.\n");
 done:
-    sign_mgr_cleanup(&verify_ctx);
+    sign_mgr_cleanup(tokdata, sess, &verify_ctx);
 
     return rc;
 }
@@ -701,6 +702,7 @@ CK_RV ec_hash_verify_update(STDLL_TokData_t *tokdata,
             return rc;
         }
         context->flag = TRUE;
+        ctx->state_unsaveable |= context->hash_context.state_unsaveable;
     }
 
     rc = digest_mgr_digest_update(tokdata, sess, &context->hash_context,
@@ -768,7 +770,7 @@ CK_RV ec_hash_verify_final(STDLL_TokData_t *tokdata,
     if (rc != CKR_OK)
         TRACE_DEVEL("Verify Mgr Verify failed.\n");
 done:
-    verify_mgr_cleanup(&verify_ctx);
+    verify_mgr_cleanup(tokdata, sess, &verify_ctx);
 
     return rc;
 }
@@ -823,7 +825,7 @@ CK_RV ckm_kdf(STDLL_TokData_t *tokdata, SESSION *sess, CK_ULONG kdf,
                            h_len);
     if (rc != CKR_OK) {
         TRACE_ERROR("digest_mgr_digest failed with rc = %s\n", ock_err(rc));
-        digest_mgr_cleanup(&ctx);
+        digest_mgr_cleanup(tokdata, sess, &ctx);
         return rc;
     }
 

--- a/usr/lib/common/mech_md2.c
+++ b/usr/lib/common/mech_md2.c
@@ -245,7 +245,7 @@ CK_RV md2_hmac_sign(STDLL_TokData_t *tokdata,
                                attr->pValue, attr->ulValueLen, hash, &hash_len);
         if (rc != CKR_OK) {
             TRACE_DEVEL("Digest Mgr Digest failed.\n");
-            digest_mgr_cleanup(&digest_ctx);
+            digest_mgr_cleanup(tokdata, sess, &digest_ctx);
             goto done;
         }
         memset(&digest_ctx, 0x0, sizeof(DIGEST_CONTEXT));

--- a/usr/lib/common/mech_rsa.c
+++ b/usr/lib/common/mech_rsa.c
@@ -1476,7 +1476,7 @@ CK_RV rsa_hash_pss_sign(STDLL_TokData_t *tokdata, SESSION *sess,
                            in_data, in_data_len, hash, &hlen);
     if (rc != CKR_OK) {
         TRACE_DEVEL("Digest Mgr Digest failed.\n");
-        digest_mgr_cleanup(&digest_ctx);
+        digest_mgr_cleanup(tokdata, sess, &digest_ctx);
         return rc;
     }
 
@@ -1497,7 +1497,7 @@ CK_RV rsa_hash_pss_sign(STDLL_TokData_t *tokdata, SESSION *sess,
         TRACE_DEVEL("Sign Mgr Sign failed.\n");
 
 done:
-    sign_mgr_cleanup(&sign_ctx);
+    sign_mgr_cleanup(tokdata, sess, &sign_ctx);
 
     return rc;
 }
@@ -1546,6 +1546,7 @@ CK_RV rsa_hash_pss_update(STDLL_TokData_t *tokdata, SESSION *sess,
             TRACE_DEVEL("Digest Mgr Init failed.\n");
             return rc;
         }
+        ctx->state_unsaveable |= digest_ctx->state_unsaveable;
     }
 
     rc = digest_mgr_digest_update(tokdata, sess, digest_ctx, in_data,
@@ -1613,7 +1614,7 @@ CK_RV rsa_hash_pss_sign_final(STDLL_TokData_t *tokdata, SESSION *sess,
         TRACE_DEVEL("Sign Mgr Sign failed.\n");
 
 done:
-    sign_mgr_cleanup(&sign_ctx);
+    sign_mgr_cleanup(tokdata, sess, &sign_ctx);
 
     return rc;
 }
@@ -1676,7 +1677,7 @@ CK_RV rsa_hash_pss_verify(STDLL_TokData_t *tokdata, SESSION *sess,
                            in_data_len, hash, &hlen);
     if (rc != CKR_OK) {
         TRACE_DEVEL("Digest Mgr Digest failed.\n");
-        digest_mgr_cleanup(&digest_ctx);
+        digest_mgr_cleanup(tokdata, sess, &digest_ctx);
         return rc;
     }
 
@@ -1698,7 +1699,7 @@ CK_RV rsa_hash_pss_verify(STDLL_TokData_t *tokdata, SESSION *sess,
         TRACE_DEVEL("Verify Mgr Verify failed.\n");
 
 done:
-    verify_mgr_cleanup(&verify_ctx);
+    verify_mgr_cleanup(tokdata, sess, &verify_ctx);
 
     return rc;
 }
@@ -1760,7 +1761,7 @@ CK_RV rsa_hash_pss_verify_final(STDLL_TokData_t *tokdata, SESSION *sess,
         TRACE_DEVEL("Verify Mgr Verify failed.\n");
 
 done:
-    verify_mgr_cleanup(&verify_ctx);
+    verify_mgr_cleanup(tokdata, sess, &verify_ctx);
 
     return rc;
 }
@@ -1842,7 +1843,7 @@ CK_RV rsa_hash_pkcs_sign(STDLL_TokData_t *tokdata,
                            in_data_len, hash, &hash_len);
     if (rc != CKR_OK) {
         TRACE_DEVEL("Digest Mgr Digest failed.\n");
-        digest_mgr_cleanup(&digest_ctx);
+        digest_mgr_cleanup(tokdata, sess, &digest_ctx);
         return rc;
     }
     // build the BER-encodings
@@ -1885,7 +1886,7 @@ error:
         free(octet_str);
     if (ber_data)
         free(ber_data);
-    sign_mgr_cleanup(&sign_ctx);
+    sign_mgr_cleanup(tokdata, sess, &sign_ctx);
 
     return rc;
 }
@@ -1934,6 +1935,7 @@ CK_RV rsa_hash_pkcs_sign_update(STDLL_TokData_t *tokdata,
             return rc;
         }
         context->flag = TRUE;
+        ctx->state_unsaveable |= context->hash_context.state_unsaveable;
     }
 
     rc = digest_mgr_digest_update(tokdata, sess, &context->hash_context,
@@ -2021,7 +2023,7 @@ CK_RV rsa_hash_pkcs_verify(STDLL_TokData_t *tokdata,
                            in_data_len, hash, &hash_len);
     if (rc != CKR_OK) {
         TRACE_DEVEL("Digest Mgr Digest failed.\n");
-        digest_mgr_cleanup(&digest_ctx);
+        digest_mgr_cleanup(tokdata, sess, &digest_ctx);
         return rc;
     }
     // Build the BER encoding
@@ -2063,7 +2065,7 @@ done:
         free(octet_str);
     if (ber_data)
         free(ber_data);
-    sign_mgr_cleanup(&verify_ctx);
+    sign_mgr_cleanup(tokdata, sess, &verify_ctx);
 
     return rc;
 }
@@ -2111,6 +2113,7 @@ CK_RV rsa_hash_pkcs_verify_update(STDLL_TokData_t *tokdata,
             return rc;
         }
         context->flag = TRUE;
+        ctx->state_unsaveable |= context->hash_context.state_unsaveable;
     }
 
     rc = digest_mgr_digest_update(tokdata, sess, &context->hash_context,
@@ -2236,7 +2239,7 @@ done:
         free(octet_str);
     if (ber_data)
         free(ber_data);
-    sign_mgr_cleanup(&sign_ctx);
+    sign_mgr_cleanup(tokdata, sess, &sign_ctx);
 
     return rc;
 }
@@ -2347,7 +2350,7 @@ done:
         free(octet_str);
     if (ber_data)
         free(ber_data);
-    verify_mgr_cleanup(&verify_ctx);
+    verify_mgr_cleanup(tokdata, sess, &verify_ctx);
 
     return rc;
 }

--- a/usr/lib/common/mech_sha.c
+++ b/usr/lib/common/mech_sha.c
@@ -80,7 +80,10 @@ CK_RV sw_sha1_hash(DIGEST_CONTEXT *ctx, CK_BYTE *in_data,
     SHA1_Final(out_data, (SHA_CTX *)ctx->context);
     *out_data_len = SHA1_HASH_SIZE;
 
-    free(ctx->context);
+    if (ctx->context_free_func != NULL)
+        ctx->context_free_func(ctx->context, ctx->context_len);
+    else
+        free(ctx->context);
     ctx->context = NULL;
 
     return CKR_OK;
@@ -105,7 +108,10 @@ CK_RV sw_sha1_final(DIGEST_CONTEXT *ctx, CK_BYTE *out_data,
     SHA1_Final(out_data, (SHA_CTX *)ctx->context);
     *out_data_len = SHA1_HASH_SIZE;
 
-    free(ctx->context);
+    if (ctx->context_free_func != NULL)
+        ctx->context_free_func(ctx->context, ctx->context_len);
+    else
+        free(ctx->context);
     ctx->context = NULL;
 
     return CKR_OK;
@@ -421,7 +427,7 @@ CK_RV sha_hmac_sign(STDLL_TokData_t *tokdata,
                                attr->pValue, attr->ulValueLen, hash, &hash_len);
         if (rc != CKR_OK) {
             TRACE_DEVEL("Digest Mgr Digest failed.\n");
-            digest_mgr_cleanup(&digest_ctx);
+            digest_mgr_cleanup(tokdata, sess, &digest_ctx);
             goto done;
         }
 
@@ -607,7 +613,7 @@ CK_RV sha_hmac_verify(STDLL_TokData_t *tokdata, SESSION *sess,
     }
 
 done:
-    sign_mgr_cleanup(&hmac_ctx);
+    sign_mgr_cleanup(tokdata, sess, &hmac_ctx);
     return rc;
 }
 

--- a/usr/lib/common/mech_ssl3.c
+++ b/usr/lib/common/mech_ssl3.c
@@ -289,6 +289,7 @@ CK_RV ssl3_mac_sign_update(STDLL_TokData_t *tokdata,
             goto done;
         }
         context->flag = TRUE;
+        ctx->state_unsaveable |= context->hash_context.state_unsaveable;
     }
 
 
@@ -485,7 +486,7 @@ CK_RV ssl3_mac_verify(STDLL_TokData_t *tokdata,
         rc = CKR_SIGNATURE_INVALID;
     }
 error:
-    sign_mgr_cleanup(&mac_ctx);
+    sign_mgr_cleanup(tokdata, sess, &mac_ctx);
 
     return rc;
 }
@@ -573,6 +574,7 @@ CK_RV ssl3_mac_verify_update(STDLL_TokData_t *tokdata,
             goto done;
         }
         context->flag = TRUE;
+        ctx->state_unsaveable |= context->hash_context.state_unsaveable;
     }
 
     rc = digest_mgr_digest_update(tokdata, sess, &context->hash_context,

--- a/usr/lib/common/new_host.c
+++ b/usr/lib/common/new_host.c
@@ -174,6 +174,7 @@ CK_RV ST_Initialize(API_Slot_t *sltp, CK_SLOT_ID SlotNumber,
         if (rc != 0) {
             sltp->FcnList = NULL;
             detach_shm(sltp->TokData, 0);
+            final_data_store(sltp->TokData);
             if (sltp->TokData)
                 free(sltp->TokData);
             sltp->TokData = NULL;
@@ -186,6 +187,7 @@ CK_RV ST_Initialize(API_Slot_t *sltp, CK_SLOT_ID SlotNumber,
     rc = load_token_data(sltp->TokData, SlotNumber);
     if (rc != CKR_OK) {
         sltp->FcnList = NULL;
+        final_data_store(sltp->TokData);
         if (sltp->TokData)
             free(sltp->TokData);
         sltp->TokData = NULL;
@@ -218,6 +220,7 @@ done:
             SC_Finalize(sltp->TokData, SlotNumber, sinfp, NULL, 0);
         } else {
             CloseXProcLock(sltp->TokData);
+            final_data_store(sltp->TokData);
             free(sltp->TokData);
             sltp->TokData = NULL;
         }

--- a/usr/lib/common/sess_mgr.c
+++ b/usr/lib/common/sess_mgr.c
@@ -243,32 +243,62 @@ CK_RV session_mgr_close_session(STDLL_TokData_t *tokdata,
     if (sess->find_list)
         free(sess->find_list);
 
-    if (sess->encr_ctx.context)
-        free(sess->encr_ctx.context);
+    if (sess->encr_ctx.context) {
+        if (sess->encr_ctx.context_free_func != NULL)
+            sess->encr_ctx.context_free_func(tokdata, sess,
+                                             sess->encr_ctx.context,
+                                             sess->encr_ctx.context_len);
+        else
+            free(sess->encr_ctx.context);
+    }
 
     if (sess->encr_ctx.mech.pParameter)
         free(sess->encr_ctx.mech.pParameter);
 
-    if (sess->decr_ctx.context)
-        free(sess->decr_ctx.context);
+    if (sess->decr_ctx.context) {
+        if (sess->decr_ctx.context_free_func != NULL)
+            sess->decr_ctx.context_free_func(tokdata, sess,
+                                             sess->decr_ctx.context,
+                                             sess->decr_ctx.context_len);
+        else
+            free(sess->decr_ctx.context);
+    }
 
     if (sess->decr_ctx.mech.pParameter)
         free(sess->decr_ctx.mech.pParameter);
 
-    if (sess->digest_ctx.context)
-        free(sess->digest_ctx.context);
+    if (sess->digest_ctx.context) {
+        if (sess->digest_ctx.context_free_func != NULL)
+            sess->digest_ctx.context_free_func(tokdata, sess,
+                                               sess->digest_ctx.context,
+                                               sess->digest_ctx.context_len);
+        else
+            free(sess->digest_ctx.context);
+    }
 
     if (sess->digest_ctx.mech.pParameter)
         free(sess->digest_ctx.mech.pParameter);
 
-    if (sess->sign_ctx.context)
-        free(sess->sign_ctx.context);
+    if (sess->sign_ctx.context) {
+        if (sess->sign_ctx.context_free_func != NULL)
+            sess->sign_ctx.context_free_func(tokdata, sess,
+                                             sess->sign_ctx.context,
+                                             sess->sign_ctx.context_len);
+        else
+            free(sess->sign_ctx.context);
+    }
 
     if (sess->sign_ctx.mech.pParameter)
         free(sess->sign_ctx.mech.pParameter);
 
-    if (sess->verify_ctx.context)
-        free(sess->verify_ctx.context);
+    if (sess->verify_ctx.context) {
+        if (sess->verify_ctx.context_free_func != NULL)
+            sess->verify_ctx.context_free_func(tokdata, sess,
+                                               sess->verify_ctx.context,
+                                               sess->verify_ctx.context_len);
+        else
+            free(sess->verify_ctx.context);
+    }
 
     if (sess->verify_ctx.mech.pParameter)
         free(sess->verify_ctx.mech.pParameter);
@@ -323,32 +353,62 @@ void session_free(STDLL_TokData_t *tokdata, void *node_value,
     if (sess->find_list)
         free(sess->find_list);
 
-    if (sess->encr_ctx.context)
-        free(sess->encr_ctx.context);
+    if (sess->encr_ctx.context) {
+        if (sess->encr_ctx.context_free_func != NULL)
+            sess->encr_ctx.context_free_func(tokdata, sess,
+                                             sess->encr_ctx.context,
+                                             sess->encr_ctx.context_len);
+        else
+            free(sess->encr_ctx.context);
+    }
 
     if (sess->encr_ctx.mech.pParameter)
         free(sess->encr_ctx.mech.pParameter);
 
-    if (sess->decr_ctx.context)
-        free(sess->decr_ctx.context);
+    if (sess->decr_ctx.context) {
+        if (sess->decr_ctx.context_free_func != NULL)
+            sess->decr_ctx.context_free_func(tokdata, sess,
+                                             sess->decr_ctx.context,
+                                             sess->decr_ctx.context_len);
+        else
+            free(sess->decr_ctx.context);
+    }
 
     if (sess->decr_ctx.mech.pParameter)
         free(sess->decr_ctx.mech.pParameter);
 
-    if (sess->digest_ctx.context)
-        free(sess->digest_ctx.context);
+    if (sess->digest_ctx.context) {
+        if (sess->digest_ctx.context_free_func != NULL)
+            sess->digest_ctx.context_free_func(tokdata, sess,
+                                               sess->digest_ctx.context,
+                                               sess->digest_ctx.context_len);
+        else
+            free(sess->digest_ctx.context);
+    }
 
     if (sess->digest_ctx.mech.pParameter)
         free(sess->digest_ctx.mech.pParameter);
 
-    if (sess->sign_ctx.context)
-        free(sess->sign_ctx.context);
+    if (sess->sign_ctx.context) {
+        if (sess->sign_ctx.context_free_func != NULL)
+            sess->sign_ctx.context_free_func(tokdata, sess,
+                                             sess->sign_ctx.context,
+                                             sess->sign_ctx.context_len);
+        else
+            free(sess->sign_ctx.context);
+    }
 
     if (sess->sign_ctx.mech.pParameter)
         free(sess->sign_ctx.mech.pParameter);
 
-    if (sess->verify_ctx.context)
-        free(sess->verify_ctx.context);
+    if (sess->verify_ctx.context) {
+        if (sess->verify_ctx.context_free_func != NULL)
+            sess->verify_ctx.context_free_func(tokdata, sess,
+                                               sess->verify_ctx.context,
+                                               sess->verify_ctx.context_len);
+        else
+            free(sess->verify_ctx.context);
+    }
 
     if (sess->verify_ctx.mech.pParameter)
         free(sess->verify_ctx.mech.pParameter);
@@ -480,6 +540,10 @@ CK_RV session_mgr_get_op_state(SESSION *sess,
     active_ops = 0;
 
     if (sess->encr_ctx.active == TRUE) {
+        if (sess->encr_ctx.state_unsaveable) {
+            TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
+            return CKR_STATE_UNSAVEABLE;
+        }
         active_ops++;
         if (op_data != NULL) {
             TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
@@ -524,6 +588,10 @@ CK_RV session_mgr_get_op_state(SESSION *sess,
     }
 
     if (sess->decr_ctx.active == TRUE) {
+        if (sess->decr_ctx.state_unsaveable) {
+            TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
+            return CKR_STATE_UNSAVEABLE;
+        }
         active_ops++;
         if (op_data != NULL) {
             TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
@@ -568,6 +636,10 @@ CK_RV session_mgr_get_op_state(SESSION *sess,
     }
 
     if (sess->digest_ctx.active == TRUE) {
+        if (sess->digest_ctx.state_unsaveable) {
+            TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
+            return CKR_STATE_UNSAVEABLE;
+        }
         active_ops++;
         if (op_data != NULL) {
             TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
@@ -612,6 +684,10 @@ CK_RV session_mgr_get_op_state(SESSION *sess,
     }
 
     if (sess->sign_ctx.active == TRUE) {
+        if (sess->sign_ctx.state_unsaveable) {
+            TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
+            return CKR_STATE_UNSAVEABLE;
+        }
         active_ops++;
         if (op_data != NULL) {
             TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
@@ -656,6 +732,10 @@ CK_RV session_mgr_get_op_state(SESSION *sess,
     }
 
     if (sess->verify_ctx.active == TRUE) {
+        if (sess->verify_ctx.state_unsaveable) {
+            TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
+            return CKR_STATE_UNSAVEABLE;
+        }
         active_ops++;
         if (op_data != NULL) {
             TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
@@ -711,7 +791,7 @@ CK_RV session_mgr_get_op_state(SESSION *sess,
 
 //
 //
-CK_RV session_mgr_set_op_state(SESSION *sess,
+CK_RV session_mgr_set_op_state(STDLL_TokData_t *tokdata, SESSION *sess,
                                CK_OBJECT_HANDLE encr_key,
                                CK_OBJECT_HANDLE auth_key,
                                CK_BYTE *data, CK_ULONG data_len)
@@ -891,19 +971,19 @@ CK_RV session_mgr_set_op_state(SESSION *sess,
     // state information looks okay.  cleanup the current session state, first
     //
     if (sess->encr_ctx.active)
-        encr_mgr_cleanup(&sess->encr_ctx);
+        encr_mgr_cleanup(tokdata, sess, &sess->encr_ctx);
 
     if (sess->decr_ctx.active)
-        decr_mgr_cleanup(&sess->decr_ctx);
+        decr_mgr_cleanup(tokdata, sess, &sess->decr_ctx);
 
     if (sess->digest_ctx.active)
-        digest_mgr_cleanup(&sess->digest_ctx);
+        digest_mgr_cleanup(tokdata, sess, &sess->digest_ctx);
 
     if (sess->sign_ctx.active)
-        sign_mgr_cleanup(&sess->sign_ctx);
+        sign_mgr_cleanup(tokdata, sess, &sess->sign_ctx);
 
     if (sess->verify_ctx.active)
-        verify_mgr_cleanup(&sess->verify_ctx);
+        verify_mgr_cleanup(tokdata, sess, &sess->verify_ctx);
 
 
     // copy the new state information

--- a/usr/lib/common/sign_mgr.c
+++ b/usr/lib/common/sign_mgr.c
@@ -805,7 +805,8 @@ done:
 
 //
 //
-CK_RV sign_mgr_cleanup(SIGN_VERIFY_CONTEXT *ctx)
+CK_RV sign_mgr_cleanup(STDLL_TokData_t *tokdata, SESSION *sess,
+                       SIGN_VERIFY_CONTEXT *ctx)
 {
     if (!ctx) {
         TRACE_ERROR("Invalid function argument.\n");
@@ -821,6 +822,7 @@ CK_RV sign_mgr_cleanup(SIGN_VERIFY_CONTEXT *ctx)
     ctx->recover = FALSE;
     ctx->context_len = 0;
     ctx->pkey_active = FALSE;
+    ctx->state_unsaveable = FALSE;
 
     if (ctx->mech.pParameter) {
         free(ctx->mech.pParameter);
@@ -828,9 +830,14 @@ CK_RV sign_mgr_cleanup(SIGN_VERIFY_CONTEXT *ctx)
     }
 
     if (ctx->context) {
-        free(ctx->context);
+        if (ctx->context_free_func != NULL)
+            ctx->context_free_func(tokdata, sess, ctx->context,
+                                   ctx->context_len);
+        else
+            free(ctx->context);
         ctx->context = NULL;
     }
+    ctx->context_free_func = NULL;
 
     return CKR_OK;
 }

--- a/usr/lib/common/sw_crypt.c
+++ b/usr/lib/common/sw_crypt.c
@@ -32,51 +32,6 @@ CK_RV sw_des3_cbc(CK_BYTE *in_data,
                   CK_ULONG *out_data_len,
                   CK_BYTE *init_v, CK_BYTE *key_value, CK_BYTE encrypt)
 {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-    DES_key_schedule des_key1;
-    DES_key_schedule des_key2;
-    DES_key_schedule des_key3;
-
-    const_DES_cblock key_SSL1, key_SSL2, key_SSL3;
-    DES_cblock ivec;
-
-    // the des decrypt will only fail if the data length is not evenly divisible
-    // by DES_BLOCK_SIZE
-    if (in_data_len % DES_BLOCK_SIZE) {
-        TRACE_ERROR("%s\n", ock_err(ERR_DATA_LEN_RANGE));
-        return CKR_DATA_LEN_RANGE;
-    }
-    // The key as passed in is a 24 byte string containing 3 keys
-    // pick it apart and create the key schedules
-    memcpy(&key_SSL1, key_value, (size_t) 8);
-    memcpy(&key_SSL2, key_value + 8, (size_t) 8);
-    memcpy(&key_SSL3, key_value + 16, (size_t) 8);
-    DES_set_key_unchecked(&key_SSL1, &des_key1);
-    DES_set_key_unchecked(&key_SSL2, &des_key2);
-    DES_set_key_unchecked(&key_SSL3, &des_key3);
-
-    memcpy(ivec, init_v, sizeof(ivec));
-
-    // Encrypt or decrypt the data
-    if (encrypt) {
-        DES_ede3_cbc_encrypt(in_data,
-                             out_data,
-                             in_data_len,
-                             &des_key1,
-                             &des_key2, &des_key3, &ivec, DES_ENCRYPT);
-        *out_data_len = in_data_len;
-    } else {
-        DES_ede3_cbc_encrypt(in_data,
-                             out_data,
-                             in_data_len,
-                             &des_key1,
-                             &des_key2, &des_key3, &ivec, DES_DECRYPT);
-
-        *out_data_len = in_data_len;
-    }
-
-    return CKR_OK;
-#else
     CK_RV rc;
     int outlen;
     const EVP_CIPHER *cipher = EVP_des_ede3_cbc();
@@ -109,7 +64,6 @@ CK_RV sw_des3_cbc(CK_BYTE *in_data,
 done:
     EVP_CIPHER_CTX_free(ctx);
     return rc;
-#endif
 }
 
 CK_RV sw_aes_cbc(CK_BYTE *in_data,
@@ -119,33 +73,6 @@ CK_RV sw_aes_cbc(CK_BYTE *in_data,
                  CK_BYTE *init_v, CK_BYTE *key_value, CK_ULONG keylen,
                  CK_BYTE encrypt)
 {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-    AES_KEY aes_key;
-
-    UNUSED(out_data_len); //XXX can this parameter be removed ?
-
-    memset(&aes_key, 0, sizeof(aes_key));
-
-    // the aes decrypt will only fail if the data length is not evenly divisible
-    // by AES_BLOCK_SIZE
-    if (in_data_len % AES_BLOCK_SIZE) {
-        TRACE_ERROR("%s\n", ock_err(ERR_DATA_LEN_RANGE));
-        return CKR_DATA_LEN_RANGE;
-    }
-
-    // Encrypt or decrypt the data
-    if (encrypt) {
-        AES_set_encrypt_key(key_value, keylen * 8, &aes_key);
-        AES_cbc_encrypt(in_data, out_data, in_data_len, &aes_key,
-                        init_v, AES_ENCRYPT);
-    } else {
-        AES_set_decrypt_key(key_value, keylen * 8, &aes_key);
-        AES_cbc_encrypt(in_data,  out_data, in_data_len, &aes_key,
-                        init_v, AES_DECRYPT);
-    }
-
-    return CKR_OK;
-#else
     CK_RV rc;
     int outlen;
     const EVP_CIPHER *cipher = NULL;
@@ -187,5 +114,4 @@ CK_RV sw_aes_cbc(CK_BYTE *in_data,
 done:
     EVP_CIPHER_CTX_free(ctx);
     return rc;
-#endif
 }

--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -8091,7 +8091,7 @@ static CK_RV ep11_ende_crypt_init(STDLL_TokData_t * tokdata, SESSION * session,
         ctx->context_len = ep11_state_l;
         ctx->pkey_active = FALSE;
         if (rc != CKR_OK) {
-            decr_mgr_cleanup(ctx);
+            decr_mgr_cleanup(tokdata, session, ctx);
             rc = ep11_error_to_pkcs11_error(rc, session);
             TRACE_ERROR("%s m_DecryptInit rc=0x%lx blob_len=0x%zx "
                         "mech=0x%lx\n", __func__, rc, blob_len,
@@ -8124,7 +8124,7 @@ static CK_RV ep11_ende_crypt_init(STDLL_TokData_t * tokdata, SESSION * session,
         ctx->context_len = ep11_state_l;
         ctx->pkey_active = FALSE;
         if (rc != CKR_OK) {
-            encr_mgr_cleanup(ctx);
+            encr_mgr_cleanup(tokdata, session, ctx);
             rc = ep11_error_to_pkcs11_error(rc, session);
             TRACE_ERROR("%s m_EncryptInit rc=0x%lx blob_len=0x%zx "
                         "mech=0x%lx\n", __func__, rc, blob_len,

--- a/usr/lib/ep11_stdll/new_host.c
+++ b/usr/lib/ep11_stdll/new_host.c
@@ -164,6 +164,7 @@ CK_RV ST_Initialize(API_Slot_t *sltp, CK_SLOT_ID SlotNumber,
         if (rc != 0) {
             sltp->FcnList = NULL;
             detach_shm(sltp->TokData, 0);
+            final_data_store(sltp->TokData);
             if (sltp->TokData)
                 free(sltp->TokData);
             sltp->TokData = NULL;
@@ -176,6 +177,7 @@ CK_RV ST_Initialize(API_Slot_t *sltp, CK_SLOT_ID SlotNumber,
     rc = load_token_data(sltp->TokData, SlotNumber);
     if (rc != CKR_OK) {
         sltp->FcnList = NULL;
+        final_data_store(sltp->TokData);
         if (sltp->TokData)
             free(sltp->TokData);
         sltp->TokData = NULL;
@@ -208,6 +210,7 @@ done:
             SC_Finalize(sltp->TokData, SlotNumber, sinfp, NULL, 0);
         } else {
             CloseXProcLock(sltp->TokData);
+            final_data_store(sltp->TokData);
             free(sltp->TokData);
             sltp->TokData = NULL;
         }

--- a/usr/lib/ica_s390_stdll/ica_specific.c
+++ b/usr/lib/ica_s390_stdll/ica_specific.c
@@ -810,8 +810,10 @@ CK_RV token_specific_sha_init(STDLL_TokData_t *tokdata, DIGEST_CONTEXT *ctx,
     }
 
     /* (re)alloc ctx in one memory area */
-    if (ctx->context)
+    if (ctx->context) {
         free(ctx->context);
+        ctx->context_free_func = NULL;
+    }
     ctx->context_len = 0;
     ctx->context = malloc(ctxsize + devctxsize);
     if (ctx->context == NULL) {

--- a/usr/lib/ica_s390_stdll/ica_specific.c
+++ b/usr/lib/ica_s390_stdll/ica_specific.c
@@ -713,6 +713,9 @@ CK_RV token_specific_tdes_cmac(STDLL_TokData_t *tokdata, CK_BYTE *message,
     UNUSED(tokdata);
     UNUSED(ctx);
 
+    if (key == NULL)
+        return CKR_ARGUMENTS_BAD;
+
     // get the key type
     rc = template_attribute_get_ulong(key->template, CKA_KEY_TYPE, &keytype);
     if (rc != CKR_OK) {
@@ -3620,6 +3623,9 @@ CK_RV token_specific_aes_cmac(STDLL_TokData_t *tokdata, CK_BYTE *message,
 
     UNUSED(tokdata);
     UNUSED(ctx);
+
+    if (key == NULL)
+        return CKR_ARGUMENTS_BAD;
 
     rc = template_attribute_get_non_empty(key->template, CKA_VALUE, &attr);
     if (rc != CKR_OK) {

--- a/usr/lib/icsf_stdll/new_host.c
+++ b/usr/lib/icsf_stdll/new_host.c
@@ -162,6 +162,7 @@ CK_RV ST_Initialize(API_Slot_t *sltp, CK_SLOT_ID SlotNumber,
         if (rc != 0) {
             sltp->FcnList = NULL;
             detach_shm(sltp->TokData, 0);
+            final_data_store(sltp->TokData);
             if (sltp->TokData)
                 free(sltp->TokData);
             sltp->TokData = NULL;
@@ -174,6 +175,7 @@ CK_RV ST_Initialize(API_Slot_t *sltp, CK_SLOT_ID SlotNumber,
     rc = load_token_data(sltp->TokData, SlotNumber);
     if (rc != CKR_OK) {
         sltp->FcnList = NULL;
+        final_data_store(sltp->TokData);
         if (sltp->TokData)
             free(sltp->TokData);
         sltp->TokData = NULL;
@@ -206,6 +208,7 @@ done:
             SC_Finalize(sltp->TokData, SlotNumber, sinfp, NULL, 0);
         } else {
             CloseXProcLock(sltp->TokData);
+            final_data_store(sltp->TokData);
             free(sltp->TokData);
             sltp->TokData = NULL;
         }

--- a/usr/lib/icsf_stdll/pbkdf.c
+++ b/usr/lib/icsf_stdll/pbkdf.c
@@ -82,7 +82,6 @@ CK_RV encrypt_aes(CK_BYTE * inbuf, int inbuflen, CK_BYTE * dkey,
     const EVP_CIPHER *cipher = EVP_aes_256_cbc();
     int tmplen;
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
     EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
 
     EVP_EncryptInit_ex(ctx, cipher, NULL, dkey, iv);
@@ -98,24 +97,6 @@ CK_RV encrypt_aes(CK_BYTE * inbuf, int inbuflen, CK_BYTE * dkey,
     *outbuflen = (*outbuflen) + tmplen;
     EVP_CIPHER_CTX_free(ctx);
 
-#else
-    EVP_CIPHER_CTX ctx;
-    EVP_CIPHER_CTX_init(&ctx);
-
-    EVP_EncryptInit_ex(&ctx, cipher, NULL, dkey, iv);
-    if (!EVP_EncryptUpdate(&ctx, outbuf, outbuflen, inbuf, inbuflen)) {
-        TRACE_ERROR("EVP_EncryptUpdate failed.\n");
-        return CKR_FUNCTION_FAILED;
-    }
-    if (!EVP_EncryptFinal_ex(&ctx, outbuf + (*outbuflen), &tmplen)) {
-        TRACE_ERROR("EVP_EncryptFinal failed.\n");
-        return CKR_FUNCTION_FAILED;
-    }
-
-    *outbuflen = (*outbuflen) + tmplen;
-    EVP_CIPHER_CTX_cleanup(&ctx);
-#endif
-
     return CKR_OK;
 }
 
@@ -125,7 +106,6 @@ CK_RV decrypt_aes(CK_BYTE * inbuf, int inbuflen, CK_BYTE * dkey,
     int size;
     const EVP_CIPHER *cipher = EVP_aes_256_cbc();
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
     EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
 
     EVP_DecryptInit_ex(ctx, cipher, NULL, dkey, iv);
@@ -146,30 +126,6 @@ CK_RV decrypt_aes(CK_BYTE * inbuf, int inbuflen, CK_BYTE * dkey,
      */
 
     EVP_CIPHER_CTX_free(ctx);
-
-#else
-    EVP_CIPHER_CTX ctx;
-    EVP_CIPHER_CTX_init(&ctx);
-
-    EVP_DecryptInit_ex(&ctx, cipher, NULL, dkey, iv);
-    if (!EVP_DecryptUpdate(&ctx, outbuf, outbuflen, inbuf, inbuflen)) {
-        TRACE_ERROR("EVP_DecryptUpdate failed.\n");
-        return CKR_FUNCTION_FAILED;
-    }
-    if (!EVP_DecryptFinal_ex(&ctx, outbuf + (*outbuflen), &size)) {
-        TRACE_ERROR("EVP_DecryptFinal failed.\n");
-        return CKR_FUNCTION_FAILED;
-    }
-
-    /* total length of the decrypted data */
-    *outbuflen = (*outbuflen) + size;
-
-    /* EVP_DecryptFinal removes any padding. The final length
-     * is the length of the decrypted data without padding.
-     */
-
-    EVP_CIPHER_CTX_cleanup(&ctx);
-#endif
 
     return CKR_OK;
 }

--- a/usr/lib/soft_stdll/soft_specific.c
+++ b/usr/lib/soft_stdll/soft_specific.c
@@ -3994,6 +3994,9 @@ CK_RV token_specific_tdes_cmac(STDLL_TokData_t *tokdata, CK_BYTE *message,
     UNUSED(tokdata);
 
     if (first) {
+        if (key == NULL)
+            return CKR_ARGUMENTS_BAD;
+
         // get the key type
         rv = template_attribute_get_ulong(key->template, CKA_KEY_TYPE, &keytype);
         if (rv != CKR_OK) {
@@ -4194,6 +4197,9 @@ CK_RV token_specific_aes_cmac(STDLL_TokData_t *tokdata, CK_BYTE *message,
     UNUSED(tokdata);
 
     if (first) {
+        if (key == NULL)
+            return CKR_ARGUMENTS_BAD;
+
         // get the key value
         rc = template_attribute_get_non_empty(key->template, CKA_VALUE, &attr);
         if (rc != CKR_OK) {

--- a/usr/lib/tpm_stdll/tpm_specific.h
+++ b/usr/lib/tpm_stdll/tpm_specific.h
@@ -56,10 +56,10 @@
 /* retry count for generating software RSA keys */
 #define KEYGEN_RETRY    5
 
-RSA *openssl_gen_key(STDLL_TokData_t *);
-int openssl_write_key(STDLL_TokData_t *, RSA *, char *, CK_BYTE *);
-CK_RV openssl_read_key(STDLL_TokData_t *, char *, CK_BYTE *, RSA **);
-int openssl_get_modulus_and_prime(RSA *, unsigned int *, unsigned char *,
+EVP_PKEY *openssl_gen_key(STDLL_TokData_t *);
+int openssl_write_key(STDLL_TokData_t *, EVP_PKEY *, char *, CK_BYTE *);
+CK_RV openssl_read_key(STDLL_TokData_t *, char *, CK_BYTE *, EVP_PKEY **);
+int openssl_get_modulus_and_prime(EVP_PKEY *, unsigned int *, unsigned char *,
                                   unsigned int *, unsigned char *);
 int util_set_file_mode(char *, mode_t);
 CK_BYTE *util_create_id(int);

--- a/usr/sbin/p11sak/p11sak.c
+++ b/usr/sbin/p11sak/p11sak.c
@@ -2036,13 +2036,16 @@ static CK_RV generate_asymmetric_key(CK_SESSION_HANDLE session, CK_SLOT_ID slot,
                                      char *label, char *attr_string)
 {
     CK_OBJECT_HANDLE pub_keyh, prv_keyh;
-    CK_ATTRIBUTE pub_attr[KEY_MAX_BOOL_ATTR_COUNT + 2] = { 0 };
+    CK_ATTRIBUTE pub_attr[KEY_MAX_BOOL_ATTR_COUNT + 2];
     CK_ULONG pub_acount = 0;
-    CK_ATTRIBUTE prv_attr[KEY_MAX_BOOL_ATTR_COUNT + 2] = { 0 };
+    CK_ATTRIBUTE prv_attr[KEY_MAX_BOOL_ATTR_COUNT + 2];
     CK_ULONG prv_acount = 0;
     CK_MECHANISM mech;
     CK_ULONG i;
     CK_RV rc;
+
+    memset(pub_attr, 0, sizeof(pub_attr));
+    memset(prv_attr, 0, sizeof(prv_attr));
 
     if (kt == kt_RSAPKCS) {
         rc = read_rsa_args((CK_ULONG) keylength, exponent, pub_attr,


### PR DESCRIPTION
A series of patches that remove any OpenSSL functions that are deprecated with OpenSSL 3.0.
At some places conditional compile is used to have OpenSSL 1.1.1 specific code and OpenSSL 30 specific code separated, other places are changed so that it works for both versions.

While at it, remove support for OpenSSL versions older than v1.1.1. 

This addresses issue https://github.com/opencryptoki/opencryptoki/issues/415 .

Please note that although deprecated functions are supposed to continue to function as before, this is not entirely true for OpenSSL 3.0.  The Soft token uses functions `EVP_MD_meth_get_app_datasize()` and `EVP_MD_CTX_md_data()` to get and set the digests state in-between C_DigestInit, C_DigestUpdate, C_DigestFiinal. This works with OpenSSL 1.1.1 (although its somewhat of a hack...), but it no longer works with OpenSSL 3.0. `EVP_MD_meth_get_app_datasize()` always returns 0 which leads to the fact that no digest state is saved at all. Thus, any multipart digest operation will produce wrong output. 

This part of the code is reworked so that it works with OpenSSL 3.0, however, it is not possible with OpenSSL 3.0 to export the digest state in a way so that it could be obtained via `C_GetOperationState()`.
A token must therefore place pointers to OpenSSL digest contexts into the session state structure.
Such a state can not be externalized through `C_GetOperationState()`. `CKR_STATE_UNSAVEABLE` is returned by `C_GetOperationState()`. if such unsavable state is used by a token.
