### PR TITLE
MAN: Update security note in opencryptoki man page

### DIFF
--- a/man/man7/opencryptoki.7.in
+++ b/man/man7/opencryptoki.7.in
@@ -21,8 +21,7 @@ All non-root users that require access to PKCS#11 tokens using openCryptoki
 must be assigned to the \fIpkcs11\fP group to be able to communicate with
 the \fIpkcsslotd\fP daemon. Only fully trusted users should be granted
 membership in the group. Group members can block other openCryptoki users
-from accessing PKCS#11 tokens, and execute arbitrary code with the
-privileges of other openCryptoki users.
+from accessing PKCS#11 tokens.
 
 .SH "SEE ALSO"
 .PD 0


### PR DESCRIPTION
The note about arbitrary code execution is no longer true since commit 3686bd27f890e95f47bc23d4961a1de4d87013da from 2013. This commit was included since Opencryptoki version 3.0.

Before that commit, the location of some shared libraries to be loaded were stored in the shared memory segment. Users in the pkcs11 group could write to the shared memory and thus replace those paths by their own shared libraries, which enabled arbitrary code execution e.g., by placing malicious code it in the library constructor.

Since the above commit, the location of those shared libraries is not read from the shared memory segment anymore since that was replaced by socket communication.

This fixes https://github.com/opencryptoki/opencryptoki/issues/467