### PR TITLE
Fix compile error

### DIFF
--- a/usr/lib/common/shared_memory.c
+++ b/usr/lib/common/shared_memory.c
@@ -37,6 +37,7 @@
 #include "host_defs.h"
 #include "h_extern.h"
 #include "trace.h"
+#include "ock_syslog.h"
 
 #include "shared_memory.h"
 


### PR DESCRIPTION
usr/lib/common/shared_memory.c:229:9: warning: implicit declaration of function
‘OCK_SYSLOG’; did you mean ‘LOG_SYSLOG’? [-Wimplicit-function-declaration]
   229 |         OCK_SYSLOG(LOG_ERR,
       |         ^~~~~~~~~~

/usr/bin/ld:
usr/lib/common/sbin_pkcscca_pkcscca-shared_memory.o: in function `sm_open':
undefined reference to `OCK_SYSLOG'
collect2: error: ld returned 1 exit status

Signed-off-by: Ingo Franzki <ifranzki@linux.ibm.com>