### PR TITLE
Testcases: EP11 can't derive keys <= 8 bytes on a CEX5

### DIFF
--- a/testcases/common/common.c
+++ b/testcases/common/common.c
@@ -102,6 +102,10 @@ int check_supp_keysize(CK_SLOT_ID slot_id, CK_ULONG mechanism, CK_ULONG keylen)
     if (rc != CKR_OK)
         return FALSE;
 
+    /* min and max being zero indicate no key size limitation */
+    if (mech_info.ulMinKeySize == 0 && mech_info.ulMaxKeySize == 0)
+        return TRUE;
+
     return ((mech_info.ulMinKeySize <= keylen)
             && (keylen <= mech_info.ulMaxKeySize));
 }

--- a/testcases/crypto/ec_func.c
+++ b/testcases/crypto/ec_func.c
@@ -578,6 +578,18 @@ CK_RV run_DeriveECDHKey()
                                   der_ec_supported[i].name);
                     continue;
                 }
+                if (is_ep11_token(SLOT_ID) &&
+                    secret_key_len[k] > 0 && secret_key_len[k] <= 8) {
+                    /*
+                     * The CEX5P seems to have a firmware bug that hinders it
+                     * from deriving a valid EP11 key blob for a derived key
+                     * size <= 8. Skip this key sizes until the firmware bug
+                     * has been fixed.
+                     */
+                    testcase_skip("EP11 cannot provide %lu key bytes on a CEX5\n",
+                                   secret_key_len[k]);
+                    continue;
+                }
                 if (secret_key_len[k] == 0 &&
                     der_ec_supported[i].type == CURVE_MONTGOMERY) {
                     testcase_skip("Curve %s can not be used without the "


### PR DESCRIPTION
The CEX5P seems to have a firmware bug that hinders it from deriving a valid EP11 key blob for a derived key size <= 8. Enhance the testcases to identify situations where invalid/unusable key blobs are produced, but also skip tests the derive keys <= 8 bytes for the EP11 token until the firmware bug is resolved.

Note: For EP11, the smallest really usable CKK_GENERIC_SECRET key is 10 bytes anyway. AES or DES/3DES keys are larger. Keys of type CKK_GENERIC_SECRET can be used for HMAC mechanism only, and HMAC usually requires a minimum key size of digest-size / 2. For HMAC-SHA-1 the minimum key is therefore 20 / 2 = 10 bytes. This key size restriction an be lifted via control point XCP_CPB_KEYSZ_HMAC_ANY for EP11.
