### PR TITLE
Introduce statistics counters

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -214,6 +214,7 @@ ci-prepare:
 	killall -HUP pkcsslotd || true
 	${srcdir}/testcases/ciconfig.sh "$(sysconfdir)/opencryptoki" "$(sysconfdir)/opencryptoki"
 	@sbindir@/pkcsslotd
+	@sbindir@/pkcsstats --reset-all
 	for slot in `awk '/slot (.*)/ { print $$2; }' $(sysconfdir)/opencryptoki/opencryptoki.conf`; do @sbindir@/pkcsconf -c $$slot -t | grep "Flags:" | grep -q TOKEN_INITIALIZED || PKCS11_USER_PIN=$(PKCS11_USER_PIN) PKCS11_SO_PIN=$(PKCS11_SO_PIN) PKCSLIB=@libdir@/opencryptoki/libopencryptoki.so ${srcdir}/testcases/init_token.sh $$slot; done
 #	cd ${srcdir}/testcases && PKCS11_USER_PIN=$(PKCS11_USER_PIN) PKCS11_VHSM_PIN=$(PKCS11_VHSM_PIN) PKCSLIB=@libdir@/opencryptoki/libopencryptoki.so ./init_vhsm.exp 42
 #	echo "VHSM_MODE" >> "$(sysconfdir)/opencryptoki/ep11tok42.conf"
@@ -235,10 +236,12 @@ ci-installcheck: ci-prepare installcheck
 	killall -HUP pkcsslotd || true
 	@sbindir@/pkcsslotd
 	cd ${srcdir}/testcases && export PKCSLIB=@libdir@/opencryptoki/libopencryptoki.so && export PKCS11_USER_PIN=$(PKCS11_USER_PIN) && ./misc_tests/p11sak_test.sh | tee log-p11sak.txt
+	@sbindir@/pkcsstats --all
 	killall -HUP pkcsslotd
 	@echo "done"
 
 ci-cleanup:
+	@sbindir@/pkcsstats --delete-all || true
 	killall -HUP pkcsslotd || true
 #	@sbindir@/pkcsslotd
 #	cd ${srcdir}/testcases && PKCS11_USER_PIN=$(PKCS11_USER_PIN) PKCSLIB=@libdir@/opencryptoki/libopencryptoki.so ./cleanup_vhsm.exp 42

--- a/configure.ac
+++ b/configure.ac
@@ -189,6 +189,12 @@ AC_ARG_ENABLE([pkcstok_migrate],
 	[],
 	[enable_pkcstok_migrate=yes])
 
+dnl --- pkcsstats
+AC_ARG_ENABLE([pkcsstats],
+	AS_HELP_STRING([--enable-pkcsstats],[build pkcsstats tool @<:@default=enabled@:>@]),
+	[],
+	[enable_pkcsstats=yes])
+
 dnl ---
 dnl --- Check for external software
 dnl --- Define what to check based on enabled features
@@ -637,6 +643,9 @@ AM_CONDITIONAL([ENABLE_P11SAK], [test "x$enable_p11sak" = "xyes"])
 dnl --- enable_pkcstok_migrate
 AM_CONDITIONAL([ENABLE_PKCSTOK_MIGRATE], [test "x$enable_pkcstok_migrate" = "xyes"])
 
+dnl --- enable_pkcsstats
+AM_CONDITIONAL([ENABLE_PKCSSTATS], [test "x$enable_pkcsstats" = "xyes"])
+
 dnl --- enable_locks
 if test "x$enable_locks" != "xno"; then
 	enable_locks=yes
@@ -681,6 +690,7 @@ AC_CONFIG_FILES([Makefile				\
 		 man/man1/pkcsep11_migrate.1		\
 		 man/man1/pkcsep11_session.1		\
 		 man/man1/pkcstok_migrate.1		\
+		 man/man1/pkcsstats.1			\
 		 man/man5/opencryptoki.conf.5		\
 		 man/man5/p11sak_defined_attrs.conf.5	\
 		 man/man5/strength.conf.5		\
@@ -700,6 +710,7 @@ echo "	Build with locks:	$enable_locks"
 echo "	Build with libudev:	$with_libudev"
 echo "	Build p11sak tool:	$enable_p11sak"
 echo "	token migrate tool:	$enable_pkcstok_migrate"
+echo "	statistics tool:	$enable_pkcsstats"
 echo
 echo "Enabled token types:"
 echo "	ICA token:		$enable_icatok"

--- a/man/man1/man1.mk
+++ b/man/man1/man1.mk
@@ -1,5 +1,9 @@
 man1_MANS += man/man1/pkcsconf.1 man/man1/pkcsicsf.1
 
+if ENABLE_PKCSSTATS
+man1_MANS += man/man1/pkcsstats.1
+endif
+
 if ENABLE_PKCSTOK_MIGRATE
 man1_MANS += man/man1/pkcstok_migrate.1
 endif

--- a/man/man1/pkcsstats.1.in
+++ b/man/man1/pkcsstats.1.in
@@ -126,6 +126,10 @@ Only the \fBroot\fP user can delete the statistics from other users.
 Deletes the shared memory segment containing the statistics counters for all
 users. Only the \fBroot\fP user can delete the statistics from other users.
 .TP
+.BR \-j ", " \-\-json
+Shows the statistics in JSON format. This is usefull to get the statistics in
+a machine readable format.
+.TP
 .BR \-h ", " \-\-help
 Displays help text and exits.
 

--- a/man/man1/pkcsstats.1.in
+++ b/man/man1/pkcsstats.1.in
@@ -1,0 +1,141 @@
+.\" pkcsstats.1
+.\"
+.\" Copyright IBM Corp. 2021
+.\" See LICENSE for details.
+.\"
+.TH PKCSSTATS 1 "October 2021" "@PACKAGE_VERSION@" "openCryptoki"
+.SH NAME
+pkcsstats \- utility to display mechanism usage statistics for openCryptoki.
+
+.SH SYNOPSIS
+.B pkcsstats
+.RB [ OPTIONS ]
+.
+.PP
+.B pkcsstats
+.BR \-\-help | \-h
+.br
+
+.SH DESCRIPTION
+Displays mechanism usage statistics for openCryptoki. Usage statistics are
+collected by openCryptoki on a per user basis. For each user, mechanism
+usage is counted per configured slot and mechanism. For each mechanism a set of
+counters exist, one for each cryptographic strength of the cryptographic
+key used with the mechanism.
+.PP
+The available strengths are defined in the strength configuration file
+\fB/etc/opencryptoki/strength.conf\fP. Supported strengths are 112, 128, 192,
+and 256 representing the corresponding strength in bits.
+The strength configuration file defines how the strength is determined for the
+various key types. A strength of zero is used to count those mechanisms that
+do not use a key, or where the key strength is less than 112 bits.
+.PP
+.B Note:
+The strength does not specify the cryptographic strength of the mechanism, but
+the cryptographic strength of the key used with the mechanism (if any).
+For example, usage of mechanism CKM\_SHA256 is reported under strength 0,
+because no key is used with this mechanism. However, usage of mechanism
+CKM\_AES\_CBC is reported under strength 128, 192, or 256, dependent on the
+cryptographic size of the AES key used with it (and the definitions in the
+strength configuration file).
+.PP
+Statistics collection is enabled by default. It can be disabled and configured
+in the openCryptoki configuration file
+\fB/etc/opencryptoki/opencryptoki.conf\fP.
+By default only explicit mechanism usage statistics from PKCS#11 applications
+are collected.
+.PP
+Optionally, implicit mechanism usage statistics can be collected, where
+additional mechanisms are specified in mechanism parameters. For example,
+RSA\-PSS or RSA\-OAEP allows to specify a hash mechanism and a mask generation
+function (MGF) in the mechanism parameter. ECDH allows to specify a key
+derivation function (KDF) in the mechanism parameter. The PBKDF2 mechanism
+allows to specify a pseudo random function (PRF) in the mechanism parameter.
+.PP
+Also optionally, opencryptoki\-internal mechanism usage statistics can be
+collected. This collects usage statistics for crypto operations used internally
+for pin handling and encryption of private token objects in the data store.
+.PP
+.B Note:
+Implicit or internal mechanism usage can not be distinguished from explicit
+mechanism usage of PKCS#11 applications in the displayed statistics.
+.PP
+Statistics are collected in a POSIX shared memory segment per user. This shared
+memory segment contains all counters for all configured slots, mechanisms, and
+strengths. The shared memory segments are named
+\fBvar.lib.opencryptoki_stats_<uid>\fP, where \fBuid\fP is the numeric user\-id
+of the user the statistics belong to. The shared memory segments are
+automatically created for a user on the first attempt to collect statistics
+(when not already existent). The shared memory segments can be deleted using
+the \fBpkcsstats\fP command with the \fB\-\-delete\fP, or \fB\-\-delete\-all\fP
+options.
+.PP
+The usage of a mechanism is counted once when the cryptographic operation is
+sucessfully initialized, i.e. during \fBC_DigestInit\fP, \fBC_EncryptInit\fP,
+\fBC_DecryptInit\fP, \fBC_SignInit\fP, \fBC_SignRecoverInit\fP, and
+\fBC_VerifyInit\fP. Multi-part operations involving the update functions like
+\fBC_DigestUpdate\fP, \fBC_EncryptUpdate\fP, \fBC_DecryptUpdate\fP,
+\fBC_SignUpdate\fP, and \fBC_VerifyUpdate\fP, are not counted additionally.
+.PP
+Other operations such as key generation, key derivation, key wrapping and
+unwrapping are counted during the respective functions like \fBC_GenerateKey\fP,
+\fBC_GenerateKeyPair\fP, \fBC_DeriveKey\fP, \fBC_DeriveKey\fP,
+\fBC_UnwrapKey\fP.
+
+.SH "OPTIONS"
+
+.TP
+.BR \-U ", " \-\-user\~\fIuser\-id\fP
+Specifies the user\-id of the user to display, reset, or delete statistics for.
+If this option is omitted, the statistics of the current user are displayed,
+resetted, or deleted. Only the \fBroot\fP user can display, reset, or delete
+statistics of other users.
+.TP
+.BR \-S ", " \-\-summary
+Shows the accumulated statistics from all users. Only the \fBroot\fP user can
+display the accumulated statistics from other users.
+.TP
+.BR \-A ", " \-\-all
+Shows the statistics from all users. Only the \fBroot\fP user can display
+statistics from all users.
+.TP
+.BR \-a ", " \-\-all\-mechs
+Shows the statistics for all mechanisms, also those with all\-zero counters.
+If this option is omitted, only those mechanisms are displayed where at least
+one counter is non\-zero.
+.TP
+.BR \-s ", " \-\-slot\~\fIslot\-id\fP
+Specifies the slot\-id to display statistics for. If this option is omitted,
+the statistics for all configured slots are displayed.
+.TP
+.BR \-r ", " \-\-reset
+Resets the statistics counters for the current user, or for the user specified
+with the \fB\-\-user\fP option. Only the \fBroot\fP user can reset the
+statistics from other users.
+.TP
+.BR \-R ", " \-\-reset\-all
+Resets the statistics counters for all users. Only the \fBroot\fP user
+can reset the statistics from other users.
+.TP
+.BR \-d ", " \-\-delete
+Deletes the shared memory segment containing the statistics counters for the
+current user, or for the user specified with the \fB\-\-user\fP option.
+Only the \fBroot\fP user can delete the statistics from other users.
+.TP
+.BR \-D ", " \-\-delete\-all
+Deletes the shared memory segment containing the statistics counters for all
+users. Only the \fBroot\fP user can delete the statistics from other users.
+.TP
+.BR \-h ", " \-\-help
+Displays help text and exits.
+
+.SH SEE ALSO
+.PD 0
+.TP
+\fBopencryptoki.conf\fP(5).
+.TP
+\fBstrength.conf\fP(5),
+.TP
+\fBopencryptoki\fP(7),
+
+.PD

--- a/man/man5/opencryptoki.conf.5.in
+++ b/man/man5/opencryptoki.conf.5.in
@@ -18,6 +18,29 @@ The following global definitions are valid:
 .BR disable-event-support
 If this keyword is specified the openCryptoki event support is disabled.
 
+.TP
+.BR statistics\~(off | on [ ,implicit ][ ,internal ] )
+Enables or disables collection of statistics of mechanism usage. By default,
+statistics collection is enabled. A value of \fB(off)\fP disables all statistics
+collection. A value of \fB(on)\fP enables collection of mechanism usage.
+The collected statistics can be displayed using the \fBpkcsstats\fP tool.
+
+In addition to enabling statistics collection for mechanisms used by PKCS#11
+applications, you can specify \fB(on,implicit)\fP to also enable collection
+of implicit mechanism usage, where additional mechanisms are specified in
+mechanism parameters. For example, RSA-PSS or RSA-OAEP allow to specify a hash
+mechanism and a mask generation function (MGF) in the mechanism parameter.
+ECDH allows to specify a key derivation function (KDF) in the mechanism
+parameter.
+
+You can additionally enable statistics collection of mechanisms internally used
+by Opencryptoki by specifying \fB(on,internal)\fP. This additionally collects
+usage statistics for crypto operations used internally for pin handling and
+encryption of private token objects in the data store.
+
+Implicit and internal statistics collection can also be combined:
+\fB(on,implicit,internal)\fP
+
 .P
 Each slot description is composed of a slot number, brackets and key-value pairs.
 
@@ -88,4 +111,6 @@ slot descriptions, as this will cause a syntax error.
 \fBopencryptoki\fP(7),
 .TP
 \fBpkcsslotd\fP(8),
+.TP
+\fBpkcsstats\fP(1),
 .PD

--- a/testcases/ciconfig.sh
+++ b/testcases/ciconfig.sh
@@ -58,6 +58,9 @@ fi
 # initialize opencryptoki.conf
 echo "version opencryptoki-3.16" > "${OCKCONFDIR}/opencryptoki.conf"
 
+# enable full statistics
+echo "statistics (on,implicit,internal)" >> "${OCKCONFDIR}/opencryptoki.conf"
+
 # ICA token
 addslot 10 libpkcs11_ica.so ica0
 addslot 11 libpkcs11_ica.so ica1

--- a/usr/include/slotmgr.h
+++ b/usr/include/slotmgr.h
@@ -100,6 +100,9 @@ typedef struct {
 } Slot_Info_t;
 
 #define FLAG_EVENT_SUPPORT_DISABLED   0x01
+#define FLAG_STATISTICS_ENABLED       0x02
+#define FLAG_STATISTICS_IMPLICIT      0x04
+#define FLAG_STATISTICS_INTERNAL      0x08
 
 #ifdef PKCS64
 

--- a/usr/lib/api/api.mk
+++ b/usr/lib/api/api.mk
@@ -1,6 +1,7 @@
 nobase_lib_LTLIBRARIES += opencryptoki/libopencryptoki.la
 
-noinst_HEADERS += usr/lib/api/apiproto.h usr/lib/api/policy.h
+noinst_HEADERS += usr/lib/api/apiproto.h usr/lib/api/policy.h		\
+	usr/lib/api/statistics.h
 
 SO_CURRENT=0
 SO_REVISION=0
@@ -14,7 +15,7 @@ opencryptoki_libopencryptoki_la_CFLAGS =				\
 	-I${top_builddir}/usr/lib/api
 
 opencryptoki_libopencryptoki_la_LDFLAGS =				\
-	-shared	-Wl,-z,defs,-Bsymbolic -lc -ldl -lpthread -lcrypto	\
+	-shared	-Wl,-z,defs,-Bsymbolic -lc -ldl -lpthread -lcrypto -lrt	\
 	-version-info $(SO_CURRENT):$(SO_REVISION):$(SO_AGE)		\
 	-Wl,--version-script=${srcdir}/opencryptoki.map
 
@@ -22,6 +23,7 @@ opencryptoki_libopencryptoki_la_SOURCES = usr/lib/api/api_interface.c	\
 	usr/lib/api/shrd_mem.c usr/lib/api/socket_client.c		\
 	usr/lib/api/apiutil.c usr/lib/common/trace.c			\
 	usr/lib/api/policy.c usr/lib/api/hashmap.c			\
+	usr/lib/api/statistics.c					\
 	usr/lib/common/utility_common.c usr/lib/common/ec_supported.c	\
 	usr/lib/config/configuration.c					\
 	usr/lib/common/ec_curve_translation.c				\

--- a/usr/lib/api/api_interface.c
+++ b/usr/lib/api/api_interface.c
@@ -3093,7 +3093,8 @@ CK_RV C_Initialize(CK_VOID_PTR pVoid)
     }
 
     rc = statistics_init(&statistics, &Anchor->SocketDataP,
-                         STATISTICS_FLAG_COUNT_IMPLICIT);
+                         STATISTICS_FLAG_COUNT_IMPLICIT |
+                         STATISTICS_FLAG_COUNT_INTERNAL);
     if (rc != CKR_OK) {
         TRACE_ERROR("Statistics initialization failed!  rc=0x%lx\n", rc);
         goto error;

--- a/usr/lib/api/api_interface.c
+++ b/usr/lib/api/api_interface.c
@@ -3092,7 +3092,8 @@ CK_RV C_Initialize(CK_VOID_PTR pVoid)
         goto error;
     }
 
