### PR TITLE
ICA: Adjust min/max key sizes for RSA mechanisms according to libica's support

### DIFF
--- a/testcases/crypto/aes_func.c
+++ b/testcases/crypto/aes_func.c
@@ -1351,6 +1351,22 @@ CK_RV do_WrapUnwrapRSA(struct generated_test_suite_info * tsuite)
         goto testcase_cleanup;
     }
 
+    if (!mech_supported(slot_id, CKM_RSA_PKCS_KEY_PAIR_GEN)) {
+        testsuite_skip(3,
+                       "Slot %u doesn't support CKM_RSA_PKCS_KEY_PAIR_GEN",
+                       (unsigned int) slot_id);
+        goto testcase_cleanup;
+    }
+
+    rc = funcs->C_GetMechanismInfo(slot_id, CKM_RSA_PKCS_KEY_PAIR_GEN, &mech_info);
+    if (rc != CKR_OK) {
+        testcase_error("C_GetMechanismInfo rc=%s", p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    if (bits < mech_info.ulMinKeySize)
+        bits = mech_info.ulMinKeySize;
+
     for (i = 0; i < 3; i++) {
 
         testcase_begin("%s wrap/unwrap of RSA key for key length=%ld and pkey=%X.",
@@ -1575,6 +1591,21 @@ CK_RV do_WrapRSA_Err(struct generated_test_suite_info * tsuite)
         goto testcase_cleanup;
     }
 
+    if (!mech_supported(slot_id, CKM_RSA_PKCS_KEY_PAIR_GEN)) {
+        testsuite_skip(3,
+                       "Slot %u doesn't support CKM_RSA_PKCS_KEY_PAIR_GEN",
+                       (unsigned int) slot_id);
+        goto testcase_cleanup;
+    }
+
+    rc = funcs->C_GetMechanismInfo(slot_id, CKM_RSA_PKCS_KEY_PAIR_GEN, &mech_info);
+    if (rc != CKR_OK) {
+        testcase_error("C_GetMechanismInfo rc=%s", p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    if (bits < mech_info.ulMinKeySize)
+        bits = mech_info.ulMinKeySize;
 
     for (i = 0; i < 3; i++) {
 
@@ -1743,6 +1774,22 @@ CK_RV do_UnwrapRSA_Err(struct generated_test_suite_info * tsuite)
                        (unsigned int) slot_id);
         goto testcase_cleanup;
     }
+
+    if (!mech_supported(slot_id, CKM_RSA_PKCS_KEY_PAIR_GEN)) {
+        testsuite_skip(3,
+                       "Slot %u doesn't support CKM_RSA_PKCS_KEY_PAIR_GEN",
+                       (unsigned int) slot_id);
+        goto testcase_cleanup;
+    }
+
+    rc = funcs->C_GetMechanismInfo(slot_id, CKM_RSA_PKCS_KEY_PAIR_GEN, &mech_info);
+    if (rc != CKR_OK) {
+        testcase_error("C_GetMechanismInfo rc=%s", p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    if (bits < mech_info.ulMinKeySize)
+        bits = mech_info.ulMinKeySize;
 
     for (i = 0; i < 3; i++) {
 

--- a/usr/include/apictl.h
+++ b/usr/include/apictl.h
@@ -66,6 +66,7 @@ typedef struct {
 #if OPENSSL_VERSION_PREREQ(3, 0)
     OSSL_LIB_CTX *openssl_libctx;
     OSSL_PROVIDER *openssl_default_provider;
+    OSSL_PROVIDER *openssl_legacy_provider;
 #endif
 } API_Proc_Struct_t;
 

--- a/usr/lib/api/api_interface.c
+++ b/usr/lib/api/api_interface.c
@@ -1659,6 +1659,8 @@ CK_RV C_Finalize(CK_VOID_PTR pReserved)
     ERR_set_mark();
     if (Anchor->openssl_default_provider != NULL)
         OSSL_PROVIDER_unload(Anchor->openssl_default_provider);
+    if (Anchor->openssl_legacy_provider != NULL)
+        OSSL_PROVIDER_unload(Anchor->openssl_legacy_provider);
     if (Anchor->openssl_libctx != NULL)
         OSSL_LIB_CTX_free(Anchor->openssl_libctx);
     ERR_pop_to_mark();
@@ -2940,7 +2942,8 @@ CK_RV C_Initialize(CK_VOID_PTR pVoid)
     /*
      * OpenSSL >= 3.0:
      * Create a separate library context for Opencryptoki's use of OpenSSL
-     * services and explicitly load the 'default' provider for this context.
+     * services and explicitly load the 'default' and 'legacy' providers for
+     * this context.
      * This prevents call loops when the calling application has configured a
      * PKCS#11 provider that uses Opencryptoki under the covers. This could
      * produce a loop with the following calling tree:
@@ -2966,6 +2969,16 @@ CK_RV C_Initialize(CK_VOID_PTR pVoid)
         ERR_pop_to_mark();
         goto error;
     }
+
+    Anchor->openssl_legacy_provider =
+                    OSSL_PROVIDER_load(Anchor->openssl_libctx, "legacy");
+    if (Anchor->openssl_legacy_provider == NULL) {
+        TRACE_ERROR("OSSL_PROVIDER_load for 'legacy' failed.\n");
+        rc = CKR_FUNCTION_FAILED;
+        ERR_pop_to_mark();
+        goto error;
+    }
+
     ERR_pop_to_mark();
 #endif
 

--- a/usr/lib/common/mech_md5.c
+++ b/usr/lib/common/mech_md5.c
@@ -43,12 +43,15 @@ CK_RV sw_md5_init(DIGEST_CONTEXT *ctx)
     ctx->context = (CK_BYTE *)EVP_MD_CTX_new();
     if (ctx->context == NULL) {
         TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
+        ctx->context_len = 0;
         return CKR_HOST_MEMORY;
     }
 
     if (!EVP_DigestInit_ex((EVP_MD_CTX *)ctx->context, EVP_md5(), NULL)) {
         TRACE_ERROR("%s\n", ock_err(ERR_FUNCTION_FAILED));
         EVP_MD_CTX_free((EVP_MD_CTX *)ctx->context);
+        ctx->context = NULL;
+        ctx->context_len = 0;
         return CKR_FUNCTION_FAILED;
     }
 

--- a/usr/lib/common/mech_sha.c
+++ b/usr/lib/common/mech_sha.c
@@ -61,12 +61,15 @@ CK_RV sw_sha1_init(DIGEST_CONTEXT *ctx)
     ctx->context = (CK_BYTE *)EVP_MD_CTX_new();
     if (ctx->context == NULL) {
         TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
+        ctx->context_len = 0;
         return CKR_HOST_MEMORY;
     }
 
     if (!EVP_DigestInit_ex((EVP_MD_CTX *)ctx->context, EVP_sha1(), NULL)) {
         TRACE_ERROR("%s\n", ock_err(ERR_FUNCTION_FAILED));
         EVP_MD_CTX_free((EVP_MD_CTX *)ctx->context);
+        ctx->context = NULL;
+        ctx->context_len = 0;
         return CKR_FUNCTION_FAILED;
     }
 

--- a/usr/lib/ica_s390_stdll/ica_specific.c
+++ b/usr/lib/ica_s390_stdll/ica_specific.c
@@ -1928,6 +1928,11 @@ static CK_RV ica_specific_rsa_keygen(STDLL_TokData_t *tokdata,
         rc = CKR_FUNCTION_NOT_SUPPORTED;
         goto privkey_cleanup;
         break;
+    case EPERM:
+        TRACE_ERROR("%s\n", ock_err(ERR_KEY_SIZE_RANGE));
+        rc = CKR_KEY_SIZE_RANGE;
+        goto privkey_cleanup;
+        break;
     default:
         TRACE_ERROR("%s\n", ock_err(ERR_FUNCTION_FAILED));
         rc = CKR_FUNCTION_FAILED;
@@ -2204,6 +2209,10 @@ static CK_RV ica_specific_rsa_encrypt(STDLL_TokData_t *tokdata,
         TRACE_ERROR("%s\n", ock_err(ERR_FUNCTION_NOT_SUPPORTED));
         rc = CKR_FUNCTION_NOT_SUPPORTED;
         break;
+    case EPERM:
+        TRACE_ERROR("%s\n", ock_err(ERR_KEY_SIZE_RANGE));
+        rc = CKR_KEY_SIZE_RANGE;
+        break;
     default:
         TRACE_ERROR("%s\n", ock_err(ERR_FUNCTION_FAILED));
         rc = CKR_FUNCTION_FAILED;
@@ -2289,6 +2298,10 @@ static CK_RV ica_specific_rsa_decrypt(STDLL_TokData_t *tokdata,
             TRACE_ERROR("%s\n", ock_err(ERR_FUNCTION_NOT_SUPPORTED));
             rc = CKR_FUNCTION_NOT_SUPPORTED;
             break;
+        case EPERM:
+            TRACE_ERROR("%s\n", ock_err(ERR_KEY_SIZE_RANGE));
+            rc = CKR_KEY_SIZE_RANGE;
+            break;
         default:
             TRACE_ERROR("%s\n", ock_err(ERR_FUNCTION_FAILED));
             rc = CKR_FUNCTION_FAILED;
@@ -2327,6 +2340,10 @@ static CK_RV ica_specific_rsa_decrypt(STDLL_TokData_t *tokdata,
         case ENODEV:
             TRACE_ERROR("%s\n", ock_err(ERR_FUNCTION_NOT_SUPPORTED));
             rc = CKR_FUNCTION_NOT_SUPPORTED;
+            break;
+        case EPERM:
+            TRACE_ERROR("%s\n", ock_err(ERR_KEY_SIZE_RANGE));
+            rc = CKR_KEY_SIZE_RANGE;
             break;
         default:
             TRACE_ERROR("%s\n", ock_err(ERR_FUNCTION_FAILED));

--- a/usr/lib/soft_stdll/soft_specific.c
+++ b/usr/lib/soft_stdll/soft_specific.c
@@ -63,10 +63,7 @@ static const MECH_LIST_ELEMENT soft_mech_list[] = {
 #if !(NODSA)
     {CKM_DSA_KEY_PAIR_GEN, {512, 1024, CKF_GENERATE_KEY_PAIR}},
 #endif
-#if !OPENSSL_VERSION_PREREQ(3, 0)
-    /* OpenSSL 3.0 supports single-DES only with the legacy provider */
     {CKM_DES_KEY_GEN, {8, 8, CKF_GENERATE}},
-#endif
     {CKM_DES3_KEY_GEN, {24, 24, CKF_GENERATE}},
 #if !(NOCDMF)
     {CKM_CDMF_KEY_GEN, {0, 0, CKF_GENERATE}},
@@ -107,13 +104,10 @@ static const MECH_LIST_ELEMENT soft_mech_list[] = {
     {CKM_DH_PKCS_KEY_PAIR_GEN, {512, 2048, CKF_GENERATE_KEY_PAIR}},
 #endif
 /* End code contributed by Corrent corp. */
-#if !OPENSSL_VERSION_PREREQ(3, 0)
-    /* OpenSSL 3.0 supports single-DES only with the legacy provider */
     {CKM_DES_ECB, {8, 8, CKF_ENCRYPT | CKF_DECRYPT | CKF_WRAP | CKF_UNWRAP}},
     {CKM_DES_CBC, {8, 8, CKF_ENCRYPT | CKF_DECRYPT | CKF_WRAP | CKF_UNWRAP}},
     {CKM_DES_CBC_PAD,
      {8, 8, CKF_ENCRYPT | CKF_DECRYPT | CKF_WRAP | CKF_UNWRAP}},
-#endif
 #if !(NOCDMF)
     {CKM_CDMF_ECB, {0, 0, CKF_ENCRYPT | CKF_DECRYPT | CKF_WRAP | CKF_UNWRAP}},
     {CKM_CDMF_CBC, {0, 0, CKF_ENCRYPT | CKF_DECRYPT | CKF_WRAP | CKF_UNWRAP}},


### PR DESCRIPTION
libica may support RSA keys > 1024 only if running in FIPS mode. Make sure the ICA token adjusts its mon/max key sizes accordingly.
Also make sure testcases only use RSA key sizes supported by the token.