### PR TITLE
CI: Perform cleanup of left over EP11 sessions

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -231,6 +231,9 @@ ci-installcheck: ci-prepare installcheck
 	killall -HUP pkcsslotd
 	@echo "done"
 
+ci-cleanup:
+	cd ${srcdir}/testcases && PKCS11_USER_PIN=$(PKCS11_USER_PIN) PKCSLIB=@libdir@/opencryptoki/libopencryptoki.so ./cleanup_vhsm.exp 42
+
 ci-uninstall: uninstall
 	rm -f $(sysconfdir)/opencryptoki/ep11tok*.conf
 	rm -rf $(localstatedir)/lib/opencryptoki/*

--- a/Makefile.am
+++ b/Makefile.am
@@ -207,8 +207,8 @@ ci-prepare:
 	killall -HUP pkcsslotd || true
 	${srcdir}/testcases/ciconfig.sh "$(sysconfdir)/opencryptoki" "$(sysconfdir)/opencryptoki"
 	@sbindir@/pkcsslotd
-	for slot in `awk '/slot (.*)/ { print $$2; }' $(sysconfdir)/opencryptoki/opencryptoki.conf`; do @sbindir@/pkcsconf -c $$slot -t | grep "Flags:" | grep -q TOKEN_INITIALIZED || ${srcdir}/testcases/init_token.sh $$slot; done
-	cd ${srcdir}/testcases && ./init_vhsm.exp 42
+	for slot in `awk '/slot (.*)/ { print $$2; }' $(sysconfdir)/opencryptoki/opencryptoki.conf`; do @sbindir@/pkcsconf -c $$slot -t | grep "Flags:" | grep -q TOKEN_INITIALIZED || PKCS11_USER_PIN=$(PKCS11_USER_PIN) PKCS11_SO_PIN=$(PKCS11_SO_PIN) PKCSLIB=@libdir@/opencryptoki/libopencryptoki.so ${srcdir}/testcases/init_token.sh $$slot; done
+	cd ${srcdir}/testcases && PKCS11_USER_PIN=$(PKCS11_USER_PIN) PKCS11_VHSM_PIN=$(PKCS11_VHSM_PIN) PKCSLIB=@libdir@/opencryptoki/libopencryptoki.so ./init_vhsm.exp 42
 	echo "VHSM_MODE" >> "$(sysconfdir)/opencryptoki/ep11tok42.conf"
 
 installcheck-local: all

--- a/testcases/cleanup_vhsm.exp.in
+++ b/testcases/cleanup_vhsm.exp.in
@@ -1,0 +1,25 @@
+#!/usr/bin/expect -f
+#
+# COPYRIGHT (c) International Business Machines Corp. 2001-2017
+#
+# This program is provided under the terms of the Common Public License,
+# version 1.0 (CPL-1.0). Any use, reproduction or distribution for this software
+# constitutes recipient's acceptance of CPL-1.0 terms which can be found
+# in the file LICENSE file or at https://opensource.org/licenses/cpl1.0.php
+#
+
+spawn @sbindir@/pkcsep11_session logout -force -slot [lindex $argv 0]
+expect {
+    "Enter the USER PIN:" { sleep .1; send $env(PKCS11_USER_PIN); send "\r"; }
+    eof { send_user "Unexpected EOF on user pin\n"; exit 1 }
+    timeout { send_user "Timeout on user pin\n"; exit 1 }
+}
+expect {
+    "EP11-Sessions logged out" {}
+    eof { send_user "Unexpected EOF at the end\n"; exit 1 }
+    timeout { send_user "Unexpected timeout at the end\n"; exit 1 }
+}
+expect {
+    eof {}
+    timeout { send_user "Unexpected timeout at the end\n"; exit 1 }
+}

--- a/testcases/init_token.sh.in
+++ b/testcases/init_token.sh.in
@@ -29,11 +29,11 @@ expect {
     default { send_user "Error sending SO PIN during SO PIN setting\n"; exit 1 }
 }
 expect {
-    "Enter the new SO PIN: " { sleep .1; send "76543210\r"; }
+    "Enter the new SO PIN: " { sleep .1; send $env(PKCS11_SO_PIN); send "\r"; }
     default { send_user "Error sending new SO PIN during SO PIN setting\n"; exit 1 }
 }
 expect {
-    "Re-enter the new SO PIN: " { sleep .1; send "76543210\r"; }
+    "Re-enter the new SO PIN: " { sleep .1; send $env(PKCS11_SO_PIN); send "\r"; }
     default { send_user "Error resending new SO PIN during SO PIN setting\n"; exit 1 }
 }
 expect {
@@ -44,7 +44,7 @@ expect {
 
 spawn @sbindir@/pkcsconf -c [lindex $argv 0] -u
 expect {
-    "Enter the SO PIN: " { sleep .1; send "76543210\r"; }
+    "Enter the SO PIN: " { sleep .1; send $env(PKCS11_SO_PIN); send "\r"; }
     default { send_user "Error sending SO PIN during user PIN initialization\n"; exit 1 }
 }
 expect {
@@ -67,11 +67,11 @@ expect {
     default { send_user "Error sending user PIN during user PIN setting\n"; exit 1 }
 }
 expect {
-    "Enter the new user PIN: " { sleep .1; send "01234567\r"; }
+    "Enter the new user PIN: " { sleep .1; send $env(PKCS11_USER_PIN); send "\r"; }
     default { send_user "Error sending new user PIN during user PIN setting\n"; exit 1 }
 }
 expect {
-    "Re-enter the new user PIN: " { sleep .1; send "01234567\r"; }
+    "Re-enter the new user PIN: " { sleep .1; send $env(PKCS11_USER_PIN); send "\r"; }
     default { send_user "Error resending new user PIN during user PIN setting\n"; exit 1 }
 }
 expect {

--- a/testcases/init_vhsm.exp.in
+++ b/testcases/init_vhsm.exp.in
@@ -10,12 +10,12 @@
 
 spawn @sbindir@/pkcsep11_session vhsmpin -slot [lindex $argv 0]
 expect {
-    "Enter the USER PIN:" { sleep .1; send "01234567\r"; }
+    "Enter the USER PIN:" { sleep .1; send $env(PKCS11_USER_PIN); send "\r"; }
     eof { send_user "Unexpected EOF on user pin\n"; exit 1 }
     timeout { send_user "Timeout on user pin\n"; exit 1 }
 }
 expect {
-    "Enter the new VHSM PIN:" { sleep .1; send "0123456789\r"; }
+    "Enter the new VHSM PIN:" { sleep .1; send $env(PKCS11_VHSM_PIN); send "\r"; }
     eof { send_user "Unexpected EOF on VHSM pin\n"; exit 1 }
     timeout { send_user "Timeout on VHSM pin\n"; exit 1 }
 }

--- a/testcases/init_vhsm.exp.in
+++ b/testcases/init_vhsm.exp.in
@@ -20,7 +20,11 @@ expect {
     timeout { send_user "Timeout on VHSM pin\n"; exit 1 }
 }
 expect {
-    "VHSM-pin successfully set." { exit 0 }
+    "VHSM-pin successfully set." {}
     eof { send_user "Unexpected EOF at the end\n"; exit 1 }
+    timeout { send_user "Unexpected timeout at the end\n"; exit 1 }
+}
+expect {
+    eof {}
     timeout { send_user "Unexpected timeout at the end\n"; exit 1 }
 }

--- a/testcases/testcases.mk
+++ b/testcases/testcases.mk
@@ -12,9 +12,9 @@ include testcases/misc_tests/misc_tests.mk
 include testcases/pkcs11/pkcs11.mk
 include testcases/build/build.mk
 
-noinst_SCRIPTS += testcases/ock_tests.sh testcases/init_token.sh testcases/init_vhsm.exp
-CLEANFILES += testcases/ock_tests.sh testcases/init_token.sh testcases/init_vhsm.exp
-EXTRA_DIST += testcases/ock_tests.sh.in testcases/init_token.sh.in testcases/init_vhsm.exp.in
+noinst_SCRIPTS += testcases/ock_tests.sh testcases/init_token.sh testcases/init_vhsm.exp testcases/cleanup_vhsm.exp
+CLEANFILES += testcases/ock_tests.sh testcases/init_token.sh testcases/init_vhsm.exp testcases/cleanup_vhsm.exp
+EXTRA_DIST += testcases/ock_tests.sh.in testcases/init_token.sh.in testcases/init_vhsm.exp.in testcases/cleanup_vhsm.exp.in
 
 testcases/ock_tests.sh: testcases/ock_tests.sh.in
 	@SED@	-e s!\@sysconfdir\@!"@sysconfdir@"!g			\
@@ -31,6 +31,13 @@ testcases/init_token.sh: testcases/init_token.sh.in
 	mv $@-t $@
 
 testcases/init_vhsm.exp: testcases/init_vhsm.exp.in
+	@SED@	-e s!\@localstatedir\@!"@localstatedir@"!g		\
+		-e s!\@sbindir\@!"@sbindir@"!g				\
+		-e s!\@libdir\@!"@libdir@"!g < $< > $@-t
+	@CHMOD@ a+x $@-t
+	mv $@-t $@
+
+testcases/cleanup_vhsm.exp: testcases/cleanup_vhsm.exp.in
 	@SED@	-e s!\@localstatedir\@!"@localstatedir@"!g		\
 		-e s!\@sbindir\@!"@sbindir@"!g				\
 		-e s!\@libdir\@!"@libdir@"!g < $< > $@-t


### PR DESCRIPTION
Allow to cleanup left over EP11 sessions for CI runs via 'make ci-cleanup'. This is to be called by the CI after 'make ci-installcheck', and before pkcsslotd is terminated.