-    rc = statistics_init(&statistics, &Anchor->SocketDataP);
+    rc = statistics_init(&statistics, &Anchor->SocketDataP,
+                         STATISTICS_FLAG_COUNT_IMPLICIT);
     if (rc != CKR_OK) {
         TRACE_ERROR("Statistics initialization failed!  rc=0x%lx\n", rc);
         goto error;

--- a/usr/lib/api/api_interface.c
+++ b/usr/lib/api/api_interface.c
@@ -2859,6 +2859,7 @@ CK_RV C_Initialize(CK_VOID_PTR pVoid)
     CK_RV rc = CKR_OK;
     CK_SLOT_ID slotID;
     API_Slot_t *sltp;
+    CK_ULONG stat_flags = 0;
 
     /*
      * Lock so that only one thread can run C_Initialize or C_Finalize at
@@ -3092,12 +3093,17 @@ CK_RV C_Initialize(CK_VOID_PTR pVoid)
         goto error;
     }
 
-    rc = statistics_init(&statistics, &Anchor->SocketDataP,
-                         STATISTICS_FLAG_COUNT_IMPLICIT |
-                         STATISTICS_FLAG_COUNT_INTERNAL);
-    if (rc != CKR_OK) {
-        TRACE_ERROR("Statistics initialization failed!  rc=0x%lx\n", rc);
-        goto error;
+    if (Anchor->SocketDataP.flags & FLAG_STATISTICS_ENABLED) {
+        if (Anchor->SocketDataP.flags & FLAG_STATISTICS_IMPLICIT)
+            stat_flags |= STATISTICS_FLAG_COUNT_IMPLICIT;
+        if (Anchor->SocketDataP.flags & FLAG_STATISTICS_INTERNAL)
+            stat_flags |= STATISTICS_FLAG_COUNT_INTERNAL;
+
+        rc = statistics_init(&statistics, &Anchor->SocketDataP, stat_flags);
+        if (rc != CKR_OK) {
+            TRACE_ERROR("Statistics initialization failed!  rc=0x%lx\n", rc);
+            goto error;
+        }
     }
 
     //Register with pkcsslotd

--- a/usr/lib/api/apiproto.h
+++ b/usr/lib/api/apiproto.h
@@ -20,6 +20,7 @@
 
 #include "apictl.h"
 #include "policy.h"
+#include "statistics.h"
 
 void *attach_shared_memory();
 void detach_shared_memory(char *);
@@ -28,7 +29,8 @@ void detach_shared_memory(char *);
 int API_Initialized();
 int API_Register();
 void API_UnRegister();
-int DL_Load_and_Init(API_Slot_t *, CK_SLOT_ID, policy_t policy);
+int DL_Load_and_Init(API_Slot_t *, CK_SLOT_ID, policy_t policy,
+                     statistics_t statistics);
 
 
 CK_RV CreateProcLock();

--- a/usr/lib/api/apiutil.c
+++ b/usr/lib/api/apiutil.c
@@ -591,6 +591,7 @@ int DL_Load_and_Init(API_Slot_t *sltp, CK_SLOT_ID slotID, policy_t policy,
         TRACE_ERROR("Allocating host memory failed.\n");
         return FALSE;
     }
+    sltp->TokData->slot_id = slotID;
     sltp->TokData->ro_session_count = 0;
     sltp->TokData->global_login_state = CKS_RO_PUBLIC_SESSION;
 #ifdef ENABLE_LOCKS

--- a/usr/lib/api/apiutil.c
+++ b/usr/lib/api/apiutil.c
@@ -553,7 +553,8 @@ void DL_Unload(API_Slot_t *sltp)
     sltp->pSTcloseall = NULL;
 }
 
-int DL_Load_and_Init(API_Slot_t *sltp, CK_SLOT_ID slotID, policy_t policy)
+int DL_Load_and_Init(API_Slot_t *sltp, CK_SLOT_ID slotID, policy_t policy,
+                     statistics_t statistics)
 {
     Slot_Mgr_Socket_t *shData = &(Anchor->SocketDataP);
 #ifdef PKCS64
@@ -598,6 +599,7 @@ int DL_Load_and_Init(API_Slot_t *sltp, CK_SLOT_ID slotID, policy_t policy)
     pthread_mutex_init(&sltp->TokData->login_mutex, NULL);
     sltp->TokData->policy = policy;
     sltp->TokData->mechtable_funcs = &mechtable_funcs;
+    sltp->TokData->statistics = statistics;
     
     if (strlen(sinfp->dll_location) > 0) {
         // Check if this DLL has been loaded already.. If so, just increment

--- a/usr/lib/api/statistics.c
+++ b/usr/lib/api/statistics.c
@@ -1,0 +1,254 @@
+/*
+ * COPYRIGHT (c) International Business Machines Corp. 2021
+ *
+ * This program is provided under the terms of the Common Public License,
+ * version 1.0 (CPL-1.0). Any use, reproduction or distribution for this
+ * software constitutes recipient's acceptance of CPL-1.0 terms which can be
+ * found in the file LICENSE file or at
+ * https://opensource.org/licenses/cpl1.0.php
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#include "statistics.h"
+#include "trace.h"
+#include "ock_syslog.h"
+
+static CK_RV statistics_increment(struct statistics *statistics,
+                                  CK_SLOT_ID slot,
+                                  const CK_MECHANISM *mech,
+                                  CK_ULONG strength_idx)
+{
+    CK_ULONG ofs;
+    counter_t *counter;
+    int mech_idx;
+
+    if (slot >= NUMBER_SLOTS_MANAGED || strength_idx > POLICY_STRENGTH_IDX_0 ||
+        mech == NULL)
+        return CKR_ARGUMENTS_BAD;
+
+    ofs = statistics->slot_shm_offsets[slot];
+    if (ofs > statistics->shm_size)
+        return CKR_SLOT_ID_INVALID;
+
+    mech_idx = mechtable_idx_from_numeric(mech->mechanism);
+    if (mech_idx < 0)
+        return CKR_MECHANISM_INVALID;
+
+    ofs += mech_idx * (NUM_SUPPORTED_STRENGTHS + 1) * sizeof(counter_t);
+
+    strength_idx = NUM_SUPPORTED_STRENGTHS - strength_idx;
+    ofs += strength_idx * sizeof(counter_t);
+
+    if (ofs > statistics->shm_size)
+        return CKR_FUNCTION_FAILED;
+
+    counter = (counter_t*)(statistics->shm_data + ofs);
+    __sync_add_and_fetch(counter, 1);
+
+    return CKR_OK;
+}
+
+/*
+ * Open the statistics shared memory segment for the specified user.
+ * If user is -1, then it is opened for the current user.
+ * If create is TRUE then the shared memory segment is created if it is not
+ * already existent.
+ */
+static CK_RV statistics_open_shm(struct statistics *statistics, int user,
+                                 CK_BBOOL create)
+{
+    int i, err, clear = 0;
+    struct stat stat_buf;
+
+    snprintf(statistics->shm_name, sizeof(statistics->shm_name) - 1,
+             "%s_stats_%u", CONFIG_PATH, user == -1 ? geteuid() : (uid_t)user);
+    for (i = 1; statistics->shm_name[i] != '\0'; i++) {
+        if (statistics->shm_name[i] == '/')
+            statistics->shm_name[i] = '.';
+    }
+    if (statistics->shm_name[0] != '/') {
+        memmove(&statistics->shm_name[1], &statistics->shm_name[0],
+                strlen(statistics->shm_name) + 1);
+        statistics->shm_name[0] = '/';
+    }
+
+    TRACE_INFO("Statistics SHM name: '%s'\n", statistics->shm_name);
+
+    statistics->shm_handle = shm_open(statistics->shm_name, O_RDWR,
+                                      S_IRUSR | S_IWUSR);
+    if (statistics->shm_handle == -1) {
+        if (create) {
+            /* try to create it */
+            statistics->shm_handle = shm_open(statistics->shm_name,
+                                              O_CREAT | O_RDWR,
+                                              S_IRUSR | S_IWUSR);
+            if (statistics->shm_handle == -1) {
+                err = errno;
+                TRACE_ERROR("Failed to create SHM '%s': %s\n",
+                            statistics->shm_name,  strerror(err));
+                OCK_SYSLOG(LOG_ERR, "Failed to create SHM '%s': %s\n",
+                           statistics->shm_name, strerror(err));
+                return CKR_FUNCTION_FAILED;
+            }
+
+            if (fchmod(statistics->shm_handle, S_IRUSR | S_IWUSR) == -1) {
+                err = errno;
+                TRACE_ERROR("Failed to change mode of SHM '%s': %s\n",
+                            statistics->shm_name,  strerror(err));
+                OCK_SYSLOG(LOG_ERR, "Failed to change mode of SHM '%s': %s\n",
+                           statistics->shm_name, strerror(err));
+                close(statistics->shm_handle);
+                shm_unlink(statistics->shm_name);
+                return CKR_FUNCTION_FAILED;
+            }
+        } else {
+            err = errno;
+            TRACE_ERROR("Failed to open SHM '%s': %s\n",
+                        statistics->shm_name,  strerror(err));
+            OCK_SYSLOG(LOG_ERR, "Failed to open SHM '%s': %s\n",
+                       statistics->shm_name, strerror(err));
+            return CKR_FUNCTION_FAILED;
+        }
+    }
+
+    if (fstat(statistics->shm_handle, &stat_buf)) {
+        err = errno;
+        TRACE_ERROR("Failed to stat SHM '%s': %s\n",
+                    statistics->shm_name,  strerror(err));
+        OCK_SYSLOG(LOG_ERR, "Failed to stat SHM '%s': %s\n",
+                   statistics->shm_name, strerror(err));
+        close(statistics->shm_handle);
+        return CKR_FUNCTION_FAILED;
+    }
+
+    /*
+     * If the shared memory segment does not belong to the current user or does
+     * not have correct permissions, do not use it.
+     */
+    if (stat_buf.st_uid != (user == -1 ? geteuid() : (uid_t)user) ||
+        (stat_buf.st_mode & ~S_IFMT) != (S_IRUSR | S_IWUSR)) {
+        TRACE_ERROR("SHM '%s' has wrong mode/owner\n", statistics->shm_name);
+        OCK_SYSLOG(LOG_ERR, "SHM '%s' has wrong mode/owner\n",
+                   statistics->shm_name);
+        close(statistics->shm_handle);
+        return CKR_FUNCTION_FAILED;
+    }
+
+    if ((CK_ULONG)stat_buf.st_size != statistics->shm_size) {
+        if (create) {
+            if (ftruncate(statistics->shm_handle, statistics->shm_size) < 0) {
+                err = errno;
+                TRACE_ERROR("Failed to set size of SHM '%s': %s\n",
+                            statistics->shm_name,  strerror(err));
+                OCK_SYSLOG(LOG_ERR, "Failed to set size of SHM '%s': %s\n",
+                           statistics->shm_name, strerror(err));
+                close(statistics->shm_handle);
+                return CKR_FUNCTION_FAILED;
+            }
+
+            clear = 1;
+        } else {
+            TRACE_ERROR("SHM '%s' has wrong size\n", statistics->shm_name);
+            OCK_SYSLOG(LOG_ERR, "SHM '%s' has wrong size\n",
+                       statistics->shm_name);
+            return CKR_FUNCTION_FAILED;
+        }
+    }
+
+    statistics->shm_data = (CK_BYTE *)mmap(NULL, statistics->shm_size,
+                                           PROT_READ | PROT_WRITE, MAP_SHARED,
+                                           statistics->shm_handle, 0);
+    if (statistics->shm_data == MAP_FAILED) {
+        err = errno;
+        TRACE_ERROR("Failed to memory-map SHM '%s': %s\n",
+                    statistics->shm_name, strerror(err));
+        OCK_SYSLOG(LOG_ERR, "Failed to memory-map SHM '%s': %s\n",
+                   statistics->shm_name, strerror(err));
+        close(statistics->shm_handle);
+        statistics->shm_data = NULL;
+        return CKR_FUNCTION_FAILED;
+    }
+
+    if (clear)
+        memset(statistics->shm_data, 0, sizeof(statistics->shm_size));
+
+    return CKR_OK;
+}
+
+static CK_RV statistics_close_shm(struct statistics *statistics,
+                                  CK_BBOOL destroy)
+{
+    CK_RV rc;
+
+    if (statistics->shm_data == NULL || statistics->shm_handle == -1)
+        return CKR_ARGUMENTS_BAD;
+
+    munmap(statistics->shm_data, statistics->shm_size);
+    close(statistics->shm_handle);
+
+    if (destroy) {
+        rc = shm_unlink(statistics->shm_name);
+        if (rc != 0) {
+            TRACE_ERROR("Failed to unlink SHM '%s': %s\n",
+                        statistics->shm_name,  strerror(errno));
+            return CKR_FUNCTION_FAILED;
+        }
+    }
+
+    statistics->shm_data = NULL;
+    statistics->shm_size = -1;
+
+    return CKR_OK;
+}
+
+CK_RV statistics_init(struct statistics *statistics,
+                      Slot_Mgr_Socket_t *slots_infos)
+{
+    CK_ULONG i;
+    CK_RV rc;
+
+    statistics->shm_handle = -1;
+    statistics->shm_data = NULL;
+
+    /* Count number of configured slots and calculate slot offsets. */
+    statistics->num_slots = 0;
+    for (i = 0; i < NUMBER_SLOTS_MANAGED; i++) {
+        if (slots_infos->slot_info[i].present) {
+            statistics->slot_shm_offsets[i] =
+                        statistics->num_slots * STAT_SLOT_SIZE;
+            statistics->num_slots++;
+        } else {
+            statistics->slot_shm_offsets[i] = (CK_ULONG)-1;
+        }
+    }
+    statistics->shm_size = statistics->num_slots * STAT_SLOT_SIZE;
+
+    TRACE_INFO("%lu slots defined\n", statistics->num_slots);
+    TRACE_INFO("Statistics SHM size: %lu\n", statistics->shm_size);
+
+    rc = statistics_open_shm(statistics, -1, CK_TRUE);
+    if (rc != CKR_OK)
+        goto error;
+
+    statistics->increment_func = statistics_increment;
+
+    return CKR_OK;
+
+error:
+    statistics_term(statistics);
+    return rc;
+}
+
+void statistics_term(struct statistics *statistics)
+{
+    statistics_close_shm(statistics, CK_FALSE);
+}
+

--- a/usr/lib/api/statistics.h
+++ b/usr/lib/api/statistics.h
@@ -41,7 +41,10 @@ typedef CK_RV (*statistics_increment_f)(struct statistics *statistics,
                                         const CK_MECHANISM *mech,
                                         CK_ULONG strength);
 
+#define STATISTICS_FLAG_COUNT_IMPLICIT      (1 << 0)
+
 struct statistics {
+    CK_ULONG flags;
     CK_ULONG num_slots;
     CK_ULONG slot_shm_offsets[NUMBER_SLOTS_MANAGED];
     CK_ULONG shm_size;
@@ -60,7 +63,7 @@ struct statistics {
     } while (0)
 
 CK_RV statistics_init(struct statistics *statistics,
-                      Slot_Mgr_Socket_t *slots_infos);
+                      Slot_Mgr_Socket_t *slots_infos, CK_ULONG flags);
 void statistics_term(struct statistics *statistics);
 
 #endif

--- a/usr/lib/api/statistics.h
+++ b/usr/lib/api/statistics.h
@@ -1,0 +1,66 @@
+/*
+ * COPYRIGHT (c) International Business Machines Corp. 2021
+ *
+ * This program is provided under the terms of the Common Public License,
+ * version 1.0 (CPL-1.0). Any use, reproduction or distribution for this
+ * software constitutes recipient's acceptance of CPL-1.0 terms which can be
+ * found in the file LICENSE file or at
+ * https://opensource.org/licenses/cpl1.0.php
+ */
+#ifndef OCK_STATISTICS_H
+#define OCK_STATISTICS_H
+
+#include <pkcs11types.h>
+#include "slotmgr.h"
+#include "mechtable.h"
+#include "supportedstrengths.h"
+
+/*
+ * Statistics are collected in a shared memory segment per user.
+ * The statistics shared memory segment has the following layout:
+ * - For each configured slot:
+ *    - For each supported mechanism:
+ *       - one counter (counter_t) for non-key mechanisms (strength=0)
+ *       - one counter for each supported strength (counter_t each)
+ *
+ * The size of the shared segment therefore is:
+ *   Num configured slots * num supp.mechanisms * (num supp. strength + 1) *
+ *                                                  size of a counter
+ */
+
+typedef CK_ULONG counter_t;
+
+#define STAT_MECH_SIZE  ((NUM_SUPPORTED_STRENGTHS + 1) * sizeof(counter_t))
+#define STAT_SLOT_SIZE  (MECHTABLE_NUM_ELEMS * STAT_MECH_SIZE)
+
+struct statistics;
+typedef struct statistics *statistics_t;
+
+typedef CK_RV (*statistics_increment_f)(struct statistics *statistics,
+                                        CK_SLOT_ID slot,
+                                        const CK_MECHANISM *mech,
+                                        CK_ULONG strength);
+
+struct statistics {
+    CK_ULONG num_slots;
+    CK_ULONG slot_shm_offsets[NUMBER_SLOTS_MANAGED];
+    CK_ULONG shm_size;
+    char shm_name[PATH_MAX];
+    int shm_handle;
+    CK_BYTE *shm_data;
+    statistics_increment_f increment_func; /* NULL if statistics disabled */
+};
+
+#define INC_COUNTER(tokdata, sess, mech, key, no_key_strength)              \
+    do {                                                                    \
+        if ((tokdata)->statistics->increment_func != NULL)                  \
+            (tokdata)->statistics->increment_func((tokdata)->statistics,    \
+                  (sess)->session_info.slotID, (mech), (key) != NULL ?      \
+                  ((OBJECT *)(key))->strength.strength : (no_key_strength));\
+    } while (0)
+
+CK_RV statistics_init(struct statistics *statistics,
+                      Slot_Mgr_Socket_t *slots_infos);
+void statistics_term(struct statistics *statistics);
+
+#endif

--- a/usr/lib/api/statistics.h
+++ b/usr/lib/api/statistics.h
@@ -42,6 +42,7 @@ typedef CK_RV (*statistics_increment_f)(struct statistics *statistics,
                                         CK_ULONG strength);
 
 #define STATISTICS_FLAG_COUNT_IMPLICIT      (1 << 0)
+#define STATISTICS_FLAG_COUNT_INTERNAL      (1 << 1)
 
 struct statistics {
     CK_ULONG flags;

--- a/usr/lib/common/dig_mgr.c
+++ b/usr/lib/common/dig_mgr.c
@@ -23,7 +23,7 @@
 #include "h_extern.h"
 #include "tok_spec_struct.h"
 #include "trace.h"
-
+#include "../api/statistics.h"
 
 //
 //
@@ -127,6 +127,9 @@ CK_RV digest_mgr_init(STDLL_TokData_t *tokdata,
     ctx->multi = FALSE;
     ctx->active = TRUE;
 
+    if (ctx->count_statistics == TRUE)
+        INC_COUNTER(tokdata, sess, mech, NULL, POLICY_STRENGTH_IDX_0);
+
     return CKR_OK;
 }
 
@@ -147,6 +150,7 @@ CK_RV digest_mgr_cleanup(STDLL_TokData_t *tokdata, SESSION *sess,
     ctx->active = FALSE;
     ctx->context_len = 0;
     ctx->state_unsaveable = FALSE;
+    ctx->count_statistics = FALSE;
 
     if (ctx->mech.pParameter) {
         free(ctx->mech.pParameter);

--- a/usr/lib/common/h_extern.h
+++ b/usr/lib/common/h_extern.h
@@ -832,6 +832,7 @@ CK_RV dh_pkcs_derive(STDLL_TokData_t *tokdata,
 // DH mechanisms
 //
 CK_RV ckm_dh_pkcs_derive(STDLL_TokData_t *tokdata,
+                         SESSION *sess,
                          CK_VOID_PTR other_pubkey,
                          CK_ULONG other_pubkey_len,
                          CK_OBJECT_HANDLE base_key,

--- a/usr/lib/common/h_extern.h
+++ b/usr/lib/common/h_extern.h
@@ -730,6 +730,8 @@ CK_RV rsa_parse_block(CK_BYTE *in_data,
                       CK_BYTE *out_data,
                       CK_ULONG *out_data_len, CK_ULONG type);
 
+CK_RV get_mgf_mech(CK_RSA_PKCS_MGF_TYPE mgf, CK_MECHANISM_TYPE *mech);
+
 // RSA mechanisms
 //
 CK_RV ckm_rsa_key_pair_gen(STDLL_TokData_t *tokdata, TEMPLATE *publ_tmpl,
@@ -846,6 +848,8 @@ CK_RV ckm_dh_pkcs_key_pair_gen(STDLL_TokData_t *tokdata,
                                TEMPLATE *publ_tmpl, TEMPLATE *priv_tmpl);
 #endif
 /* End code contributed by Corrent corp. */
+
+CK_RV digest_from_kdf(CK_EC_KDF_TYPE kdf, CK_MECHANISM_TYPE *mech);
 
 CK_RV pkcs_get_keytype(CK_ATTRIBUTE *attrs, CK_ULONG attrs_len,
                        CK_MECHANISM_PTR mech, CK_ULONG *type, CK_ULONG *class);

--- a/usr/lib/common/h_extern.h
+++ b/usr/lib/common/h_extern.h
@@ -457,6 +457,11 @@ void final_data_store(STDLL_TokData_t * tokdata);
 void copy_token_contents_sensibly(CK_TOKEN_INFO_PTR pInfo,
                                   TOKEN_DATA *nv_token_data);
 
+CK_RV compute_PKCS5_PBKDF2_HMAC(STDLL_TokData_t *tokdata,
+                                CK_CHAR *pPin, CK_ULONG ulPinLen,
+                                CK_BYTE *salt, CK_ULONG salt_len,
+                                CK_ULONG it_count, const EVP_MD *digest,
+                                CK_ULONG key_len, CK_BYTE *key);
 CK_RV compute_md5(STDLL_TokData_t *tokdata, CK_BYTE *data, CK_ULONG len,
                   CK_BYTE *hash);
 CK_RV compute_sha1(STDLL_TokData_t *tokdata, CK_BYTE *data, CK_ULONG len,

--- a/usr/lib/common/host_defs.h
+++ b/usr/lib/common/host_defs.h
@@ -360,6 +360,7 @@ struct _LW_SHM_TYPE {
 
 struct _STDLL_TokData_t {
     CK_SLOT_INFO slot_info;
+    CK_SLOT_ID slot_id;
     int spinxplfd;              // token specific lock
     unsigned int spinxplfd_count; // counter for recursive file lock
     pthread_mutex_t spinxplfd_mutex; // token specific pthread lock
@@ -391,6 +392,7 @@ struct _STDLL_TokData_t {
     struct policy *policy;
     const struct mechtable_funcs *mechtable_funcs;
     struct statistics *statistics;
+    struct tokstore_strength store_strength;
 };
 
 #endif

--- a/usr/lib/common/host_defs.h
+++ b/usr/lib/common/host_defs.h
@@ -22,6 +22,7 @@
 #include "local_types.h"
 #include "../api/policy.h"
 #include "../api/mechtable.h"
+#include "../api/statistics.h"
 
 struct _SESSION;
 
@@ -41,6 +42,7 @@ typedef struct _ENCR_DECR_CONTEXT {
                                 // on first call *after* init
     CK_BBOOL pkey_active;
     CK_BBOOL state_unsaveable;
+    CK_BBOOL count_statistics;
 } ENCR_DECR_CONTEXT;
 
 typedef struct _DIGEST_CONTEXT {
@@ -53,6 +55,7 @@ typedef struct _DIGEST_CONTEXT {
     CK_BBOOL multi_init;        // multi field is initialized
                                 // on first call *after* init
     CK_BBOOL state_unsaveable;
+    CK_BBOOL count_statistics;
 } DIGEST_CONTEXT;
 
 typedef struct _SIGN_VERIFY_CONTEXT {
@@ -69,6 +72,7 @@ typedef struct _SIGN_VERIFY_CONTEXT {
                                 // on first call *after* init
     CK_BBOOL pkey_active;
     CK_BBOOL state_unsaveable;
+    CK_BBOOL count_statistics;
 } SIGN_VERIFY_CONTEXT;
 
 
@@ -386,6 +390,7 @@ struct _STDLL_TokData_t {
     CK_ULONG mech_list_len;
     struct policy *policy;
     const struct mechtable_funcs *mechtable_funcs;
+    struct statistics *statistics;
 };
 
 #endif

--- a/usr/lib/common/key_mgr.c
+++ b/usr/lib/common/key_mgr.c
@@ -37,6 +37,7 @@
 #include "trace.h"
 
 #include "../api/policy.h"
+#include "../api/statistics.h"
 
 #include <openssl/crypto.h>
 
@@ -284,6 +285,9 @@ CK_RV key_mgr_generate_key(STDLL_TokData_t *tokdata,
         TRACE_DEVEL("object_mgr_create_final failed.\n");
         goto error;
     }
+
+    if (rc == CKR_OK)
+        INC_COUNTER(tokdata, sess, mech, key_obj, POLICY_STRENGTH_IDX_0);
 
     return rc;
 
@@ -629,6 +633,9 @@ CK_RV key_mgr_generate_key_pair(STDLL_TokData_t *tokdata,
         publ_key_obj = NULL;
         goto error;
     }
+
+    if (rc == CKR_OK)
+        INC_COUNTER(tokdata, sess, mech, priv_key_obj, POLICY_STRENGTH_IDX_0);
 
     return rc;
 
@@ -1045,6 +1052,10 @@ CK_RV key_mgr_wrap_key(STDLL_TokData_t *tokdata,
     free(ctx);
 
 done:
+    if (rc == CKR_OK)
+        INC_COUNTER(tokdata, sess, mech, wrapping_key_obj,
+                    POLICY_STRENGTH_IDX_0);
+
     if (wrapping_key_obj != NULL) {
         object_put(tokdata, wrapping_key_obj, TRUE);
         wrapping_key_obj = NULL;
@@ -1371,6 +1382,10 @@ final:
     }
 
 done:
+    if (rc == CKR_OK)
+        INC_COUNTER(tokdata, sess, mech, unwrapping_key_obj,
+                    POLICY_STRENGTH_IDX_0);
+
     if (rc != CKR_OK && key_obj)
         object_free(key_obj);
     if (unwrapping_key_obj != NULL) {

--- a/usr/lib/common/mech_dh.c
+++ b/usr/lib/common/mech_dh.c
@@ -94,7 +94,8 @@ CK_RV dh_pkcs_derive(STDLL_TokData_t *tokdata,
     // Extract public-key from mechanism parameters. base-key contains the
     // private key, prime, and base. The return value will be in the handle.
 
-    rc = ckm_dh_pkcs_derive(tokdata, mech->pParameter, mech->ulParameterLen,
+    rc = ckm_dh_pkcs_derive(tokdata, sess,
+                            mech->pParameter, mech->ulParameterLen,
                             base_key, secret_key_value, &secret_key_value_len,
                             mech);
     if (rc != CKR_OK)
@@ -147,6 +148,7 @@ CK_RV dh_pkcs_derive(STDLL_TokData_t *tokdata,
 //
 //
 CK_RV ckm_dh_pkcs_derive(STDLL_TokData_t *tokdata,
+                         SESSION *sess,
                          CK_VOID_PTR other_pubkey,
                          CK_ULONG other_pubkey_len,
                          CK_OBJECT_HANDLE base_key,
@@ -246,6 +248,9 @@ CK_RV ckm_dh_pkcs_derive(STDLL_TokData_t *tokdata,
         TRACE_DEVEL("Token specific dh pkcs derive failed.\n");
 
 done:
+    if (rc == CKR_OK)
+        INC_COUNTER(tokdata, sess, mech, base_key_obj, POLICY_STRENGTH_IDX_0);
+
     object_put(tokdata, base_key_obj, TRUE);
     base_key_obj = NULL;
 

--- a/usr/lib/common/mech_ec.c
+++ b/usr/lib/common/mech_ec.c
@@ -790,8 +790,9 @@ CK_RV ckm_kdf_X9_63(STDLL_TokData_t *tokdata, SESSION *sess, CK_ULONG kdf,
     return CKR_OK;
 }
 
-CK_RV ckm_ecdh_pkcs_derive(STDLL_TokData_t *tokdata, CK_VOID_PTR other_pubkey,
-                           CK_ULONG other_pubkey_len, CK_OBJECT_HANDLE base_key,
+CK_RV ckm_ecdh_pkcs_derive(STDLL_TokData_t *tokdata, SESSION *sess,
+                           CK_VOID_PTR other_pubkey, CK_ULONG other_pubkey_len,
+                           CK_OBJECT_HANDLE base_key,
                            CK_BYTE *secret_value, CK_ULONG *secret_value_len,
                            CK_MECHANISM_PTR mech)
 {
@@ -890,6 +891,9 @@ CK_RV ckm_ecdh_pkcs_derive(STDLL_TokData_t *tokdata, CK_VOID_PTR other_pubkey,
     }
 
 done:
+    if (rc == CKR_OK)
+        INC_COUNTER(tokdata, sess, mech, base_key_obj, POLICY_STRENGTH_IDX_0);
+
     object_put(tokdata, base_key_obj, TRUE);
     base_key_obj = NULL;
 
@@ -1147,7 +1151,7 @@ CK_RV ecdh_pkcs_derive(STDLL_TokData_t *tokdata, SESSION *sess,
     }
 
     /* Derive the shared secret */
-    rc = ckm_ecdh_pkcs_derive(tokdata, pParms->pPublicData,
+    rc = ckm_ecdh_pkcs_derive(tokdata, sess, pParms->pPublicData,
                               pParms->ulPublicDataLen, base_key, z_value,
                               &z_len, mech);
     if (rc != CKR_OK) {

--- a/usr/lib/common/mech_ec.c
+++ b/usr/lib/common/mech_ec.c
@@ -900,32 +900,6 @@ done:
     return rc;
 }
 
-static CK_RV digest_from_kdf(CK_EC_KDF_TYPE kdf, CK_MECHANISM_TYPE *mech)
-{
-    switch (kdf) {
-    case CKD_SHA1_KDF:
-        *mech = CKM_SHA_1;
-        break;
-    case CKD_SHA224_KDF:
-        *mech = CKM_SHA224;
-        break;
-    case CKD_SHA256_KDF:
-        *mech = CKM_SHA256;
-        break;
-    case CKD_SHA384_KDF:
-        *mech = CKM_SHA384;
-        break;
-    case CKD_SHA512_KDF:
-        *mech = CKM_SHA512;
-        break;
-    default:
-        TRACE_ERROR("Error unsupported KDF %ld.\n", kdf);
-        return CKR_FUNCTION_FAILED;
-    }
-
-    return CKR_OK;
-}
-
 CK_RV pkcs_get_keytype(CK_ATTRIBUTE *attrs, CK_ULONG attrs_len,
                        CK_MECHANISM_PTR mech, CK_ULONG *type, CK_ULONG *class)
 {

--- a/usr/lib/common/mech_rsa.c
+++ b/usr/lib/common/mech_rsa.c
@@ -307,32 +307,6 @@ CK_RV rsa_parse_block(CK_BYTE *in_data,
     return rc;
 }
 
-/* helper function for rsa-oaep */
-CK_RV get_mgf_mech(CK_RSA_PKCS_MGF_TYPE mgf, CK_MECHANISM_TYPE *mech)
-{
-    switch (mgf) {
-    case CKG_MGF1_SHA1:
-        *mech = CKM_SHA_1;
-        break;
-    case CKG_MGF1_SHA224:
-        *mech = CKM_SHA224;
-        break;
-	case CKG_MGF1_SHA256:
-        *mech = CKM_SHA256;
-        break;
-    case CKG_MGF1_SHA384:
-        *mech = CKM_SHA384;
-        break;
-    case CKG_MGF1_SHA512:
-        *mech = CKM_SHA512;
-        break;
-    default:
-        return CKR_MECHANISM_INVALID;
-    }
-
-    return CKR_OK;
-}
-
 //
 //
 CK_RV rsa_pkcs_encrypt(STDLL_TokData_t *tokdata,

--- a/usr/lib/common/mech_ssl3.c
+++ b/usr/lib/common/mech_ssl3.c
@@ -1303,6 +1303,8 @@ CK_RV ssl3_master_key_derive(STDLL_TokData_t *tokdata,
     // occur in a separate call to C_DestroyObject
     //
 
+    INC_COUNTER(tokdata, sess, mech, base_key_obj, POLICY_STRENGTH_IDX_0);
+
     object_put(tokdata, base_key_obj, TRUE);
     base_key_obj = NULL;
 
@@ -1683,6 +1685,8 @@ CK_RV ssl3_key_and_mac_derive(STDLL_TokData_t *tokdata,
         params->pReturnedKeyMaterial->pIVServer = p2;
 #endif
     }
+
+    INC_COUNTER(tokdata, sess, mech, base_key_obj, POLICY_STRENGTH_IDX_0);
 
 error:
     object_put(tokdata, base_key_obj, TRUE);

--- a/usr/lib/common/new_host.c
+++ b/usr/lib/common/new_host.c
@@ -2060,6 +2060,7 @@ CK_RV SC_EncryptInit(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
         goto done;
     }
 
+    sess->encr_ctx.count_statistics = TRUE;
     rc = encr_mgr_init(tokdata, sess, &sess->encr_ctx, OP_ENCRYPT_INIT,
                        pMechanism, hKey, TRUE);
 
@@ -2290,6 +2291,7 @@ CK_RV SC_DecryptInit(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
         goto done;
     }
 
+    sess->decr_ctx.count_statistics = TRUE;
     rc = decr_mgr_init(tokdata, sess, &sess->decr_ctx, OP_DECRYPT_INIT,
                        pMechanism, hKey, TRUE);
     if (rc != CKR_OK)
@@ -2523,6 +2525,7 @@ CK_RV SC_DigestInit(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
         goto done;
     }
 
+    sess->digest_ctx.count_statistics = TRUE;
     rc = digest_mgr_init(tokdata, sess, &sess->digest_ctx, pMechanism, TRUE);
     if (rc != CKR_OK)
         TRACE_DEVEL("digest_mgr_init() failed.\n");
@@ -2756,6 +2759,7 @@ CK_RV SC_SignInit(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
         goto done;
     }
 
+    sess->sign_ctx.count_statistics = TRUE;
     rc = sign_mgr_init(tokdata, sess, &sess->sign_ctx, pMechanism, FALSE, hKey,
                        TRUE);
     if (rc != CKR_OK)
@@ -3092,6 +3096,7 @@ CK_RV SC_VerifyInit(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
         goto done;
     }
 
+    sess->verify_ctx.count_statistics = TRUE;
     rc = verify_mgr_init(tokdata, sess, &sess->verify_ctx, pMechanism,
                          FALSE, hKey, TRUE);
     if (rc != CKR_OK)
@@ -4024,6 +4029,8 @@ CK_RV SC_IBM_ReencryptSingle(STDLL_TokData_t *tokdata, ST_SESSION_T *sSession,
         goto done;
     }
 
+    sess->decr_ctx.count_statistics = TRUE;
+    sess->encr_ctx.count_statistics = TRUE;
     rc = encr_mgr_reencrypt_single(tokdata, sess, &sess->decr_ctx, pDecrMech,
                                    hDecrKey, &sess->encr_ctx, pEncrMech,
                                    hEncrKey, pEncryptedData, ulEncryptedDataLen,

--- a/usr/lib/common/new_host.c
+++ b/usr/lib/common/new_host.c
@@ -123,7 +123,7 @@ CK_RV ST_Initialize(API_Slot_t *sltp, CK_SLOT_ID SlotNumber,
     newdatastore = sinfp->version >= TOK_NEW_DATA_STORE ? CK_TRUE : CK_FALSE;
     rc = policy->check_token_store(policy, newdatastore,
                                    token_specific.data_store.encryption_algorithm,
-                                   SlotNumber, NULL);
+                                   SlotNumber, &sltp->TokData->store_strength);
     if (rc != CKR_OK) {
         TRACE_ERROR("POLICY VIOLATION: Token cannot load since data store encryption is too weak for policy.\n");
         goto done;
@@ -449,13 +449,12 @@ CK_RV SC_InitToken(STDLL_TokData_t *tokdata, CK_SLOT_ID sid, CK_CHAR_PTR pPin,
             goto done;
         }
     } else {
-        rc = PKCS5_PBKDF2_HMAC((char *)pPin, ulPinLen,
-                               dat->so_login_salt, 64,
-                               dat->so_login_it, EVP_sha512(),
-                               256 / 8, login_key);
-        if (rc != 1) {
+        rc = compute_PKCS5_PBKDF2_HMAC(tokdata, pPin, ulPinLen,
+                                       dat->so_login_salt, 64,
+                                       dat->so_login_it, EVP_sha512(),
+                                       256 / 8, login_key);
+        if (rc != CKR_OK) {
             TRACE_DEVEL("PBKDF2 failed.\n");
-            rc = CKR_FUNCTION_FAILED;
             goto done;
         }
         if (CRYPTO_memcmp(dat->so_login_key, login_key, 32) != 0) {
@@ -581,13 +580,13 @@ CK_RV SC_InitPIN(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
         memcpy(login_salt, USER_KDF_LOGIN_PURPOSE, 32);
         rng_generate(tokdata, login_salt + 32, 32);
 
-        rc = PKCS5_PBKDF2_HMAC((char *)pPin, ulPinLen,
-                               login_salt, 64,
-                               login_it, EVP_sha512(),
-                               256 / 8, login_key);
-        if (rc != 1) {
+
+        rc = compute_PKCS5_PBKDF2_HMAC(tokdata, pPin, ulPinLen,
+                                       login_salt, 64,
+                                       login_it, EVP_sha512(),
+                                       256 / 8, login_key);
+        if (rc != CKR_OK) {
             TRACE_DEVEL("PBKDF2 failed.\n");
-            rc = CKR_FUNCTION_FAILED;
             goto done;
         }
 
@@ -595,13 +594,12 @@ CK_RV SC_InitPIN(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
         memcpy(wrap_salt, USER_KDF_WRAP_PURPOSE, 32);
         rng_generate(tokdata, wrap_salt + 32, 32);
 
-        rc = PKCS5_PBKDF2_HMAC((char *)pPin, ulPinLen,
-                               wrap_salt, 64,
-                               wrap_it, EVP_sha512(),
-                               256 / 8, wrap_key);
-        if (rc != 1) {
+        rc = compute_PKCS5_PBKDF2_HMAC(tokdata, pPin, ulPinLen,
+                                       wrap_salt, 64,
+                                       wrap_it, EVP_sha512(),
+                                       256 / 8, wrap_key);
+        if (rc != CKR_OK) {
             TRACE_DEVEL("PBKDF2 failed.\n");
-            rc = CKR_FUNCTION_FAILED;
             goto done;
         }
     }
@@ -756,13 +754,12 @@ CK_RV SC_SetPIN(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
             memcpy(login_salt, USER_KDF_LOGIN_PURPOSE, 32);
             rng_generate(tokdata, login_salt + 32, 32);
 
-            rc = PKCS5_PBKDF2_HMAC((char *)pNewPin, ulNewLen,
-	                           login_salt, 64,
-                                   login_it, EVP_sha512(),
-                                   256 / 8, new_login_key);
-            if (rc != 1) {
+            rc = compute_PKCS5_PBKDF2_HMAC(tokdata, pNewPin, ulNewLen,
+                                           login_salt, 64,
+                                           login_it, EVP_sha512(),
+                                           256 / 8, new_login_key);
+            if (rc != CKR_OK) {
                 TRACE_DEVEL("PBKDF2 failed.\n");
-                rc = CKR_FUNCTION_FAILED;
                 goto done;
             }
 
@@ -770,32 +767,30 @@ CK_RV SC_SetPIN(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
             memcpy(wrap_salt, USER_KDF_WRAP_PURPOSE, 32);
             rng_generate(tokdata, wrap_salt + 32, 32);
 
-            rc = PKCS5_PBKDF2_HMAC((char *)pNewPin, ulNewLen,
-	                           wrap_salt, 64,
-                                   wrap_it, EVP_sha512(),
-                                   256 / 8, new_wrap_key);
-            if (rc != 1) {
+            rc = compute_PKCS5_PBKDF2_HMAC(tokdata, pNewPin, ulNewLen,
+                                           wrap_salt, 64,
+                                           wrap_it, EVP_sha512(),
+                                           256 / 8, new_wrap_key);
+            if (rc != CKR_OK) {
                 TRACE_DEVEL("PBKDF2 failed.\n");
-                rc = CKR_FUNCTION_FAILED;
                 goto done;
             }
 
-            rc = PKCS5_PBKDF2_HMAC((char *)pOldPin, ulOldLen,
-	                           dat->user_login_salt, 64,
-                                   dat->user_login_it, EVP_sha512(),
-                                   256 / 8, old_login_key);
-            if (rc != 1) {
+            rc = compute_PKCS5_PBKDF2_HMAC(tokdata, pOldPin, ulOldLen,
+                                           dat->user_login_salt, 64,
+                                           dat->user_login_it, EVP_sha512(),
+                                           256 / 8, old_login_key);
+            if (rc != CKR_OK) {
                 TRACE_DEVEL("PBKDF2 failed.\n");
-                rc = CKR_FUNCTION_FAILED;
                 goto done;
             }
-            rc = PKCS5_PBKDF2_HMAC((char *)pNewPin, ulNewLen,
-	                           dat->user_login_salt, 64,
-                                   dat->user_login_it, EVP_sha512(),
-                                   256 / 8, new_login_key_old_salt);
-            if (rc != 1) {
+
+            rc = compute_PKCS5_PBKDF2_HMAC(tokdata, pNewPin, ulNewLen,
+                                           dat->user_login_salt, 64,
+                                           dat->user_login_it, EVP_sha512(),
+                                           256 / 8, new_login_key_old_salt);
+            if (rc != CKR_OK) {
                 TRACE_DEVEL("PBKDF2 failed.\n");
-                rc = CKR_FUNCTION_FAILED;
                 goto done;
             }
 
@@ -880,13 +875,12 @@ CK_RV SC_SetPIN(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
             memcpy(login_salt, SO_KDF_LOGIN_PURPOSE, 32);
             rng_generate(tokdata, login_salt + 32, 32);
 
-            rc = PKCS5_PBKDF2_HMAC((char *)pNewPin, ulNewLen,
-	                           login_salt, 64,
-                                   login_it, EVP_sha512(),
-                                   256 / 8, new_login_key);
-            if (rc != 1) {
+            rc = compute_PKCS5_PBKDF2_HMAC(tokdata, pNewPin, ulNewLen,
+                                           login_salt, 64,
+                                           login_it, EVP_sha512(),
+                                           256 / 8, new_login_key);
+            if (rc != CKR_OK) {
                 TRACE_DEVEL("PBKDF2 failed.\n");
-                rc = CKR_FUNCTION_FAILED;
                 goto done;
             }
 
@@ -894,32 +888,30 @@ CK_RV SC_SetPIN(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
             memcpy(wrap_salt, SO_KDF_WRAP_PURPOSE, 32);
             rng_generate(tokdata, wrap_salt + 32, 32);
 
-            rc = PKCS5_PBKDF2_HMAC((char *)pNewPin, ulNewLen,
-	                           wrap_salt, 64,
-                                   wrap_it, EVP_sha512(),
-                                   256 / 8, new_wrap_key);
-            if (rc != 1) {
+            rc = compute_PKCS5_PBKDF2_HMAC(tokdata, pNewPin, ulNewLen,
+                                           wrap_salt, 64,
+                                           wrap_it, EVP_sha512(),
+                                           256 / 8, new_wrap_key);
+            if (rc != CKR_OK) {
                 TRACE_DEVEL("PBKDF2 failed.\n");
-                rc = CKR_FUNCTION_FAILED;
                 goto done;
             }
 
-            rc = PKCS5_PBKDF2_HMAC((char *)pOldPin, ulOldLen,
-	                           dat->so_login_salt, 64,
-                                   dat->so_login_it, EVP_sha512(),
-                                   256 / 8, old_login_key);
-            if (rc != 1) {
+            rc = compute_PKCS5_PBKDF2_HMAC(tokdata, pOldPin, ulOldLen,
+                                           dat->so_login_salt, 64,
+                                           dat->so_login_it, EVP_sha512(),
+                                           256 / 8, old_login_key);
+            if (rc != CKR_OK) {
                 TRACE_DEVEL("PBKDF2 failed.\n");
-                rc = CKR_FUNCTION_FAILED;
                 goto done;
             }
-            rc = PKCS5_PBKDF2_HMAC((char *)pNewPin, ulNewLen,
-	                           dat->so_login_salt, 64,
-                                   dat->so_login_it, EVP_sha512(),
-                                   256 / 8, new_login_key_old_salt);
-            if (rc != 1) {
+
+            rc = compute_PKCS5_PBKDF2_HMAC(tokdata, pNewPin, ulNewLen,
+                                           dat->so_login_salt, 64,
+                                           dat->so_login_it, EVP_sha512(),
+                                           256 / 8, new_login_key_old_salt);
+            if (rc != CKR_OK) {
                 TRACE_DEVEL("PBKDF2 failed.\n");
-                rc = CKR_FUNCTION_FAILED;
                 goto done;
             }
 
@@ -1341,22 +1333,21 @@ CK_RV SC_Login(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
             compute_md5(tokdata, pPin, ulPinLen, tokdata->user_pin_md5);
             memset(tokdata->so_pin_md5, 0x0, MD5_HASH_SIZE);
         } else {
-            rc = PKCS5_PBKDF2_HMAC((char *)pPin, ulPinLen,
-	                           dat->user_login_salt, 64,
-                                   dat->user_login_it, EVP_sha512(),
-                                   256 / 8, login_key);
-            if (rc != 1) {
+            rc = compute_PKCS5_PBKDF2_HMAC(tokdata, pPin, ulPinLen,
+                                           dat->user_login_salt, 64,
+                                           dat->user_login_it, EVP_sha512(),
+                                           256 / 8, login_key);
+            if (rc != CKR_OK) {
                 TRACE_DEVEL("PBKDF2 failed.\n");
-                rc = CKR_FUNCTION_FAILED;
                 goto done;
             }
-            rc = PKCS5_PBKDF2_HMAC((char *)pPin, ulPinLen,
-	                           dat->user_wrap_salt, 64,
-                                   dat->user_wrap_it, EVP_sha512(),
-                                   256 / 8, wrap_key);
-            if (rc != 1) {
+
+            rc = compute_PKCS5_PBKDF2_HMAC(tokdata, pPin, ulPinLen,
+                                           dat->user_wrap_salt, 64,
+                                           dat->user_wrap_it, EVP_sha512(),
+                                           256 / 8, wrap_key);
+            if (rc != CKR_OK) {
                 TRACE_DEVEL("PBKDF2 failed.\n");
-                rc = CKR_FUNCTION_FAILED;
                 goto done;
             }
 
@@ -1443,22 +1434,21 @@ CK_RV SC_Login(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
             compute_md5(tokdata, pPin, ulPinLen, tokdata->so_pin_md5);
             memset(tokdata->user_pin_md5, 0x0, MD5_HASH_SIZE);
         } else {
-            rc = PKCS5_PBKDF2_HMAC((char *)pPin, ulPinLen,
-	                           dat->so_login_salt, 64,
-                                   dat->so_login_it, EVP_sha512(),
-                                   256 / 8, login_key);
-            if (rc != 1) {
+            rc = compute_PKCS5_PBKDF2_HMAC(tokdata, pPin, ulPinLen,
+                                           dat->so_login_salt, 64,
+                                           dat->so_login_it, EVP_sha512(),
+                                           256 / 8, login_key);
+            if (rc != CKR_OK) {
                 TRACE_DEVEL("PBKDF2 failed.\n");
-                rc = CKR_FUNCTION_FAILED;
                 goto done;
             }
-            rc = PKCS5_PBKDF2_HMAC((char *)pPin, ulPinLen,
-	                           dat->so_wrap_salt, 64,
-                                   dat->so_wrap_it, EVP_sha512(),
-                                   256 / 8, wrap_key);
-            if (rc != 1) {
+
+            rc = compute_PKCS5_PBKDF2_HMAC(tokdata, pPin, ulPinLen,
+                                           dat->so_wrap_salt, 64,
+                                           dat->so_wrap_it, EVP_sha512(),
+                                           256 / 8, wrap_key);
+            if (rc != CKR_OK) {
                 TRACE_DEVEL("PBKDF2 failed.\n");
-                rc = CKR_FUNCTION_FAILED;
                 goto done;
             }
 

--- a/usr/lib/common/utility_common.c
+++ b/usr/lib/common/utility_common.c
@@ -10,6 +10,7 @@
 
 #include "pkcs11types.h"
 #include "defs.h"
+#include "trace.h"
 
 CK_RV get_sha_size(CK_ULONG mech, CK_ULONG *hsize)
 {
@@ -159,5 +160,69 @@ CK_RV get_hmac_digest(CK_ULONG mech, CK_ULONG *digest_mech, CK_BBOOL *general)
     default:
         return CKR_MECHANISM_INVALID;
     }
+    return CKR_OK;
+}
+
+CK_RV digest_from_kdf(CK_EC_KDF_TYPE kdf, CK_MECHANISM_TYPE *mech)
+{
+    switch (kdf) {
+    case CKD_SHA1_KDF:
+        *mech = CKM_SHA_1;
+        break;
+    case CKD_SHA224_KDF:
+        *mech = CKM_SHA224;
+        break;
+    case CKD_SHA256_KDF:
+        *mech = CKM_SHA256;
+        break;
+    case CKD_SHA384_KDF:
+        *mech = CKM_SHA384;
+        break;
+    case CKD_SHA512_KDF:
+        *mech = CKM_SHA512;
+        break;
+    default:
+        TRACE_ERROR("Error unsupported KDF %ld.\n", kdf);
+        return CKR_FUNCTION_FAILED;
+    }
+
+    return CKR_OK;
+}
+
+/* helper function for rsa-oaep and rsa-pss */
+CK_RV get_mgf_mech(CK_RSA_PKCS_MGF_TYPE mgf, CK_MECHANISM_TYPE *mech)
+{
+    switch (mgf) {
+    case CKG_MGF1_SHA1:
+        *mech = CKM_SHA_1;
+        break;
+    case CKG_MGF1_SHA224:
+        *mech = CKM_SHA224;
+        break;
+    case CKG_MGF1_SHA256:
+        *mech = CKM_SHA256;
+        break;
+    case CKG_MGF1_SHA384:
+        *mech = CKM_SHA384;
+        break;
+    case CKG_MGF1_SHA512:
+        *mech = CKM_SHA512;
+        break;
+    case CKG_IBM_MGF1_SHA3_224:
+        *mech = CKM_IBM_SHA3_224;
+        break;
+    case CKG_IBM_MGF1_SHA3_256:
+        *mech = CKM_IBM_SHA3_256;
+        break;
+    case CKG_IBM_MGF1_SHA3_384:
+        *mech = CKM_IBM_SHA3_384;
+        break;
+    case CKG_IBM_MGF1_SHA3_512:
+        *mech = CKM_IBM_SHA3_512;
+        break;
+    default:
+        return CKR_MECHANISM_INVALID;
+    }
+
     return CKR_OK;
 }

--- a/usr/lib/common/verify_mgr.c
+++ b/usr/lib/common/verify_mgr.c
@@ -26,6 +26,7 @@
 #include "trace.h"
 
 #include "../api/policy.h"
+#include "../api/statistics.h"
 
 //
 //
@@ -800,6 +801,9 @@ CK_RV verify_mgr_init(STDLL_TokData_t *tokdata,
     rc = CKR_OK;
 
 done:
+    if (ctx->count_statistics == TRUE && rc == CKR_OK)
+        INC_COUNTER(tokdata, sess, mech, key_obj, POLICY_STRENGTH_IDX_0);
+
     object_put(tokdata, key_obj, TRUE);
     key_obj = NULL;
 
@@ -827,6 +831,7 @@ CK_RV verify_mgr_cleanup(STDLL_TokData_t *tokdata, SESSION *sess,
     ctx->context_len = 0;
     ctx->pkey_active = FALSE;
     ctx->state_unsaveable = FALSE;
+    ctx->count_statistics = FALSE;
 
     if (ctx->mech.pParameter) {
         free(ctx->mech.pParameter);

--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -3822,6 +3822,8 @@ CK_RV ep11tok_generate_key(STDLL_TokData_t * tokdata, SESSION * session,
         goto error;
     }
 
+    INC_COUNTER(tokdata, session, mech, key_obj, POLICY_STRENGTH_IDX_0);
+
     goto done;
 error:
     if (key_obj)
@@ -5053,6 +5055,9 @@ CK_RV ep11tok_derive_key(STDLL_TokData_t * tokdata, SESSION * session,
         TRACE_ERROR("%s object_mgr_create_final with rc=0x%lx\n", __func__, rc);
         goto error;
     }
+
+    INC_COUNTER(tokdata, session, mech_orig, base_key_obj,
+                POLICY_STRENGTH_IDX_0);
 
     goto out;
 error:
@@ -6562,6 +6567,10 @@ CK_RV ep11tok_generate_key_pair(STDLL_TokData_t * tokdata, SESSION * sess,
         public_key_obj = NULL;
         goto error;
     }
+
+    INC_COUNTER(tokdata, sess, pMechanism, private_key_obj,
+                POLICY_STRENGTH_IDX_0);
+
     return rc;
 
 error:
@@ -6876,6 +6885,9 @@ CK_RV ep11tok_sign_init(STDLL_TokData_t * tokdata, SESSION * session,
     }
 
 done:
+    if (rc == CKR_OK)
+        INC_COUNTER(tokdata, session, mech, key_obj, POLICY_STRENGTH_IDX_0);
+
     object_put(tokdata, key_obj, TRUE);
     key_obj = NULL;
 
@@ -7038,8 +7050,6 @@ CK_RV ep11tok_sign_single(STDLL_TokData_t *tokdata, SESSION *session,
     CK_BYTE *keyblob;
     OBJECT *key_obj = NULL;
 
-    UNUSED(length_only);
-
     rc = h_opaque_2_blob(tokdata, key, &keyblob, &keyblobsize, &key_obj,
                          READ_LOCK);
     if (rc != CKR_OK) {
@@ -7073,6 +7083,9 @@ CK_RV ep11tok_sign_single(STDLL_TokData_t *tokdata, SESSION *session,
     }
 
 done:
+    if (rc == CKR_OK && length_only == FALSE)
+        INC_COUNTER(tokdata, session, mech, key_obj, POLICY_STRENGTH_IDX_0);
+
     object_put(tokdata, key_obj, TRUE);
     key_obj = NULL;
 
@@ -7193,6 +7206,9 @@ CK_RV ep11tok_verify_init(STDLL_TokData_t * tokdata, SESSION * session,
     }
 
 done:
+    if (rc == CKR_OK)
+        INC_COUNTER(tokdata, session, mech, key_obj, POLICY_STRENGTH_IDX_0);
+
     object_put(tokdata, key_obj, TRUE);
     key_obj = NULL;
 
@@ -7395,6 +7411,9 @@ CK_RV ep11tok_verify_single(STDLL_TokData_t *tokdata, SESSION *session,
     }
 
 done:
+    if (rc == CKR_OK || rc == CKR_SIGNATURE_INVALID)
+        INC_COUNTER(tokdata, session, mech, key_obj, POLICY_STRENGTH_IDX_0);
+
     object_put(tokdata, key_obj, TRUE);
     key_obj = NULL;
 
@@ -7557,8 +7576,6 @@ CK_RV ep11tok_decrypt_single(STDLL_TokData_t *tokdata, SESSION *session,
     CK_BYTE *keyblob;
     OBJECT *key_obj = NULL;
 
-    UNUSED(length_only);
-
     rc = h_opaque_2_blob(tokdata, key, &keyblob, &keyblobsize, &key_obj,
                          READ_LOCK);
     if (rc != CKR_OK) {
@@ -7591,6 +7608,9 @@ CK_RV ep11tok_decrypt_single(STDLL_TokData_t *tokdata, SESSION *session,
     } else {
         TRACE_INFO("%s rc=0x%lx\n", __func__, rc);
     }
+
+    if (rc == CKR_OK && length_only == FALSE)
+        INC_COUNTER(tokdata, session, mech, key_obj, POLICY_STRENGTH_IDX_0);
 
  done:
     object_put(tokdata, key_obj, TRUE);
@@ -7755,8 +7775,6 @@ CK_RV ep11tok_encrypt_single(STDLL_TokData_t *tokdata, SESSION *session,
     CK_BYTE *keyblob;
     OBJECT *key_obj = NULL;
 
-    UNUSED(length_only);
-
     rc = h_opaque_2_blob(tokdata, key, &keyblob, &keyblobsize, &key_obj,
                          READ_LOCK);
     if (rc != CKR_OK) {
@@ -7800,6 +7818,9 @@ CK_RV ep11tok_encrypt_single(STDLL_TokData_t *tokdata, SESSION *session,
     } else {
         TRACE_INFO("%s rc=0x%lx\n", __func__, rc);
     }
+
+    if (rc == CKR_OK && length_only == FALSE)
+        INC_COUNTER(tokdata, session, mech, key_obj, POLICY_STRENGTH_IDX_0);
 
 done:
     object_put(tokdata, key_obj, TRUE);
@@ -7940,6 +7961,9 @@ static CK_RV ep11_ende_crypt_init(STDLL_TokData_t * tokdata, SESSION * session,
     }
 
 done:
+    if (rc == CKR_OK)
+        INC_COUNTER(tokdata, session, mech, key_obj, POLICY_STRENGTH_IDX_0);
+
     object_put(tokdata, key_obj, TRUE);
     key_obj = NULL;
 
@@ -8127,6 +8151,10 @@ CK_RV ep11tok_wrap_key(STDLL_TokData_t * tokdata, SESSION * session,
         free(wrapped_key);
 
 done:
+    if (rc == CKR_OK && !size_query)
+        INC_COUNTER(tokdata, session, mech, wrap_key_obj,
+                    POLICY_STRENGTH_IDX_0);
+
     object_put(tokdata, wrap_key_obj, TRUE);
     wrap_key_obj = NULL;
     object_put(tokdata, key_obj, TRUE);
@@ -8472,6 +8500,8 @@ CK_RV ep11tok_unwrap_key(STDLL_TokData_t * tokdata, SESSION * session,
         TRACE_ERROR("%s object_mgr_create_final with rc=0x%lx\n", __func__, rc);
         goto error;
     }
+
+    INC_COUNTER(tokdata, session, mech, kobj, POLICY_STRENGTH_IDX_0);
 
     goto done;
 

--- a/usr/lib/ep11_stdll/new_host.c
+++ b/usr/lib/ep11_stdll/new_host.c
@@ -2679,6 +2679,7 @@ CK_RV SC_DigestInit(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
         goto done;
     }
 
+    sess->digest_ctx.count_statistics = TRUE;
     /* Policy already checked. */
     rc = digest_mgr_init(tokdata, sess, &sess->digest_ctx, pMechanism, FALSE);
     if (rc != CKR_OK)
@@ -2891,6 +2892,7 @@ CK_RV SC_SignInit(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
     }
 
     if (ep11tok_libica_mech_available(tokdata, pMechanism->mechanism, hKey)) {
+        sess->sign_ctx.count_statistics = TRUE;
         rc = sign_mgr_init(tokdata, sess, &sess->sign_ctx, pMechanism, FALSE,
                            hKey, TRUE);
         if (rc != CKR_OK)
@@ -3279,6 +3281,7 @@ CK_RV SC_VerifyInit(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
     }
 
     if (ep11tok_libica_mech_available(tokdata, pMechanism->mechanism, hKey)) {
+        sess->verify_ctx.count_statistics = TRUE;
         rc = verify_mgr_init(tokdata, sess, &sess->verify_ctx, pMechanism,
                              FALSE, hKey, TRUE);
         if (rc != CKR_OK)
@@ -4253,6 +4256,8 @@ CK_RV SC_IBM_ReencryptSingle(STDLL_TokData_t *tokdata, ST_SESSION_T *sSession,
         goto done;
     }
 
+    sess->decr_ctx.count_statistics = TRUE;
+    sess->encr_ctx.count_statistics = TRUE;
     rc = encr_mgr_reencrypt_single(tokdata, sess, &sess->decr_ctx, pDecrMech,
                                    hDecrKey, &sess->encr_ctx, pEncrMech,
                                    hEncrKey, pEncryptedData, ulEncryptedDataLen,

--- a/usr/lib/icsf_stdll/icsf_specific.c
+++ b/usr/lib/icsf_stdll/icsf_specific.c
@@ -2122,6 +2122,12 @@ CK_RV icsftok_generate_key_pair(STDLL_TokData_t * tokdata, SESSION * session,
     *p_priv_key = priv_node_number;
 
 done:
+    if (rc == CKR_OK && tokdata->statistics->increment_func != NULL)
+        tokdata->statistics->increment_func(tokdata->statistics,
+                                            session->session_info.slotID,
+                                            mech,
+                                            priv_key_mapping->strength.strength);
+
     free_attribute_array(new_pub_attrs, new_pub_attrs_len);
     free_attribute_array(new_priv_attrs, new_priv_attrs_len);
 
@@ -2239,6 +2245,11 @@ CK_RV icsftok_generate_key(STDLL_TokData_t * tokdata, SESSION * session,
     *handle = node_number;
 
 done:
+    if (rc == CKR_OK && tokdata->statistics->increment_func != NULL)
+        tokdata->statistics->increment_func(tokdata->statistics,
+                                            session->session_info.slotID,
+                                            mech, mapping->strength.strength);
+
     if (new_attrs)
         free_attribute_array(new_attrs, new_attrs_len);
 
@@ -2387,8 +2398,6 @@ CK_RV icsftok_encrypt_init(STDLL_TokData_t * tokdata,
                                           &mapping->strength,
                                           POLICY_CHECK_ENCRYPT,
                                           session);
-    bt_put_node_value(&icsf_data->objects, mapping);
-    mapping = NULL;
     if (rc != CKR_OK) {
         TRACE_ERROR("POLICY VIOLATION: encrypt init\n");
         goto done;
@@ -2456,8 +2465,15 @@ CK_RV icsftok_encrypt_init(STDLL_TokData_t * tokdata,
     }
 
 done:
+    if (rc == CKR_OK && tokdata->statistics->increment_func != NULL)
+        tokdata->statistics->increment_func(tokdata->statistics,
+                                            session->session_info.slotID,
+                                            mech, mapping->strength.strength);
+
     if (rc != CKR_OK)
         free_encr_ctx(encr_ctx);
+    bt_put_node_value(&icsf_data->objects, mapping);
+    mapping = NULL;
 
     return rc;
 }
@@ -2899,8 +2915,6 @@ CK_RV icsftok_decrypt_init(STDLL_TokData_t * tokdata,
                                           &mapping->strength,
                                           POLICY_CHECK_DECRYPT,
                                           session);
-    bt_put_node_value(&icsf_data->objects, mapping);
-    mapping = NULL;
     if (rc != CKR_OK) {
         TRACE_ERROR("POLICY VIOLATION: decrypt init\n");
         goto done;
@@ -2968,8 +2982,15 @@ CK_RV icsftok_decrypt_init(STDLL_TokData_t * tokdata,
     }
 
 done:
+    if (rc == CKR_OK && tokdata->statistics->increment_func != NULL)
+        tokdata->statistics->increment_func(tokdata->statistics,
+                                            session->session_info.slotID,
+                                            mech, mapping->strength.strength);
+
     if (rc != CKR_OK)
         free_encr_ctx(decr_ctx);
+    bt_put_node_value(&icsf_data->objects, mapping);
+    mapping = NULL;
 
     return rc;
 }
@@ -4014,6 +4035,11 @@ CK_RV icsftok_sign_init(STDLL_TokData_t * tokdata,
     ctx->active = TRUE;
 
 done:
+    if (rc == CKR_OK && tokdata->statistics->increment_func != NULL)
+        tokdata->statistics->increment_func(tokdata->statistics,
+                                            session->session_info.slotID,
+                                            mech, mapping->strength.strength);
+
     if (mapping) {
         bt_put_node_value(&icsf_data->objects, mapping);
         mapping = NULL;
@@ -4606,6 +4632,11 @@ CK_RV icsftok_verify_init(STDLL_TokData_t * tokdata,
     ctx->active = TRUE;
 
 done:
+    if (rc == CKR_OK && tokdata->statistics->increment_func != NULL)
+        tokdata->statistics->increment_func(tokdata->statistics,
+                                            session->session_info.slotID,
+                                            mech, mapping->strength.strength);
+
     if (mapping) {
         bt_put_node_value(&icsf_data->objects, mapping);
         mapping = NULL;
@@ -5088,6 +5119,12 @@ CK_RV icsftok_wrap_key(STDLL_TokData_t * tokdata,
     }
 
 done:
+    if (rc == CKR_OK && tokdata->statistics->increment_func != NULL)
+        tokdata->statistics->increment_func(tokdata->statistics,
+                                            session->session_info.slotID,
+                                            mech,
+                                            wrapping_key_mapping->strength.strength);
+
     if (wrapping_key_mapping) {
         bt_put_node_value(&icsf_data->objects, wrapping_key_mapping);
         wrapping_key_mapping = NULL;
@@ -5221,6 +5258,12 @@ CK_RV icsftok_unwrap_key(STDLL_TokData_t * tokdata,
     *p_key = node_number;
 
 done:
+    if (rc == CKR_OK && tokdata->statistics->increment_func != NULL)
+        tokdata->statistics->increment_func(tokdata->statistics,
+                                            session->session_info.slotID,
+                                            mech,
+                                            wrapping_key_mapping->strength.strength);
+
     if (wrapping_key_mapping) {
         bt_put_node_value(&icsf_data->objects, wrapping_key_mapping);
         wrapping_key_mapping = NULL;
@@ -5404,6 +5447,12 @@ CK_RV icsftok_derive_key(STDLL_TokData_t * tokdata, SESSION * session,
     }
 
 done:
+    if (rc == CKR_OK && tokdata->statistics->increment_func != NULL)
+        tokdata->statistics->increment_func(tokdata->statistics,
+                                            session->session_info.slotID,
+                                            mech,
+                                            base_key_mapping->strength.strength);
+
     if (base_key_mapping) {
         bt_put_node_value(&icsf_data->objects, base_key_mapping);
         base_key_mapping = NULL;

--- a/usr/lib/icsf_stdll/new_host.c
+++ b/usr/lib/icsf_stdll/new_host.c
@@ -113,11 +113,12 @@ CK_RV ST_Initialize(API_Slot_t *sltp, CK_SLOT_ID SlotNumber,
     newdatastore = sinfp->version >= TOK_NEW_DATA_STORE ? CK_TRUE : CK_FALSE;
     rc = policy->check_token_store(policy, newdatastore,
                                    token_specific.data_store.encryption_algorithm,
-                                   SlotNumber, NULL);
+                                   SlotNumber, &sltp->TokData->store_strength);
     if (rc != CKR_OK) {
         TRACE_ERROR("POLICY VIOLATION: Token cannot load since data store encryption is too weak for policy.\n");
         goto done;
     }
+
     /* Initialize Lock */
     if (XProcLock_Init(sltp->TokData) != CKR_OK) {
         TRACE_ERROR("Thread lock failed.\n");

--- a/usr/lib/icsf_stdll/new_host.c
+++ b/usr/lib/icsf_stdll/new_host.c
@@ -1937,6 +1937,7 @@ CK_RV SC_DigestInit(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
         goto done;
     }
 
+    sess->digest_ctx.count_statistics = TRUE;
     rc = digest_mgr_init(tokdata, sess, &sess->digest_ctx, pMechanism, TRUE);
     if (rc != CKR_OK)
         TRACE_DEVEL("digest_mgr_init() failed.\n");

--- a/usr/lib/icsf_stdll/pbkdf.h
+++ b/usr/lib/icsf_stdll/pbkdf.h
@@ -28,24 +28,33 @@
 
 CK_RV get_randombytes(unsigned char *output, int bytes);
 
-CK_RV encrypt_aes(CK_BYTE * racfpwd, int racflen, CK_BYTE * dkey,
-                  CK_BYTE * iv, CK_BYTE * outbuf, int *outbuflen);
+CK_RV encrypt_aes(STDLL_TokData_t *tokdata,
+                  CK_BYTE * racfpwd, int racflen, CK_BYTE * dkey,
+                  CK_BYTE * iv, CK_BYTE * outbuf, int *outbuflen,
+                  CK_BBOOL wrap);
 
-CK_RV decrypt_aes(CK_BYTE * edata, int edatalen, CK_BYTE * dkey,
-                  CK_BYTE * iv, CK_BYTE * ddata, int *ddatalen);
+CK_RV decrypt_aes(STDLL_TokData_t *tokdata,
+                  CK_BYTE * edata, int edatalen, CK_BYTE * dkey,
+                  CK_BYTE * iv, CK_BYTE * ddata, int *ddatalen,
+                  CK_BBOOL unwrap);
 
-CK_RV get_racf(CK_BYTE * mk, CK_ULONG mklen, CK_BYTE * racfpwd, int *racflen);
+CK_RV get_racf(STDLL_TokData_t *tokdata,
+               CK_BYTE * mk, CK_ULONG mklen, CK_BYTE * racfpwd, int *racflen);
 
-CK_RV get_masterkey(CK_BYTE *pin, CK_ULONG pinlen, const char *fname,
+CK_RV get_masterkey(STDLL_TokData_t *tokdata,
+                    CK_BYTE *pin, CK_ULONG pinlen, const char *fname,
                     CK_BYTE *masterkey, int *len);
 
-CK_RV pbkdf(CK_BYTE * passwd, CK_ULONG passwdlen, CK_BYTE * salt,
+CK_RV pbkdf(STDLL_TokData_t *tokdata,
+            CK_BYTE * passwd, CK_ULONG passwdlen, CK_BYTE * salt,
             CK_BYTE * dkey, CK_ULONG klen);
 
-CK_RV secure_racf(CK_BYTE * racfpwd, CK_ULONG racflen, CK_BYTE * mk,
+CK_RV secure_racf(STDLL_TokData_t *tokdata,
+                  CK_BYTE * racfpwd, CK_ULONG racflen, CK_BYTE * mk,
                   CK_ULONG mklen);
 
-CK_RV secure_masterkey(CK_BYTE * masterkey, CK_ULONG len, CK_BYTE * pin,
+CK_RV secure_masterkey(STDLL_TokData_t *tokdata,
+                       CK_BYTE * masterkey, CK_ULONG len, CK_BYTE * pin,
                        CK_ULONG pinlen, const char *fname);
 
 #endif

--- a/usr/sbin/pkcsicsf/pkcsicsf.c
+++ b/usr/sbin/pkcsicsf/pkcsicsf.c
@@ -503,7 +503,7 @@ static int secure_racf_passwd(char *racfpwd, unsigned int len)
     }
 
     /* use the master key to secure the racf passwd */
-    rc = secure_racf((CK_BYTE *)racfpwd, len, masterkey, AES_KEY_SIZE_256);
+    rc = secure_racf(NULL, (CK_BYTE *)racfpwd, len, masterkey, AES_KEY_SIZE_256);
     if (rc != 0) {
         fprintf(stderr, "Failed to secure racf passwd.\n");
         rc = -1;
@@ -513,7 +513,7 @@ static int secure_racf_passwd(char *racfpwd, unsigned int len)
     /* now secure the master key with a derived key */
     /* first get the filename to put the  encrypted masterkey */
     snprintf(fname, sizeof(fname), "%s/MK_SO", ICSF_CONFIG_PATH);
-    rc = secure_masterkey(masterkey, AES_KEY_SIZE_256, (CK_BYTE *)sopin,
+    rc = secure_masterkey(NULL, masterkey, AES_KEY_SIZE_256, (CK_BYTE *)sopin,
                           strlen(sopin), fname);
 
     if (rc != 0) {

--- a/usr/sbin/pkcsslotd/socket_server.c
+++ b/usr/sbin/pkcsslotd/socket_server.c
@@ -1640,7 +1640,6 @@ int init_socket_data(Slot_Mgr_Socket_t *socketData)
 {
     unsigned int processed = 0;
 
-    socketData->flags = 0;
     PopulateCKInfo(&(socketData->ck_info));
     socketData->num_slots = NumberSlotsInDB;
     PopulateSlotInfo(socketData->slot_info, &processed);

--- a/usr/sbin/pkcsstats/pkcsstats.c
+++ b/usr/sbin/pkcsstats/pkcsstats.c
@@ -1,0 +1,867 @@
+/*
+ * COPYRIGHT (c) International Business Machines Corp. 2021
+ *
+ * This program is provided under the terms of the Common Public License,
+ * version 1.0 (CPL-1.0). Any use, reproduction or distribution for this
+ * software constitutes recipient's acceptance of CPL-1.0 terms which can be
+ * found in the file LICENSE file or at
+ * https://opensource.org/licenses/cpl1.0.php
+ */
+
+/*
+ * pkcsstats - A tool to display mechanism usage statistics.
+ *
+ */
+
+#define _GNU_SOURCE
+#include <fcntl.h>
+#include <err.h>
+#include <errno.h>
+#include <getopt.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <limits.h>
+#include <pwd.h>
+#include <dlfcn.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <dirent.h>
+#include <pkcs11types.h>
+
+#include "statistics.h"
+#include "p11util.h"
+
+#define UNUSED(var)            ((void)(var))
+
+static void usage(char *progname)
+{
+    printf("Usage: %s [OPTIONS]\n\n", progname);
+    printf("Display mechanism usage statistics for openCryptoki.\n\n");
+    printf("OPTIONS:\n");
+    printf(" -U, --user USERID  show the statistics from one user. (root user only)\n");
+    printf(" -S, --summary      show the accumulated statistics from all users. (root user only)\n");
+    printf(" -A, --all          show the statistic tables from all users. (root user only)\n");
+    printf(" -a, --all-mechs    show all mechanisms, also those with all zero counters.\n");
+    printf(" -s, --slot SLOTID  show the statistics from one slot only.\n");
+    printf(" -r, --reset        set the own statistics to zero.\n");
+    printf(" -R, --reset-all    reset the statistics from all users. (root user only)\n");
+    printf(" -d, --delete       delete your own statistics.\n");
+    printf(" -D, --delete-all   delete the statistics from all users. (root user only)\n");
+    printf(" -h, --help         display help information.\n");
+
+    return;
+}
+
+static void make_shm_name(char *shm_name, size_t max_shm_len, int user_id)
+{
+    int i;
+
+    if (user_id == -1)
+        snprintf(shm_name, max_shm_len - 1, "%s_stats", CONFIG_PATH);
+    else
+        snprintf(shm_name, max_shm_len - 1, "%s_stats_%u", CONFIG_PATH,
+                 user_id);
+
+    for (i = 1; shm_name[i] != '\0'; i++) {
+        if (shm_name[i] == '/')
+            shm_name[i] = '.';
+    }
+    if (shm_name[0] != '/') {
+        memmove(&shm_name[1], &shm_name[0], strlen(shm_name) + 1);
+        shm_name[0] = '/';
+    }
+}
+
+static int open_shm(uid_t user_id, const char *user_name,
+                    CK_ULONG num_slots, int *shm_fd, CK_BYTE **shm_data,
+                    CK_ULONG *shm_size)
+{
+    char shm_name[PATH_MAX];
+    struct stat stat_buf;
+
+    make_shm_name(shm_name, sizeof(shm_name), user_id);
+
+    *shm_fd = shm_open(shm_name, O_RDWR, S_IRUSR | S_IWUSR);
+    if (*shm_fd == -1) {
+        if (errno == ENOENT)
+            warnx("No statistics are available for user '%s'", user_name);
+        else
+            warnx("Failed to open statistics for user '%s': shm_open('%s'): %s",
+                  user_name, shm_name, strerror(errno));
+        return 1;
+    }
+
+    if (fstat(*shm_fd, &stat_buf)) {
+        warnx("Failed to open statistics for user '%s': stat('%s'): %s",
+              user_name, shm_name, strerror(errno));
+        close(*shm_fd);
+        return 1;
+    }
+
+    /*
+     * If the shared memory segment does not belong to the pkcs11 group or does
+     * not have correct permissions, do not use it.
+     */
+    if (stat_buf.st_uid != user_id || stat_buf.st_gid != user_id ||
+        (stat_buf.st_mode & ~S_IFMT) != (S_IRUSR | S_IWUSR)) {
+        warnx("Failed to open statistics for user '%s': SHM '%s' has wrong mode/owner",
+              user_name, shm_name);
+        close(*shm_fd);
+        return 1;
+    }
+
+    *shm_size = num_slots * STAT_SLOT_SIZE;
+
+    if ((CK_ULONG)stat_buf.st_size != *shm_size) {
+        warnx("Failed to open statistics for user '%s': SHM '%s' has wrong size",
+              user_name, shm_name);
+        close(*shm_fd);
+        return 1;
+    }
+
+    *shm_data = (CK_BYTE *)mmap(NULL, *shm_size,
+                                PROT_READ | PROT_WRITE, MAP_SHARED,
+                                *shm_fd, 0);
+    if (*shm_data == MAP_FAILED) {
+        warnx("Failed to open statistics for user '%s': mmap('%s'): %s",
+              user_name, shm_name,  strerror(errno));
+        close(*shm_fd);
+        return 1;
+    }
+
+    return 0;
+}
+
+static void close_shm(int shm_fd, CK_BYTE *shm_data, CK_ULONG shm_size)
+{
+    if (shm_data == NULL || shm_fd == -1)
+         return;
+
+     munmap(shm_data, shm_size);
+     close(shm_fd);
+}
+
+typedef int (*user_f)(int user_id, const char *user_name, void *private);
+
+static int for_all_users(user_f user_cb, void *cb_private)
+{
+    char shm_prefix[PATH_MAX];
+    struct dirent *direntp;
+    DIR *shmDir;
+    struct passwd *pwd;
+    int rc = 0, uid;
+    char *endptr;
+
+    make_shm_name(shm_prefix, sizeof(shm_prefix), -1);
+
+    shmDir = opendir("/dev/shm");
+    if (shmDir == NULL) {
+        warnx("Failed to open /dev/shm: %s", strerror(errno));
+        return 1;
+    }
+
+    while ((direntp = readdir(shmDir)) != NULL) {
+        if(strstr(direntp->d_name, &shm_prefix[1]) != NULL) {
+            errno = 0;
+            uid = strtoul(&direntp->d_name[strlen(shm_prefix)], &endptr, 10);
+            if ((errno == ERANGE && uid >= INT_MAX) ||
+                (errno != 0 && uid == 0) || *endptr != '\0')
+                continue;
+
+            if((pwd = getpwuid(uid)) == NULL)
+                continue;
+
+            rc = user_cb(uid, pwd->pw_name, cb_private);
+            if (rc != 0)
+                break;
+        }
+    }
+
+    closedir(shmDir);
+    return rc;
+}
+
+typedef int (*slot_f)(CK_SLOT_ID slot_id, CK_BYTE *slot_data,
+                      CK_ULONG slot_size, void *private);
+
+static int for_all_slots(slot_f slot_cb, void *cb_private,
+                         CK_BYTE *shm_data, CK_ULONG shm_size,
+                         CK_ULONG num_slots, CK_SLOT_ID *slots,
+                         bool slot_id_specified, CK_SLOT_ID slot_id)
+{
+    int rc = 0;
+    CK_ULONG i;
+    bool slot_found = false;
+
+    for (i = 0; i < num_slots; i++) {
+        if (slot_id_specified && slots[i] != slot_id)
+             continue;
+
+        slot_found = true;
+
+        if ((i * STAT_SLOT_SIZE) + STAT_SLOT_SIZE > shm_size)
+            break;
+
+        rc = slot_cb(slots[i], &shm_data[i * STAT_SLOT_SIZE],  STAT_SLOT_SIZE,
+                     cb_private);
+        if (rc != 0)
+            break;
+    }
+
+    if (slot_id_specified && !slot_found) {
+        warnx("Slot %lu is not available", slot_id);
+        return 1;
+    }
+
+    return rc;
+}
+
+static bool all_conters_zero(CK_BYTE *mech_data, CK_ULONG mech_size)
+{
+    counter_t *counter = (counter_t *)mech_data;
+    int i;
+
+    for (i = 0; i < NUM_SUPPORTED_STRENGTHS + 1 &&
+                i * sizeof(counter_t) < mech_size; i++) {
+        if (counter[i] != 0)
+            return false;
+    }
+
+    return true;
+}
+
+typedef int (*mech_f)(CK_MECHANISM_TYPE mech, const char *mech_name,
+                      CK_BYTE *mech_data, CK_ULONG mech_size,
+                      CK_ULONG ofs, void *private);
+
+static int for_each_mech(mech_f mech_cb, void *cb_private,
+                         CK_BYTE *slot_data, CK_ULONG slot_size,
+                         bool all_mechs)
+{
+    CK_ULONG i, ofs;
+    int rc = -1;
+
+    for (i = 0, ofs = 0; i < MECHTABLE_NUM_ELEMS; i++, ofs += STAT_MECH_SIZE) {
+        if (ofs + STAT_MECH_SIZE > slot_size)
+            break;
+
+        if (!all_mechs && all_conters_zero(&slot_data[ofs], STAT_MECH_SIZE))
+            continue;
+
+        rc = mech_cb(mechtable_rows[i].numeric, mechtable_rows[i].string,
+                     &slot_data[ofs], STAT_MECH_SIZE, ofs, cb_private);
+        if (rc != 0)
+            break;
+    }
+
+    return rc;
+}
+
+static int delete_shm(uid_t user_id, const char *user_name)
+{
+    char shm_name[PATH_MAX];
+    int rc;
+
+    make_shm_name(shm_name, sizeof(shm_name), user_id);
+    rc = shm_unlink(shm_name);
+    if (rc != 0) {
+        if (errno == ENOENT)
+            warnx("No statistics are available for user '%s'", user_name);
+        else
+            warnx("Failed to delete statistics for user '%s': shm_unlink('%s'): %s",
+                  user_name, shm_name,  strerror(errno));
+        return 1;
+    }
+
+    printf("Deleted statistics for user '%s'\n", user_name);
+
+    return 0;
+}
+
+static int delete_all_cb(int user_id, const char *user_name, void *private)
+{
+    UNUSED(private);
+
+    return delete_shm(user_id, user_name);
+}
+
+static int reset_slot_cb(CK_SLOT_ID slot_id, CK_BYTE *slot_data,
+                         CK_ULONG slot_size, void *private)
+{
+    UNUSED(slot_id);
+    UNUSED(private);
+
+    memset(slot_data, 0, slot_size);
+
+    return 0;
+}
+
+static int reset_shm(uid_t user_id, const char *user_name,
+                     CK_ULONG num_slots, CK_SLOT_ID *slots,
+                     bool slot_id_specified, CK_SLOT_ID slot_id)
+{
+    int rc = 0, shm_fd = -1;
+    CK_BYTE *shm_data = NULL;
+    CK_ULONG shm_size = 0;
+
+    rc = open_shm(user_id, user_name, num_slots, &shm_fd, &shm_data, &shm_size);
+    if (rc != 0)
+        return rc;
+
+    rc = for_all_slots(reset_slot_cb, NULL, shm_data, shm_size,
+                       num_slots, slots, slot_id_specified, slot_id);
+
+    if (rc == 0) {
+        if (slot_id_specified)
+            printf("Resetted statistics for user '%s' and slot %lu\n",
+                   user_name, slot_id);
+        else
+            printf("Resetted statistics for user '%s'\n", user_name);
+    }
+
+    close_shm(shm_fd, shm_data, shm_size);
+    return rc;
+}
+
+struct reset_data {
+    CK_ULONG num_slots;
+    CK_SLOT_ID *slots;
+    bool slot_id_specified;
+    CK_SLOT_ID slot_id;
+};
+
+static int reset_all_cb(int user_id, const char *user_name, void *private)
+{
+    struct reset_data *rd = (struct reset_data *)private;
+
+    return reset_shm(user_id, user_name, rd->num_slots, rd->slots,
+                     rd->slot_id_specified, rd->slot_id);
+}
+
+static int get_slot_infos(CK_FUNCTION_LIST_PTR func_list,
+                          CK_SLOT_ID **slots, CK_ULONG *num_slots)
+{
+    CK_RV rc;
+
+    rc = func_list->C_GetSlotList(FALSE, NULL, num_slots);
+    if (rc != CKR_OK) {
+        warnx("Error getting number of slots: 0x%lX (%s)\n", rc,
+               p11_get_ckr(rc));
+        return 1;
+    }
+
+    if (*num_slots == 0) {
+        warnx("C_GetSlotList returned 0 slots. Check that your tokens"
+               " are installed correctly.\n");
+        return 1;
+    }
+
+    *slots = (CK_SLOT_ID_PTR) malloc(*num_slots * sizeof(CK_SLOT_ID));
+
+    rc = func_list->C_GetSlotList(FALSE, *slots, num_slots);
+    if (rc != CKR_OK) {
+        warnx("Error getting slot list: 0x%lX (%s)\n", rc, p11_get_ckr(rc));
+        return rc;
+    }
+
+    return 0;
+}
+
+int get_token_infos(CK_FUNCTION_LIST_PTR func_list, CK_SLOT_ID slot,
+                    char *label, size_t label_len,
+                    char *model, size_t model_len)
+{
+    CK_TOKEN_INFO info;
+    CK_RV rc;
+    int i;
+
+    rc = func_list->C_GetTokenInfo(slot, &info);
+    if (rc == CKR_TOKEN_NOT_PRESENT)
+        return -1;
+    if (rc != CKR_OK) {
+        warnx("Error getting token infos for slot %lu: 0x%lX (%s)\n", slot, rc,
+               p11_get_ckr(rc));
+        return 1;
+    }
+
+    for (i = sizeof(info.label) - 1; i >= 0 && info.label[i] == ' '; i--)
+        info.label[i] = '\0';
+    for (i = sizeof(info.model) - 1; i >= 0 && info.model[i] == ' '; i--)
+        info.model[i] = '\0';
+
+    if (label_len > sizeof(info.label))
+        label_len = sizeof(info.label);
+    strncpy(label, (char*)info.label, label_len);
+    label[label_len - 1] = '\0';
+
+    if (model_len > sizeof(info.model))
+        model_len = sizeof(info.model);
+    strncpy(model, (char*)info.model, model_len);
+    model[model_len - 1] = '\0';
+
+    return 0;
+}
+
+static int display_mech_cb(CK_MECHANISM_TYPE mech, const char *mech_name,
+                           CK_BYTE *mech_data, CK_ULONG mech_size,
+                           CK_ULONG ofs, void *private)
+{
+    counter_t *counter = (counter_t *)mech_data;
+    int i;
+
+    UNUSED(mech);
+    UNUSED(private);
+    UNUSED(ofs);
+
+    printf("%-30s |", mech_name);
+
+    for (i = 0; i < NUM_SUPPORTED_STRENGTHS + 1 &&
+                 i * sizeof(counter_t) < mech_size; i++)
+         printf(" %15lu", counter[i]);
+
+    printf("\n");
+
+    return 0;
+}
+
+struct display_data {
+    CK_FUNCTION_LIST *func_list;
+    CK_ULONG num_slots;
+    CK_SLOT_ID *slots;
+    bool slot_id_specified;
+    CK_SLOT_ID slot_id;
+    bool all_mechs;
+};
+
+static void print_horizontal_line()
+{
+    int i;
+
+    printf("-------------------------------+");
+    for (i = 0; i < NUM_SUPPORTED_STRENGTHS + 1; i++)
+        printf("----------------");
+    printf("-\n");
+}
+
+static void print_header()
+{
+    int i;
+
+    print_horizontal_line();
+    printf("mechanism                      | strength 0      ");
+    for (i = 0; i < NUM_SUPPORTED_STRENGTHS; i++)
+        printf("strength %-5lu  ",
+               supportedstrengths[NUM_SUPPORTED_STRENGTHS - 1 - i]);
+    printf("\n");
+    printf("                               | or no key\n");
+    print_horizontal_line();
+}
+
+static void print_footer()
+{
+    print_horizontal_line();
+    printf("\n");
+}
+
+
+static int display_slot_stats(CK_FUNCTION_LIST *func_list, CK_SLOT_ID slot,
+                              CK_BYTE *slot_data, CK_ULONG slot_size,
+                              bool all_mechs)
+{
+    char label[33], model[33];
+    int rc;
+
+    rc = get_token_infos(func_list, slot, label, sizeof(label),
+                         model, sizeof(model));
+    if (rc > 0)
+        return rc;
+
+    if (rc == 0)
+        printf("Slot: %lu (label: '%s' model: '%s')\n\n", slot, label, model);
+    else
+        printf("Slot: %lu (no token present)\n\n", slot);
+
+    print_header();
+
+    rc = for_each_mech(display_mech_cb, NULL, slot_data, slot_size, all_mechs);
+    if (rc < 0)
+        printf("[no mechanisms were used]      |\n");
+    else if (rc != 0)
+        return rc;
+
+    print_footer();
+
+    return 0;
+}
+
+static int display_slot_cb(CK_SLOT_ID slot_id, CK_BYTE *slot_data,
+                           CK_ULONG slot_size, void *private)
+{
+    return display_slot_stats(((struct display_data *)private)->func_list,
+                               slot_id, slot_data, slot_size,
+                              ((struct display_data *)private)->all_mechs);
+}
+
+static int display_stats(int user_id, const char *user_name,
+                         struct display_data* dd)
+{
+    int rc = 0, shm_fd = -1;
+    CK_BYTE *shm_data = NULL;
+    CK_ULONG shm_size = 0;
+
+    rc = open_shm(user_id, user_name, dd->num_slots, &shm_fd, &shm_data,
+                  &shm_size);
+    if (rc != 0)
+        return rc;
+
+    printf("User: %s\n\n", user_name);
+
+    rc = for_all_slots(display_slot_cb, dd, shm_data, shm_size,
+                       dd->num_slots, dd->slots,
+                       dd->slot_id_specified, dd->slot_id);
+
+    close_shm(shm_fd, shm_data, shm_size);
+    return rc;
+}
+
+static int display_all_cb(int user_id, const char *user_name, void *private)
+{
+    return display_stats(user_id, user_name, (struct display_data *)private);
+}
+
+struct summary_data {
+    CK_ULONG num_slots;
+    CK_SLOT_ID *slots;
+    CK_BYTE *summary_data;
+    CK_ULONG summary_size;
+    CK_SLOT_ID slot_id;
+};
+
+static int summary_mech_cb(CK_MECHANISM_TYPE mech, const char *mech_name,
+                           CK_BYTE *mech_data, CK_ULONG mech_size,
+                           CK_ULONG ofs, void *private)
+{
+    struct summary_data *sd = private;
+    counter_t *slot_counter = (counter_t *)mech_data;
+    counter_t *sum_counter;
+    int i;
+
+    UNUSED(mech);
+    UNUSED(mech_name);
+
+    ofs += sd->slot_id * STAT_SLOT_SIZE;
+    if (ofs + (NUM_SUPPORTED_STRENGTHS + 1) * sizeof(counter_t) >
+                                                        sd->summary_size) {
+        warnx("Internal error: mechanism offset larger than summary size");
+        return 1;
+    }
+
+    sum_counter = (counter_t *)(&sd->summary_data[ofs]);
+
+    for (i = 0; i < NUM_SUPPORTED_STRENGTHS + 1 &&
+                i * sizeof(counter_t) < mech_size; i++)
+        sum_counter[i] += slot_counter[i];
+
+    return 0;
+}
+
+static int summary_slot_cb(CK_SLOT_ID slot_id, CK_BYTE *slot_data,
+                           CK_ULONG slot_size, void *private)
+{
+    int rc;
+    struct summary_data *sd = private;
+
+    sd->slot_id = slot_id;
+
+    rc = for_each_mech(summary_mech_cb, sd, slot_data, slot_size, true);
+
+    return rc < 0 ? 0 : rc;
+}
+
+static int display_summary_cb(int user_id, const char *user_name, void *private)
+{
+    struct summary_data *sd = private;
+    int rc = 0, shm_fd = -1;
+    CK_BYTE *shm_data = NULL;
+    CK_ULONG shm_size = 0;
+
+    rc = open_shm(user_id, user_name, sd->num_slots, &shm_fd, &shm_data,
+                  &shm_size);
+    if (rc != 0)
+        return rc;
+
+    rc = for_all_slots(summary_slot_cb, sd, shm_data, shm_size,
+                       sd->num_slots, sd->slots, false, 0);
+
+    close_shm(shm_fd, shm_data, shm_size);
+    return rc;
+
+}
+
+static int display_summary(struct display_data* dd)
+{
+    struct summary_data sd;
+    int rc = 0;
+
+    sd.num_slots = dd->num_slots;
+    sd.slots = dd->slots;
+    sd.summary_size = dd->num_slots * STAT_SLOT_SIZE;
+    sd.summary_data = calloc(sd.summary_size, 1);
+    if (sd.summary_data == NULL) {
+        warnx("Failed to allocate the summary buffer");
+        return 1;
+    }
+
+    rc = for_all_users(display_summary_cb, &sd);
+    if (rc != 0)
+        goto done;
+
+    printf("Summary (all users):\n\n");
+
+    rc = for_all_slots(display_slot_cb, dd, sd.summary_data, sd.summary_size,
+                       dd->num_slots, dd->slots,
+                       dd->slot_id_specified, dd->slot_id);
+
+done:
+    free(sd.summary_data);
+
+    return rc;
+}
+
+int init_ock(void **dll, CK_FUNCTION_LIST_PTR *func_list)
+{
+    void (*sym_ptr)();
+    CK_RV rc;
+
+    *dll = dlopen("libopencryptoki.so", RTLD_NOW);
+    if (*dll == NULL) {
+        warnx("Error loading PKCS#11 library: dlopen: %s", dlerror());
+        return 1;
+    }
+
+    *(void **)(&sym_ptr) = dlsym(*dll, "C_GetFunctionList");
+    if (sym_ptr == NULL) {
+        warnx("Error loading PKCS#11 library: dlsym(C_GetFunctionList): %s",
+              dlerror());
+        dlclose(*dll);
+        *dll = NULL;
+        return 1;
+    }
+
+    sym_ptr(func_list);
+    if (*func_list == NULL) {
+        warnx("Error getting function list from PKCS11 library");
+        dlclose(*dll);
+        *dll = NULL;
+        return 1;
+    }
+
+    rc = (*func_list)->C_Initialize(NULL);
+    if (rc != CKR_OK) {
+        warnx("Error initializing the PKCS11 library: 0x%lX (%s)", rc,
+               p11_get_ckr(rc));
+        dlclose(*dll);
+        *dll = NULL;
+        *func_list = NULL;
+        return 1;
+    }
+
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    int opt = 0;
+    struct passwd *pswd = NULL;
+    int user_id = -1;
+    bool summary = false, all_users = false, all_mechs = false;
+    bool reset = false, reset_all = false;
+    bool delete = false, delete_all = false;
+    bool slot_id_specified = false;
+    CK_SLOT_ID slot_id = 0;
+    void *dll = NULL;
+    CK_FUNCTION_LIST *func_list = NULL;
+    CK_ULONG num_slots = 0;
+    CK_SLOT_ID *slots = NULL;
+    char *endptr;
+    int rc = 0;
+    struct display_data dd;
+    struct reset_data rd;
+
+    static const struct option long_opts[] = {
+        {"user", required_argument, NULL, 'U'},
+        {"summary", no_argument, NULL, 'S'},
+        {"all", no_argument, NULL, 'A'},
+        {"all-mechs", no_argument, NULL, 'a'},
+        {"slot", required_argument, NULL, 's'},
+        {"reset", no_argument, NULL, 'r'},
+        {"reset-all", no_argument, NULL, 'R'},
+        {"delete", no_argument, NULL, 'd'},
+        {"delete-all", no_argument, NULL, 'D'},
+        {"help", no_argument, NULL, 'h'},
+        {0, 0, 0, 0}
+    };
+
+    while ((opt = getopt_long(argc, argv, "U:SAas:rRdDh", long_opts, NULL)) != -1) {
+        switch (opt) {
+        case 'U':
+            if ((pswd = getpwnam(optarg)) == NULL) {
+                warnx("The username '%s' is not known on this system", optarg);
+                return EXIT_FAILURE;
+            }
+            if(geteuid() != 0 && geteuid() != pswd->pw_uid) {
+                warnx("You have no rights to display the statistics from other users");
+                return EXIT_FAILURE;
+            }
+            user_id = pswd->pw_uid;
+            break;
+        case 'S':
+            if (geteuid() != 0) {
+                warnx("You have no rights to display the statistics from all users");
+                return EXIT_FAILURE;
+            }
+            summary = true;
+            break;
+        case 'A':
+            if (geteuid() != 0) {
+                warnx("You have no rights to display the statistics from all users");
+                return EXIT_FAILURE;
+            }
+            all_users = true;
+            break;
+        case 'a':
+            all_mechs = true;
+            break;
+        case 's':
+            errno = 0;
+            slot_id = strtoul(optarg, &endptr, 10);
+            if ((errno == ERANGE && slot_id == ULONG_MAX) ||
+                (errno != 0 && slot_id == 0)) {
+                warnx("Slot parameter invalid: '%s'", optarg);
+                exit(EXIT_FAILURE);
+            }
+            slot_id_specified = CK_TRUE;
+            break;
+        case 'r':
+            reset = true;
+            break;
+        case 'R':
+            if (geteuid() != 0) {
+                warnx("You have no rights to reset the statistics from all users");
+                return EXIT_FAILURE;
+            }
+            reset_all = true;
+            break;
+        case 'd':
+            delete = true;
+            break;
+        case 'D':
+            if (geteuid() != 0) {
+                warnx("You have no rights to delete the statistics from all users");
+                return EXIT_FAILURE;
+            }
+            delete_all = true;
+            break;
+        case 'h':
+            usage(basename(argv[0]));
+            exit(EXIT_SUCCESS);
+        default:
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    if (optind < argc) {
+        warnx("unrecognized option '%s'", argv[optind]);
+        exit(EXIT_FAILURE);
+    }
+
+    if (user_id != -1 && all_users) {
+        warnx("Options -u/--user and -A/--all can not be specified together");
+        exit(EXIT_FAILURE);
+    }
+
+    if (user_id == -1) {
+        user_id = geteuid();
+        pswd = getpwuid(user_id);
+        if (pswd == NULL) {
+            warnx("Failed to get current user name");
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    if (delete) {
+        if (slot_id_specified) {
+            warnx("Options -s/--slot and -d/--delete can not be specified together");
+            exit(EXIT_FAILURE);
+        }
+
+        rc = delete_shm(user_id, pswd->pw_name);
+        goto done;
+    }
+
+    if (delete_all) {
+        if (slot_id_specified) {
+            warnx("Options -s/--slot and -D/--delete-all can not be specified together");
+            exit(EXIT_FAILURE);
+        }
+
+        rc = for_all_users(delete_all_cb, NULL);
+        goto done;
+    }
+
+    rc = init_ock(&dll, &func_list);
+    if (rc != 0)
+        goto done;
+
+    rc = get_slot_infos(func_list, &slots, &num_slots);
+    if (rc != 0)
+        goto done;
+
+    if (reset) {
+        rc = reset_shm(user_id, pswd->pw_name, num_slots, slots,
+                       slot_id_specified, slot_id);
+        goto done;
+    }
+
+    if (reset_all) {
+        rd.num_slots = num_slots;
+        rd.slots = slots;
+        rd.slot_id_specified = slot_id_specified;
+        rd.slot_id = slot_id;
+
+        rc = for_all_users(reset_all_cb, &rd);
+        goto done;
+    }
+
+    dd.func_list = func_list;
+    dd.num_slots = num_slots;
+    dd.slots = slots;
+    dd.slot_id_specified = slot_id_specified;
+    dd.slot_id = slot_id;
+    dd.all_mechs = all_mechs;
+    if (all_users) {
+        rc = for_all_users(display_all_cb, &dd);
+        goto done;
+    } else if (summary) {
+        rc = display_summary(&dd);
+        goto done;
+    } else {
+        rc = display_stats(user_id, pswd->pw_name, &dd);
+        goto done;
+    }
+
+done:
+    if (slots != NULL)
+        free(slots);
+
+    if (dll != NULL) {
+        func_list->C_Finalize(NULL);
+        dlclose(dll);
+    }
+
+    return rc == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/usr/sbin/pkcsstats/pkcsstats.mk
+++ b/usr/sbin/pkcsstats/pkcsstats.mk
@@ -1,0 +1,17 @@
+sbin_PROGRAMS += usr/sbin/pkcsstats/pkcsstats
+
+usr_sbin_pkcsstats_pkcsstats_LDFLAGS = -lcrypto -ldl -lrt
+
+usr_sbin_pkcsstats_pkcsstats_CFLAGS  =			\
+	-DOCK_TOOL					\
+	-DSTDLL_NAME=\"pkcsstats\"			\
+	-I${srcdir}/usr/include 			\
+	-I${srcdir}/usr/lib/common 			\
+	-I${srcdir}/usr/lib/api				\
+	-I${top_builddir}/usr/lib/api
+
+usr_sbin_pkcsstats_pkcsstats_SOURCES =			\
+	usr/sbin/pkcsstats/pkcsstats.c			\
+	usr/lib/common/p11util.c			\
+	usr/lib/api/supportedstrengths.c		\
+	usr/lib/api/mechtable.c

--- a/usr/sbin/sbin.mk
+++ b/usr/sbin/sbin.mk
@@ -16,6 +16,9 @@ endif
 if ENABLE_PKCSTOK_MIGRATE
 include usr/sbin/pkcstok_migrate/pkcstok_migrate.mk
 endif
+if ENABLE_PKCSSTATS
+include usr/sbin/pkcsstats/pkcsstats.mk
+endif
 
 include usr/sbin/pkcsslotd/pkcsslotd.mk
 include usr/sbin/pkcsconf/pkcsconf.mk


### PR DESCRIPTION
Add support for collecting and displaying mechanism usage statistics for openCryptoki. Usage statistics are collected by openCryptoki on a per user basis. For each user, mechanism usage is counted per configured slot and mechanism. For each mechanism a set of counters exist, one for each cryptographics strength of the cryptographic key used with the mechanism.