### PR TITLE
P11SAK: CKA_PRIVATE now set by OCK

### DIFF
--- a/man/man1/p11sak.1.in
+++ b/man/man1/p11sak.1.in
@@ -84,7 +84,7 @@ option will show the arguments and options available.
 .B \-\-label
 .IR LABEL
 .B \-\-attr
-.IR [M R L S E D G V W U A X N T]
+.IR [P M R L S E D G V W U A X N T]
 .B \-\-help | \-h
 .PP
 Use the
@@ -105,7 +105,7 @@ option allows the user to set the
 .IR LABEL
 attribute of the key and
 .B \-\-attr
-.IR [M R L S E D G V W U A X N T]
+.IR [P M R L S E D G V W U A X N T]
 can be used to set the binary attributes of the key (see below for detailed description of the attributes).
 .
 .PP
@@ -122,7 +122,7 @@ can be used to set the binary attributes of the key (see below for detailed desc
 .B \-\-label
 .IR LABEL
 .B \-\-attr
-.IR [M R L S E D G V W U A X N T]
+.IR [P M R L S E D G V W U A X N T]
 .B \-\-help | \-h
 .PP
 Use the
@@ -143,7 +143,7 @@ option allows the user to set the
 .IR LABEL
 attribute of the key and
 .B \-\-attr
-.IR [M R L S E D G V W U A X N T]
+.IR [P M R L S E D G V W U A X N T]
 can be used to set the binary attributes of the key (see below for detailed description of the attributes).
 .
 .PP
@@ -162,7 +162,7 @@ can be used to set the binary attributes of the key (see below for detailed desc
 .B \-\-exponent
 .IR EXP
 .B \-\-attr
-.IR [M R L S E D G V W U A X N T]
+.IR [P M R L S E D G V W U A X N T]
 .B \-\-help | \-h
 .PP
 Use the
@@ -183,7 +183,7 @@ option allows the user to set the
 .IR LABEL
 attribute of the key and
 .B \-\-attr
-.IR [M R L S E D G V W U A X N T]
+.IR [P M R L S E D G V W U A X N T]
 can be used to set the binary attributes of the key (see below for detailed description of the attributes). Furthermore, the
 .B \-\-exponent
 .IR EXP
@@ -203,7 +203,7 @@ options allows the user to specify the exponent used for generating the RSA key.
 .B \-\-label
 .IR LABEL
 .B \-\-attr
-.IR [M R L S E D G V W U A X N T]
+.IR [P M R L S E D G V W U A X N T]
 .B \-\-help | \-h
 .PP
 Use the
@@ -234,7 +234,7 @@ option allows the user to set the
 .IR LABEL
 attribute of the key and
 .B \-\-attr
-.IR [M R L S E D G V W U A X N T]
+.IR [P M R L S E D G V W U A X N T]
 can be used to set the binary attributes of the key (see below for detailed description of the attributes).
 .
 .PP
@@ -352,7 +352,7 @@ sets the RSA exponent to
 .
 .
 .
-.SS "\-\-attr [M R L S E D G V W U A X N T]"
+.SS "\-\-attr [P M R L S E D G V W U A X N T]"
 sets the binary attributes of a key.
 .PP
 .B Note:
@@ -364,6 +364,9 @@ by default and switched to
 .B TRUE
 when the letter that is associated with the given binary attribute is specified. The following letters are associated with the respective
 .B CK_ATTRIBUTE:
+.IP "\(bu" 2
+.B P
+- CKA_PRIVATE
 .IP "\(bu" 2
 .B M
 - CKA_MODIFIABLE


### PR DESCRIPTION
This is a small fix addressing a problem, where p11sak sets the CKA_PRIVATE attribute for every generated key to true. CKA_PRIVATE can now be set, alongside the other standard attributes, with the --attr option and the letter P. 