### PR TITLE
API: Clear TokData to prevent double free

### DIFF
--- a/usr/lib/api/apiutil.c
+++ b/usr/lib/api/apiutil.c
@@ -455,6 +455,7 @@ void DL_UnLoad(API_Slot_t *sltp, CK_SLOT_ID slotID, CK_BBOOL inchildforkinit)
 #endif
         pthread_mutex_destroy(&sltp->TokData->login_mutex);
         free(sltp->TokData);
+        sltp->TokData = NULL;
     }
 
     sinfp = &(shData->slot_info[slotID]);


### PR DESCRIPTION
Since we did not set TokData to NULL after freeing it, we double freed it
under certain circumstances.

Signed-off-by: Juergen Christ <jchrist@linux.ibm.com>