### PR TITLE
TESTCASE: tok2tok_transport: Enhance error handling

### DIFF
--- a/testcases/misc_tests/tok2tok_transport.c
+++ b/testcases/misc_tests/tok2tok_transport.c
@@ -820,8 +820,8 @@ CK_RV do_wrap_key_test(struct wrapped_mech_info *tsuite,
         }
         if ((rc == CKR_MECHANISM_INVALID || rc == CKR_KEY_TYPE_INCONSISTENT) &&
             is_ep11_token(slot_id2) && wrap_mech->mechanism == CKM_DES3_CBC &&
-            key_type == CKK_EC) {
-            testcase_skip("EP11 does not support unwrap of EC keys with DES3 CBC");
+            (key_type == CKK_EC || key_type == CKK_RSA)) {
+            testcase_skip("EP11 does not support unwrap of EC or RSA keys with DES3 CBC");
             rc = CKR_OK;
             goto testcase_cleanup;
         }


### PR DESCRIPTION
The same that was fixed with commit 022f04d9902d2d621158f1acefc0c7268b95ed6b for EC keys can also happen with RSA keys. Lets skip the testcase for RSA keys the same way as for EC keys.

FYI: @chrisRund 