### PR TITLE
EP11: Trace EP11 blob attributes on Keygen, Unwrap, Derive

### DIFF
--- a/usr/lib/common/p11util.c
+++ b/usr/lib/common/p11util.c
@@ -217,6 +217,17 @@ const char *p11_get_cka(CK_ATTRIBUTE_TYPE atype)
         _sym2str(CKA_IBM_USE_AS_DATA);
         _sym2str(CKA_IBM_STRUCT_PARAMS);
         _sym2str(CKA_IBM_STD_COMPLIANCE1);
+        _sym2str(CKA_IBM_PROTKEY_EXTRACTABLE);
+        _sym2str(CKA_IBM_PROTKEY_NEVER_EXTRACTABLE);
+        _sym2str(CKA_IBM_OPAQUE_PKEY);
+        _sym2str(CKA_IBM_DILITHIUM_KEYFORM);
+        _sym2str(CKA_IBM_DILITHIUM_RHO);
+        _sym2str(CKA_IBM_DILITHIUM_SEED);
+        _sym2str(CKA_IBM_DILITHIUM_TR);
+        _sym2str(CKA_IBM_DILITHIUM_S1);
+        _sym2str(CKA_IBM_DILITHIUM_S2);
+        _sym2str(CKA_IBM_DILITHIUM_T0);
+        _sym2str(CKA_IBM_DILITHIUM_T1);
     default:
         sprintf(buf, "unknown attribute type 0x%08lx", atype);
         return buf;


### PR DESCRIPTION
To help debugging when the EP11 host lib does not like certain attribute settings.