### PR TITLE
[EP11] Fix memory leak reported by LSAN

### DIFF
--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -3323,12 +3323,7 @@ static CK_RV import_DSA_key(STDLL_TokData_t * tokdata, SESSION * sess,
 
         /*
          * Builds the DER encoding (ansi_x962) SPKI.
-         * (get the length first)
          */
-        rc = ber_encode_DSAPublicKey(TRUE, &data, &data_len,
-                                     prime, subprime, base, value);
-        data = malloc(data_len);
-
         rc = ber_encode_DSAPublicKey(FALSE, &data, &data_len,
                                      prime, subprime, base, value);
         if (rc != CKR_OK) {

--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -782,6 +782,8 @@ done:
 
     if (blob_attr)
         free(blob_attr);
+    if (pkey_attr)
+        free(pkey_attr);
 
     put_target_info(tokdata, target_info);
 

--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -3128,12 +3128,7 @@ static CK_RV import_EC_key(STDLL_TokData_t * tokdata, SESSION * sess,
 
         /*
          * Builds the DER encoding (ansi_x962) SPKI.
-         * (get the length first)
          */
-        rc = ber_encode_ECPublicKey(TRUE, &data, &data_len,
-                                    ec_params, &ec_point_uncompr);
-        data = malloc(data_len);
-
         rc = ber_encode_ECPublicKey(FALSE, &data, &data_len,
                                     ec_params, &ec_point_uncompr);
         free(ecpoint);

--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -3502,11 +3502,7 @@ static CK_RV import_DH_key(STDLL_TokData_t * tokdata, SESSION * sess,
 
         /*
          * Builds the DER encoding (ansi_x962) SPKI.
-         * (get the length first)
          */
-        rc = ber_encode_DHPublicKey(TRUE, &data, &data_len, prime, base, value);
-        data = malloc(data_len);
-
         rc = ber_encode_DHPublicKey(FALSE, &data, &data_len,
                                     prime, base, value);
         if (rc != CKR_OK) {
@@ -5305,24 +5301,18 @@ CK_RV ep11tok_derive_key(STDLL_TokData_t * tokdata, SESSION * session,
         goto error;
     }
 
-    if (allocated && ecpoint != NULL)
-        free(ecpoint);
-
-    object_put(tokdata, base_key_obj, TRUE);
-    base_key_obj = NULL;
-
-    return rc;
-
+    goto out;
 error:
     if (key_obj)
         object_free(key_obj);
     *handle = 0;
-    if (new_attrs)
-        free_attribute_array(new_attrs, new_attrs_len);
+ out:
     if (opaque_attr != NULL)
         free(opaque_attr);
     if (chk_attr != NULL)
         free(chk_attr);
+    if (new_attrs)
+        free_attribute_array(new_attrs, new_attrs_len);
     if (new_attrs2)
         free_attribute_array(new_attrs2, new_attrs2_len);
     if (allocated && ecpoint != NULL)

--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -5040,14 +5040,14 @@ CK_RV ep11tok_derive_key(STDLL_TokData_t * tokdata, SESSION * session,
 
             ecdh1_parms2 = *ecdh1_parms;
 
-            rc = h_opaque_2_blob(tokdata, hBaseKey, &keyblob, &keyblobsize,
-                                 &base_key_obj, READ_LOCK);
-            if (rc != CKR_OK) {
-                TRACE_ERROR("%s failed hBaseKey=0x%lx\n", __func__, hBaseKey);
-                return rc;
-            }
-
             if (mech->mechanism == CKM_ECDH1_DERIVE) {
+                rc = h_opaque_2_blob(tokdata, hBaseKey, &keyblob, &keyblobsize,
+                                     &base_key_obj, READ_LOCK);
+                if (rc != CKR_OK) {
+                    TRACE_ERROR("%s failed hBaseKey=0x%lx\n", __func__, hBaseKey);
+                    return rc;
+                }
+
                 rc = get_ecsiglen(base_key_obj, &privlen);
                 privlen /= 2;
 


### PR DESCRIPTION
LSAN on `pkcsconf -t` reported leak in EP11:

```
==571289==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 88 byte(s) in 1 object(s) allocated from:
    #0 0x3ff915b085d in __interceptor_malloc (/usr/lib64/libasan.so.6+0xb085d)
    #1 0x3ff89f191bf in build_attribute usr/lib/common/utility.c:520
    #2 0x3ff89f5c9d5 in ep11tok_pkey_skey2pkey usr/lib/ep11_stdll/ep11_specific.c:698
    #3 0x3ff89faedc7 in ep11tok_pkey_get_firmware_mk_vp usr/lib/ep11_stdll/ep11_specific.c:770
    #4 0x3ff89fb10ad in ep11tok_init usr/lib/ep11_stdll/ep11_specific.c:2639
    #5 0x3ff89f47987 in ST_Initialize usr/lib/ep11_stdll/new_host.c:163
    #6 0x3ff8c45a6a1 in DL_Load_and_Init usr/lib/api/apiutil.c:599
    #7 0x3ff8c452ea5 in C_Initialize usr/lib/api/api_interface.c:3009
    #8 0x100b9e7 in init usr/sbin/pkcsconf/pkcsconf.c:1145
    #9 0x100247b in main usr/sbin/pkcsconf/pkcsconf.c:186
    #10 0x3ff904abdb3 in __libc_start_main (/usr/lib64/libc.so.6+0x2bdb3)
    #11 0x1003aad  (/usr/local/sbin/pkcsconf+0x1003aad)
```

Signed-off-by: Juergen Christ <jchrist@linux.ibm.com>