### PR TITLE
Change /var/run to /run for pid file and sockets

### DIFF
--- a/misc/pkcsslotd.in
+++ b/misc/pkcsslotd.in
@@ -12,7 +12,7 @@
 
 . /etc/init.d/functions
 
-PIDFILE=/var/run/pkcsslotd.pid
+PIDFILE=/run/pkcsslotd.pid
 LOCKFILE=/var/lock/subsys/pkcsslotd
 SLOTDBIN=@sbindir@/pkcsslotd
 

--- a/misc/pkcsslotd.service.in
+++ b/misc/pkcsslotd.service.in
@@ -4,7 +4,7 @@ After=local-fs.target
 
 [Service]
 Type=forking
-PIDFile=/var/run/pkcsslotd.pid
+PIDFile=/run/pkcsslotd.pid
 ExecStart=@sbindir@/pkcsslotd
 
 [Install]

--- a/usr/include/slotmgr.h
+++ b/usr/include/slotmgr.h
@@ -30,10 +30,10 @@
 #define TOK_PATH  SBIN_PATH "/pkcsslotd"
 #define OCK_API_LOCK_FILE LOCKDIR_PATH "/LCK..APIlock"
 
-#define PROC_SOCKET_FILE_PATH "/var/run/pkcsslotd.socket"
-#define ADMIN_SOCKET_FILE_PATH "/var/run/pkcsslotd.admin.socket"
+#define PROC_SOCKET_FILE_PATH "/run/pkcsslotd.socket"
+#define ADMIN_SOCKET_FILE_PATH "/run/pkcsslotd.admin.socket"
 
-#define PID_FILE_PATH "/var/run/pkcsslotd.pid"
+#define PID_FILE_PATH "/run/pkcsslotd.pid"
 #define OCK_CONFIG OCK_CONFDIR "/opencryptoki.conf"
 
 #ifndef CK_BOOL


### PR DESCRIPTION
The usage of /var/run is deprecated.

Change was suggested by Mark Post (@markkp) in https://github.com/opencryptoki/opencryptoki/pull/403