### PR TITLE
ICSF: replace PBKDF implementation by libcrypto call

### DIFF
--- a/usr/lib/icsf_stdll/pbkdf.h
+++ b/usr/lib/icsf_stdll/pbkdf.h
@@ -20,11 +20,19 @@
 
 #define SALTSIZE        16      // salt is 16 bytes
 #define DKEYLEN  32      // 256 bytes is max key size to be derived
-#define PIN_SIZE 80      // samedefine in pkcsconf
+#define PIN_SIZE 80      // same define in pkcsconf
 #define ENCRYPT_SIZE 96      // PIN_SIZE + AES_BLOCK_SIZE (for padding)
+
+/*
+ * SP 800-132 recommends a minimum iteration count of 1000.
+ * so lets try that for now...
+ */
+#define ITERATIONS 1000
 
 #define ICSF_CONFIG_PATH CONFIG_PATH "/icsf"
 #define RACFFILE ICSF_CONFIG_PATH "/RACF"
+
+#define ICSF_MK_FILE_VERSION    2
 
 CK_RV get_randombytes(unsigned char *output, int bytes);
 
@@ -45,9 +53,13 @@ CK_RV get_masterkey(STDLL_TokData_t *tokdata,
                     CK_BYTE *pin, CK_ULONG pinlen, const char *fname,
                     CK_BYTE *masterkey, int *len);
 
-CK_RV pbkdf(STDLL_TokData_t *tokdata,
-            CK_BYTE * passwd, CK_ULONG passwdlen, CK_BYTE * salt,
-            CK_BYTE * dkey, CK_ULONG klen);
+CK_RV pbkdf_old(STDLL_TokData_t *tokdata,
+                CK_BYTE * passwd, CK_ULONG passwdlen, CK_BYTE * salt,
+                CK_BYTE * dkey, CK_ULONG klen);
+
+CK_RV pbkdf_openssl(STDLL_TokData_t *tokdata,
+                    CK_BYTE *password, CK_ULONG len, CK_BYTE *salt,
+                    CK_BYTE *dkey, CK_ULONG klen);
 
 CK_RV secure_racf(STDLL_TokData_t *tokdata,
                   CK_BYTE * racfpwd, CK_ULONG racflen, CK_BYTE * mk,


### PR DESCRIPTION
The PKBDF2 implementation of the ICSF token is not correct, and thus can not be simply replaced by the OpenSSL implementation of PBKDF2.

Introduce a version field in ICCF's MK_SO and MK_USER files to be able to detect old version files. Old version files do not have a version field, but start with the total-length field right away. The length contained in the total-length field can be distinguished from a valid version value. That way we can still read old version files, but can also transparently support the new version files with the correct PKBDF2 implementation.

When writing ICSF MK_SO or MK_USER files, we always use the new version format. This allows a smooth transition to the new version. Just set new pins for SO and USER and the MK files are updated with the new version format.

Based on the work from Patrick Steuer: https://github.com/opencryptoki/opencryptoki/pull/318
