### PR TITLE
CI: Fix ci-cleanup target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -232,7 +232,10 @@ ci-installcheck: ci-prepare installcheck
 	@echo "done"
 
 ci-cleanup:
+	killall -HUP pkcsslotd || true
+	@sbindir@/pkcsslotd
 	cd ${srcdir}/testcases && PKCS11_USER_PIN=$(PKCS11_USER_PIN) PKCSLIB=@libdir@/opencryptoki/libopencryptoki.so ./cleanup_vhsm.exp 42
+	killall -HUP pkcsslotd
 
 ci-uninstall: uninstall
 	rm -f $(sysconfdir)/opencryptoki/ep11tok*.conf


### PR DESCRIPTION
Target ci-installcheck stopped the pkcsslotd, so restart it before running cleanup_vhsm.exp and stop it afterwards.