### PR TITLE
Validate object name when loading token objects

### DIFF
--- a/usr/lib/common/h_extern.h
+++ b/usr/lib/common/h_extern.h
@@ -432,7 +432,8 @@ CK_RV restore_private_token_object(STDLL_TokData_t *tokdata,
                                    CK_BYTE *header,
                                    CK_BYTE *data, CK_ULONG len,
                                    CK_BYTE *footer,
-                                   OBJECT *pObj);
+                                   OBJECT *pObj,
+                                   const char *fname);
 
 CK_RV delete_token_object(STDLL_TokData_t *tokdata, OBJECT *ptr);
 CK_RV delete_token_data(STDLL_TokData_t *tokdata);
@@ -2164,11 +2165,12 @@ CK_BBOOL object_mgr_purge_token_objects(STDLL_TokData_t *tokdata);
 CK_BBOOL object_mgr_purge_private_token_objects(STDLL_TokData_t *tokdata);
 
 CK_RV object_mgr_restore_obj(STDLL_TokData_t *tokdata, CK_BYTE *data,
-                             OBJECT *oldObj);
+                             OBJECT *oldObj, const char *fname);
 
 CK_RV object_mgr_restore_obj_withSize(STDLL_TokData_t *tokdata,
                                       CK_BYTE *data, OBJECT *oldObj,
-                                      int data_size);
+                                      int data_size,
+                                      const char *fname);
 
 CK_RV object_mgr_save_token_object(STDLL_TokData_t *tokdata, OBJECT *obj);
 
@@ -2245,7 +2247,8 @@ CK_RV object_get_attribute_values(OBJECT *obj,
 CK_ULONG object_get_size(OBJECT *obj);
 
 CK_RV object_restore_withSize(struct policy *policy, CK_BYTE *data,
-                              OBJECT **obj, CK_BBOOL replace, int data_size);
+                              OBJECT **obj, CK_BBOOL replace, int data_size,
+                              const char *fname);
 
 CK_RV object_set_attribute_values(STDLL_TokData_t *tokdata,
                                   OBJECT *obj,

--- a/usr/lib/common/obj_mgr.c
+++ b/usr/lib/common/obj_mgr.c
@@ -1439,16 +1439,17 @@ CK_BBOOL object_mgr_purge_private_token_objects(STDLL_TokData_t *tokdata)
 //
 //
 CK_RV object_mgr_restore_obj(STDLL_TokData_t *tokdata, CK_BYTE *data,
-                             OBJECT *oldObj)
+                             OBJECT *oldObj, const char *fname)
 {
-    return object_mgr_restore_obj_withSize(tokdata, data, oldObj, -1);
+    return object_mgr_restore_obj_withSize(tokdata, data, oldObj, -1, fname);
 }
 
 //
 //Modified verrsion of object_mgr_restore_obj to bounds check
 //If data_size==-1, won't check bounds
 CK_RV object_mgr_restore_obj_withSize(STDLL_TokData_t *tokdata, CK_BYTE *data,
-                                      OBJECT *oldObj, int data_size)
+                                      OBJECT *oldObj, int data_size,
+                                      const char *fname)
 {
     OBJECT *obj = NULL;
     CK_BBOOL priv;
@@ -1464,10 +1465,10 @@ CK_RV object_mgr_restore_obj_withSize(STDLL_TokData_t *tokdata, CK_BYTE *data,
     if (oldObj != NULL) {
         obj = oldObj;
         rc = object_restore_withSize(tokdata->policy,
-                                     data, &obj, TRUE, data_size);
+                                     data, &obj, TRUE, data_size, fname);
     } else {
         rc = object_restore_withSize(tokdata->policy,
-                                     data, &obj, FALSE, data_size);
+                                     data, &obj, FALSE, data_size, fname);
         if (rc == CKR_OK) {
             rc = XProcLock(tokdata);
             if (rc != CKR_OK) {

--- a/usr/sbin/pkcscca/pkcscca.c
+++ b/usr/sbin/pkcscca/pkcscca.c
@@ -184,7 +184,8 @@ cleanup:
  */
 int adjust_key_object_attributes(unsigned char *data, unsigned long data_len,
                                  unsigned char **new_data,
-                                 unsigned long *new_data_len)
+                                 unsigned long *new_data_len,
+                                 const char *fname)
 {
     int rc;
     OBJECT *obj = NULL;
@@ -194,7 +195,7 @@ int adjust_key_object_attributes(unsigned char *data, unsigned long data_len,
     *new_data_len = 0;
 
     /* Now unflatten the OBJ */
-    rc = object_restore_withSize(NULL, data, &obj, CK_FALSE, data_len);
+    rc = object_restore_withSize(NULL, data, &obj, CK_FALSE, data_len, fname);
     if (rc)
         goto cleanup;
 
@@ -235,7 +236,8 @@ cleanup:
 int reencrypt_private_token_object(unsigned char *data, unsigned long len,
                                    unsigned char *new_cipher,
                                    unsigned long *new_cipher_len,
-                                   unsigned char *masterkey)
+                                   unsigned char *masterkey,
+                                   const char *fname)
 {
     unsigned char *clear = NULL;
     unsigned char des3_key[64];
@@ -291,7 +293,8 @@ int reencrypt_private_token_object(unsigned char *data, unsigned long len,
     /* Adjust the key object attributes */
     ret = adjust_key_object_attributes(clear + sizeof(CK_ULONG_32),
                                        obj_data_len_32,
-                                       &new_obj_data, &new_obj_data_len);
+                                       &new_obj_data, &new_obj_data_len,
+                                       fname);
     if (ret)
         goto done;
 
@@ -412,13 +415,13 @@ int load_token_objects(unsigned char *data_store,
             memset(new_cipher, 0, new_cipher_len);
             rc = reencrypt_private_token_object(buf, size,
                                                 new_cipher, &new_cipher_len,
-                                                masterkey);
+                                                masterkey, fname);
             if (rc)
                 goto cleanup;
         } else {
             /* public token object */
             rc = adjust_key_object_attributes(buf, size, &new_cipher,
-                                              &new_cipher_len);
+                                              &new_cipher_len, fname);
             if (rc)
                 goto cleanup;
 


### PR DESCRIPTION
The object name within a token object payload must match the file name it was loaded from. For private token objects (CKA_PRIVATE=TRUE) the object name is part of the encrypted payload.

A mismatch may indicate that the token object file has been tampered, for example due to a file rename or replacement. Don't load such objects, since this is most likely not the expected object that is being loaded.