### PR TITLE
[TEST] Allow to specify which slot should be traced.

### DIFF
--- a/testcases/ock_tests.sh.in
+++ b/testcases/ock_tests.sh.in
@@ -288,12 +288,18 @@ main_script()
         LOGFILE=1
     fi
 
+    # Turn space separated list into array
+    totrace=($OCK_TRACE_TOKENS)
+
     for i in $SLOT; do (
         echo "********** Testing Slot $i **********"
         check_slot $i || { echo "SKIPPING slot $i"; exit; }
         if [ $NONEED_TOKEN_INIT -eq 0 ]; then
             init_slot $i || { echo "SKIPPING slot $i"; exit; }
         fi
+        for item in "${totrace[@]}"; do
+            [[ "$i" == "$item" ]] && export OPENCRYPTOKI_TRACE_LEVEL=4
+        done
         if [ "$LOGFILE" = "1" ]; then
             echo "test output for slot $i stored in log-slot_$i.txt"
             run_tests $i > "log-slot_$i.txt" 2>&1


### PR DESCRIPTION
Introduce an environment variable OCK_TRACE_TOKENS to specify which slots
should be traced.  Set this environment variable to a space-separated list of
token numbers and the ock_test.sh driver will set OPENCRYPTOKI_TRACE_LEVEL to
4 before running tests on these slots.

Signed-off-by: Juergen Christ <jchrist@linux.ibm.com>