### PR TITLE
[COMMON,ICSF] Fix permission of token SHM segment.

### DIFF
--- a/usr/lib/common/utility.c
+++ b/usr/lib/common/utility.c
@@ -663,7 +663,7 @@ CK_RV attach_shm(STDLL_TokData_t *tokdata, CK_SLOT_ID slot_id)
         rc = CKR_FUNCTION_FAILED;
         goto err;
     }
-    ret = sm_open(buf, 0666, (void **) shm, sizeof(**shm), 0);
+    ret = sm_open(buf, 0660, (void **) shm, sizeof(**shm), 0);
     if (ret < 0) {
         TRACE_DEVEL("sm_open failed.\n");
         rc = CKR_FUNCTION_FAILED;

--- a/usr/lib/icsf_stdll/icsf_specific.c
+++ b/usr/lib/icsf_stdll/icsf_specific.c
@@ -507,7 +507,7 @@ CK_RV token_specific_attach_shm(STDLL_TokData_t * tokdata, CK_SLOT_ID slot_id)
      * exists. When the it's created (ret=0) the region is initialized with
      * zeroes.
      */
-    ret = sm_open(shm_id, 0666, (void **) &ptr, len, 1);
+    ret = sm_open(shm_id, 0660, (void **) &ptr, len, 1);
     if (ret < 0) {
         TRACE_ERROR("Failed to open shared memory \"%s\".\n", shm_id);
         rc = CKR_FUNCTION_FAILED;


### PR DESCRIPTION
The shm token segments were generated with permission 0666 for the user that
created the segment and the corresponding primary group.  This is potentially
a security problem since especially the segmant was word-rw.

This patch changes the permission to 0660 and changes the ownership of the
segment on creation to group "pkcs11".  Since every user that should be
allowed to use OCK has to be in that group, we should not have any usage
regressions.  If the segments already exist, a reboot might be necessary (or
any other way that cleans up the segments).

Signed-off-by: Juergen Christ <jchrist@linux.ibm.com>