### PR TITLE
Config: Add BARE constants and some bugfixes

### DIFF
--- a/usr/lib/config/config.mk
+++ b/usr/lib/config/config.mk
@@ -2,16 +2,15 @@ noinst_HEADERS += usr/lib/config/configuration.h usr/lib/config/cfglex.h usr/lib
 
 EXTRA_DIST += usr/lib/config/cfgparse.y usr/lib/config/cfglex.l
 
-BUILT_SOURCES += usr/lib/config/cfglex.h usr/lib/config/cfgparse.h	\
-		usr/lib/config/cfgparse.c
+BUILT_SOURCES += usr/lib/config/cfglex.c usr/lib/config/cfgparse.c
 
-usr/lib/config/cfglex.c: usr/lib/config/cfgparse.h
-usr/lib/config/cfgparse.c: usr/lib/config/cfglex.h
+usr/lib/config/cfglex.$(OBJEXT): usr/lib/config/cfgparse.h
+usr/lib/config/cfgparse.$(OBJEXT): usr/lib/config/cfglex.h
 
-usr/lib/config/cfgparse.c usr/lib/config/cfgparse.h usr/lib/config/cfgparse.output: usr/lib/config/cfgparse.y
+usr/lib/config/cfgparse.c: usr/lib/config/cfgparse.y
 	$(AM_V_YACC)$(am__skipyacc) $(SHELL) $(YLWRAP) $< cfgparse.tab.c usr/lib/config/cfgparse.c cfgparse.tab.h usr/lib/config/cfgparse.h cfgparse.output usr/lib/config/cfgparse.output -- $(YACCCOMPILE)
 
-usr/lib/config/cfglex.c usr/lib/config/cfglex.h: usr/lib/config/cfglex.l
+usr/lib/config/cfglex.c: usr/lib/config/cfglex.l
 	$(AM_V_LEX)$(am__skiplex) $(SHELL) $(YLWRAP) $< lex.config.c usr/lib/config/cfglex.c cfglex.h usr/lib/config/cfglex.h -- $(LEXCOMPILE)
 
 CLEANFILES += usr/lib/config/cfglex.c usr/lib/config/cfglex.h	\

--- a/usr/lib/config/configuration.c
+++ b/usr/lib/config/configuration.c
@@ -50,6 +50,9 @@ void confignode_free(struct ConfigBaseNode *n)
         case CT_BARE:
             confignode_freebare(confignode_to_bare(n));
             break;
+        case CT_BARECONST:
+            confignode_freebareconst(confignode_to_bareconst(n));
+            break;
         default:
             break;
         }
@@ -190,6 +193,8 @@ static void confignode_dump_i(FILE *fp, struct ConfigBaseNode *n,
             newatbol = 1;
             break;
         case CT_BARE:
+            /* Fallthrough */
+        case CT_BARECONST:
             fputs(i->key, fp);
             break;
         default:
@@ -451,6 +456,31 @@ confignode_allocbaredumpable(char *bareval, int line, char *comment)
             confignode_append(&(res->base), &(eoc->base));
         } else {
             confignode_freebare(res);
+            res = NULL;
+        }
+    } else {
+        free(dkey);
+    }
+    return res;
+}
+
+struct ConfigBareConstNode *
+confignode_allocbareconstdumpable(char *key, int line, char *comment)
+{
+    struct ConfigBareConstNode *res;
+    struct ConfigEOCNode *eoc;
+    char *dkey;
+
+    dkey = strdup(key);
+    if (!dkey)
+        return NULL;
+    res = confignode_allocbareconst(dkey, line);
+    if (res) {
+        eoc = confignode_alloceoc(comment ? strdup(comment) : NULL, line);
+        if (eoc) {
+            confignode_append(&(res->base), &(eoc->base));
+        } else {
+            confignode_freebareconst(res);
             res = NULL;
         }
     } else {

--- a/usr/lib/config/configuration.c
+++ b/usr/lib/config/configuration.c
@@ -164,8 +164,8 @@ static void confignode_dump_i(FILE *fp, struct ConfigBaseNode *n,
             break;
         case CT_VERSIONVAL:
             fprintf(fp, "%s = %d.%d", i->key,
-                    (confignode_to_versionval(i)->value & 0xff00) >> 16,
-                    confignode_to_versionval(i)->value & 0xff);
+                    (confignode_to_versionval(i)->value & 0xffff0000) >> 16,
+                    confignode_to_versionval(i)->value & 0xffff);
             break;
         case CT_BAREVAL:
             fprintf(fp, "%s = %s", i->key, confignode_to_bareval(i)->value);

--- a/usr/lib/config/configuration.h
+++ b/usr/lib/config/configuration.h
@@ -310,6 +310,7 @@ static inline void confignode_freebarelist(struct ConfigBareListNode *n)
     if (n) {
         free(n->base.key);
         confignode_deepfree(n->beforeOpen);
+        confignode_deepfree(n->value);
         free(n);
     }
 }


### PR DESCRIPTION
    The inital configlib commit did not include the possibility to use bare word
    constants.  This is needed, e.g., for the "disable-event-support" keyword of
    opencryptoki.conf.
    
    To support this, add ConfigNodeBareConst to keep the constant in the key
    without any further values in the node.  Also restructure the grammar:
    - Every configelem now takes care of the positions of comments _within_ and
    _after_ the element.
    - Since "after element i" is "before element (i+1)", the config element cannot
    take care of comments before the element (shift/reduce conflict since the
    parser cannot know if the comment is after element i or before element i+1).
    To alleviate this situation and preserve comments at the beginning of a file
    or a structure content, add a commentedconfigelemstar that only takes care of
    comments before the first configelem.  That should cover all comment
    positions.

   Fix incorrect version masks in dump of ConfigVersionValNode.

    confignode_deepfree did not free elements in BARELISTs causing memory leaks.

    BUILT_SOURCES should not contain the generated headers.  They are generated
    and updated via ylwrap which does a content comparison for all but the
    generated parser/lexer C sources.  If the inputs to bison or flex change but
    still produce the same header file, make install will regenerate the parser
    and lexer, recompile them, and relink all binaries that use the config lib.
    By using the generated C files in the BUILT_SOURCES variable we solve this
    problem since the C files are always updated by ylwrap (even if they did not
    change).
