### PR TITLE
libica version 4 support and a minor fix

### DIFF
--- a/usr/lib/common/key.c
+++ b/usr/lib/common/key.c
@@ -1303,6 +1303,7 @@ CK_RV priv_key_validate_attribute(STDLL_TokData_t *tokdata, TEMPLATE *tmpl,
          * support the attribute, the command SHALL return
          * CKR_ATTRIBUTE_TYPE_INVALID.
          */
+        TRACE_ERROR("%s\n", ock_err(ERR_ATTRIBUTE_TYPE_INVALID));
         return CKR_ATTRIBUTE_TYPE_INVALID;
     case CKA_UNWRAP_TEMPLATE:
         if ((attr->ulValueLen > 0 && attr->pValue == NULL) ||

--- a/usr/lib/ica_s390_stdll/ica_specific.c
+++ b/usr/lib/ica_s390_stdll/ica_specific.c
@@ -83,7 +83,8 @@ const char label[] = "icatok";
 
 static pthread_mutex_t rngmtx = PTHREAD_MUTEX_INITIALIZER;
 
-#define LIBICA_SHARED_LIB "libica.so.3"
+#define LIBICA_SHARED_LIB_V3 "libica.so.3"
+#define LIBICA_SHARED_LIB_V4 "libica.so.4"
 #define BIND(dso, sym)  do {                                             \
                             if (p_##sym == NULL)                         \
                                 *(void **)(&p_##sym) = dlsym(dso, #sym); \
@@ -221,9 +222,13 @@ static CK_RV load_libica(void)
     void *ibmca_dso = NULL;
 
     /* Load libica */
-    ibmca_dso = dlopen(LIBICA_SHARED_LIB, RTLD_NOW);
+    ibmca_dso = dlopen(LIBICA_SHARED_LIB_V4, RTLD_NOW);
+    if (ibmca_dso == NULL)
+        ibmca_dso = dlopen(LIBICA_SHARED_LIB_V3, RTLD_NOW);
+
     if (ibmca_dso == NULL) {
-        TRACE_ERROR("%s: dlopen(%s) failed\n", __func__, LIBICA_SHARED_LIB);
+        TRACE_ERROR("%s: dlopen(%s or %s) failed: %s\n", __func__,
+                    LIBICA_SHARED_LIB_V4, LIBICA_SHARED_LIB_V3, dlerror());
         return CKR_FUNCTION_FAILED;
     }
 


### PR DESCRIPTION
Now that libica version 4 is available, we need to adjust the ICA and EP11 tokens to support libica version 4 (libica.so.4), but fallback to version 3 (libica.so.3) if version 4 is not available. That way we don't have a requirement on a specific libica version. 