### PR TITLE
COMMON: Fix bug introduced during load/unload refactoring

### DIFF
--- a/testcases/common/common.c
+++ b/testcases/common/common.c
@@ -53,7 +53,7 @@ static void *pkcs11lib = NULL;
 static void unload_pkcslib(void)
 {
     if (pkcs11lib != NULL) {
-        dlclose(pkcs11lib);
+         dlclose(pkcs11lib);
     }
 }
 

--- a/usr/lib/api/api_interface.c
+++ b/usr/lib/api/api_interface.c
@@ -1695,8 +1695,7 @@ CK_RV C_Finalize(CK_VOID_PTR pReserved)
          * Since the atfork handler table is currently locked when we are in
          * an atfork handler, this would produce a deadlock.
          */
-        if (!in_child_fork_initializer)
-            DL_UnLoad(sltp, slotID);
+        DL_UnLoad(sltp, slotID, in_child_fork_initializer);
     }
     END_OPENSSL_LIBCTX(rc)
 
@@ -3120,7 +3119,7 @@ CK_RV C_Initialize(CK_VOID_PTR pVoid)
                                   &trace, 0);
                 }
             }
-            DL_UnLoad(sltp, slotID);
+            DL_UnLoad(sltp, slotID, FALSE);
         }
         END_OPENSSL_LIBCTX(rc)
 

--- a/usr/lib/api/apiproto.h
+++ b/usr/lib/api/apiproto.h
@@ -42,7 +42,7 @@ void decr_sess_counts(CK_SLOT_ID);
 unsigned long AddToSessionList(ST_SESSION_T *);
 void RemoveFromSessionList(CK_SESSION_HANDLE);
 int Valid_Session(CK_SESSION_HANDLE, ST_SESSION_T *);
-void DL_UnLoad(API_Slot_t *, CK_SLOT_ID);
+void DL_UnLoad(API_Slot_t *, CK_SLOT_ID, CK_BBOOL inchildforkinit);
 void DL_Unload(API_Slot_t *);
 
 void CK_Info_From_Internal(CK_INFO_PTR dest, CK_INFO_PTR_64 src);


### PR DESCRIPTION
Make sure the TokData member is always freed.  Special care has to be taken
for the fork situation.  In that case, we have to free TokData but block all
paths to a dlclose.

Signed-off-by: Juergen Christ <jchrist@linux.ibm.com>