### PR TITLE
Update travis from Ubuntu 18.04 LTS to Ubuntu 20.04 LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: bionic
+dist: focal
 
 language: c
 


### PR DESCRIPTION
We require OpenSSL >= 1.1.1 now.

Signed-off-by: Patrick Steuer <patrick.steuer@de.ibm.com>