### PR TITLE
List all configured slots with C_GetSlotList and 'pkcsconf -t'

### DIFF
--- a/usr/lib/api/api_interface.c
+++ b/usr/lib/api/api_interface.c
@@ -2708,7 +2708,7 @@ CK_RV C_GetSlotList(CK_BBOOL tokenPresent,
     for (index = 0; index < NUMBER_SLOTS_MANAGED; index++) {
         // if there is a STDLL in the slot then we have to count it
         // otherwise the slot is NOT counted.
-        if (sinfp[index].present == TRUE && slot_loaded[index] == TRUE) {
+        if (sinfp[index].present == TRUE) {
             if (tokenPresent) {
                 if ((sinfp[index].pk_slot.flags & CKF_TOKEN_PRESENT)) {
                     count++;
@@ -2744,7 +2744,7 @@ CK_RV C_GetSlotList(CK_BBOOL tokenPresent,
     //
     for (sindx = 0, index = 0;
          (index < NUMBER_SLOTS_MANAGED) && (sindx < count); index++) {
-        if (sinfp[index].present == TRUE && slot_loaded[index] == TRUE) {
+        if (sinfp[index].present == TRUE) {
             if (tokenPresent) {
                 if (sinfp[index].pk_slot.flags & CKF_TOKEN_PRESENT) {
                     pSlotList[sindx] = sinfp[index].slot_number;

--- a/usr/lib/api/apiutil.c
+++ b/usr/lib/api/apiutil.c
@@ -637,6 +637,7 @@ int DL_Load_and_Init(API_Slot_t *sltp, CK_SLOT_ID slotID)
         return FALSE;
     } else {
         sltp->DLLoaded = TRUE;
+        sinfp->pk_slot.flags |= CKF_TOKEN_PRESENT;
         // Check if a SC_Finalize function has been exported
         *(void **)(&sltp->pSTfini) = dlsym(sltp->dlop_p, "SC_Finalize");
         *(void **)(&sltp->pSTcloseall) =

--- a/usr/sbin/pkcsslotd/slotmgr.c
+++ b/usr/sbin/pkcsslotd/slotmgr.c
@@ -410,12 +410,10 @@ static int slotmgr_key_str(void *private, int tok, const char *val)
     switch (tok) {
     case KW_STDLL:
         if (do_str(d, (char *)&d->sinfo_struct.dll_location,
-                   sizeof(d->sinfo_struct.dll_location), tok, val, 0)) {
+                   sizeof(d->sinfo_struct.dll_location), tok, val, 0))
             res = 1;
-        } else {
+        else
             d->sinfo_struct.present = TRUE;
-            d->sinfo_struct.pk_slot.flags |= (CKF_TOKEN_PRESENT);
-        }
         break;
     case KW_SLOTDESC:
         if (do_str(d, (char *)d->sinfo_struct.pk_slot.slotDescription,


### PR DESCRIPTION
C_GetSlotList with tokenPresent=false is supposed to list all configured slots, not only those with a token present.  Also let 'pkcsconf -t' and 'pkcsconf -l' list all configured slots, not only those with a token present