### PR TITLE
Use mkstemp for unique token object name generation

### DIFF
--- a/usr/lib/common/h_extern.h
+++ b/usr/lib/common/h_extern.h
@@ -417,8 +417,6 @@ CK_RV communicate(CK_ULONG cmd_id,
                   CK_BYTE_PTR pOut, CK_ULONG out_len,
                   CK_BYTE_PTR pIn, CK_ULONG in_len);
 
-CK_RV compute_next_token_obj_name(CK_BYTE *current, CK_BYTE *next);
-
 CK_RV save_token_object(STDLL_TokData_t *tokdata, OBJECT *obj);
 CK_RV save_private_token_object(STDLL_TokData_t *tokdata, OBJECT *obj);
 CK_RV save_public_token_object(STDLL_TokData_t *tokdata, OBJECT *obj);
@@ -2098,8 +2096,6 @@ CK_RV object_mgr_search_shm_for_obj(TOK_OBJ_ENTRY *list,
                                     CK_ULONG lo,
                                     CK_ULONG hi,
                                     OBJECT *obj, CK_ULONG *index);
-CK_RV object_mgr_sort_priv_shm(void);
-CK_RV object_mgr_sort_publ_shm(void);
 CK_RV object_mgr_update_from_shm(STDLL_TokData_t *tokdata);
 CK_RV object_mgr_update_publ_tok_obj_from_shm(STDLL_TokData_t *tokdata);
 CK_RV object_mgr_update_priv_tok_obj_from_shm(STDLL_TokData_t *tokdata);

--- a/usr/lib/common/host_defs.h
+++ b/usr/lib/common/host_defs.h
@@ -280,7 +280,7 @@ typedef struct _TOKEN_DATA {
 
     CK_BYTE user_pin_sha[3 * DES_BLOCK_SIZE];
     CK_BYTE so_pin_sha[3 * DES_BLOCK_SIZE];
-    CK_BYTE next_token_object_name[8];
+    CK_BYTE unused[8];
     TWEAK_VEC tweak_vector;
 
     /* new for tokversion >= 3.12 */

--- a/usr/lib/common/utility.c
+++ b/usr/lib/common/utility.c
@@ -411,8 +411,6 @@ CK_RV init_token_data(STDLL_TokData_t *tokdata, CK_SLOT_ID slot_id)
         }
     }
 
-    memcpy(tokdata->nv_token_data->next_token_object_name, "00000000", 8);
-
     // generate the master key used for signing the Operation State information
     //                          `
     memset(tokdata->nv_token_data->token_info.label, ' ',
@@ -451,66 +449,6 @@ CK_RV init_token_data(STDLL_TokData_t *tokdata, CK_SLOT_ID slot_id)
     rc = save_token_data(tokdata, slot_id);
 
     return rc;
-}
-
-// Function:  compute_next_token_obj_name()
-//
-// Given a token object name (8 bytes in the range [0-9A-Z]) increment by one
-// adjusting as necessary
-//
-// This gives us a namespace of 36^8 = 2,821,109,907,456 objects before wrapping
-// around
-//
-// Note: If the current name contains an invalid character (i.e. not within
-//       [0-9A-Z]), then this character is set to '0' in the next name and
-//       the following characters are incremented by 1 adjusting as necessary.
-//
-CK_RV compute_next_token_obj_name(CK_BYTE *current, CK_BYTE *next)
-{
-    int val[8];
-    int i;
-
-    if (!current || !next) {
-        TRACE_ERROR("Invalid function arguments.\n");
-        return CKR_FUNCTION_FAILED;
-    }
-    // Convert to integral base 36
-    //
-    for (i = 0; i < 8; i++) {
-        if (current[i] >= '0' && current[i] <= '9')
-            val[i] = current[i] - '0';
-        else if (current[i] >= 'A' && current[i] <= 'Z')
-            val[i] = current[i] - 'A' + 10;
-        else
-            val[i] = 36;
-    }
-
-    val[0]++;
-
-    i = 0;
-
-    while (val[i] > 35) {
-        val[i] = 0;
-
-        if (i + 1 < 8) {
-            val[i + 1]++;
-            i++;
-        } else {
-            val[0]++;
-            i = 0;              // start pass 2
-        }
-    }
-
-    // now, convert back to [0-9A-Z]
-    //
-    for (i = 0; i < 8; i++) {
-        if (val[i] < 10)
-            next[i] = '0' + val[i];
-        else
-            next[i] = 'A' + val[i] - 10;
-    }
-
-    return CKR_OK;
 }
 
 //


### PR DESCRIPTION
Do no longer use the pre-calculated next object name in the token's shared memory segment, but use a unique name generated by mkstemp instead. This guarantees unique file names, and the next object name to be used can not be tampered in the shared memory segment.

Existing token object files keep their names, only new files are created via mkstemp. There is no update/migration problem because files with old names and new names can live together without a problem.

The field used to contain the next token object name is kept in struct TOKEN_DATA but renamed to 'unused'. Removing this field would cause update/migration problems.