### PR TITLE
EP11: Add support for CKM_GENERIC_SECRET_KEY_GEN

### DIFF
--- a/usr/lib/common/mech_ec.c
+++ b/usr/lib/common/mech_ec.c
@@ -1051,6 +1051,9 @@ CK_RV pkcs_get_keytype(CK_ATTRIBUTE *attrs, CK_ULONG attrs_len,
     case CKM_AES_KEY_GEN:
         *type = CKK_AES;
         break;
+    case CKM_GENERIC_SECRET_KEY_GEN:
+        *type = CKK_GENERIC_SECRET;
+        break;
     case CKM_RSA_PKCS_KEY_PAIR_GEN:
         *type = CKK_RSA;
         break;

--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -1547,9 +1547,9 @@ static CK_RV check_key_attributes(STDLL_TokData_t * tokdata,
     CK_ULONG check_types_sec_sensitive[] =
         { CKA_ENCRYPT, CKA_DECRYPT, CKA_WRAP, CKA_UNWRAP, CKA_SENSITIVE };
     CK_ULONG check_types_gen_sec[] =
-        { CKA_SIGN, CKA_VERIFY, CKA_ENCRYPT, CKA_DECRYPT };
+        { CKA_SIGN, CKA_VERIFY };
     CK_ULONG check_types_gen_sec_sensitive[] =
-        { CKA_SIGN, CKA_VERIFY, CKA_ENCRYPT, CKA_DECRYPT, CKA_SENSITIVE };
+        { CKA_SIGN, CKA_VERIFY, CKA_SENSITIVE };
     CK_ULONG check_types_derive[] = { CKA_DERIVE };
     CK_ULONG *check_types = NULL;
     CK_BBOOL *check_values[] = { &cktrue, &cktrue, &cktrue, &cktrue, &cktrue };
@@ -8731,6 +8731,7 @@ static const CK_MECHANISM_TYPE ep11_supported_mech_list[] = {
     CKM_SHA512_RSA_PKCS_PSS,
     CKM_SHA_1,
     CKM_SHA_1_HMAC,
+    CKM_GENERIC_SECRET_KEY_GEN,
     CKM_IBM_ATTRIBUTEBOUND_WRAP,
 };
 


### PR DESCRIPTION
For whatever reason, CKM_GENERIC_SECRET_KEY_GEN was excluded from the list of supported mechanisms of the EP11 token.