### PR TITLE
Testcases cleanup and fix counting

### DIFF
--- a/testcases/crypto/abfunc.c
+++ b/testcases/crypto/abfunc.c
@@ -1180,7 +1180,7 @@ int main(int argc, char **argv)
     }
 
     if (is_ep11_token(SLOT_ID)) {
-        testcase_setup(0);
+        testcase_setup();
         rc = do_CheckMechanismInfo();
         if (rc != CKR_OK) {
             // Skip, but don't crash the test executor

--- a/testcases/crypto/aes_func.c
+++ b/testcases/crypto/aes_func.c
@@ -2569,7 +2569,7 @@ int main(int argc, char **argv)
             return rc;
     }
 
-    testcase_setup(0);          //TODO
+    testcase_setup();
 
     pkey = CK_FALSE;
     rv = aes_funcs();

--- a/testcases/crypto/des3_func.c
+++ b/testcases/crypto/des3_func.c
@@ -1411,7 +1411,7 @@ int main(int argc, char **argv)
         }
     }
 
-    testcase_setup(0);          //TODO
+    testcase_setup();
     rc = des3_funcs();
     testcase_print_result();
 

--- a/testcases/crypto/des_func.c
+++ b/testcases/crypto/des_func.c
@@ -1155,7 +1155,7 @@ int main(int argc, char **argv)
         }
     }
     rc = 0;
-    testcase_setup(0);          //TODO
+    testcase_setup();
     rc = des_funcs();
     testcase_print_result();
 

--- a/testcases/crypto/dh_func.c
+++ b/testcases/crypto/dh_func.c
@@ -587,7 +587,7 @@ int main(int argc, char **argv)
             return rc;
     }
 
-    testcase_setup(0);
+    testcase_setup();
 
     rv = dh_functions();
 

--- a/testcases/crypto/digest_func.c
+++ b/testcases/crypto/digest_func.c
@@ -1718,7 +1718,7 @@ int main(int argc, char **argv)
             return rc;
 
     }
-    testcase_setup(0);          //TODO
+    testcase_setup();
     rv = digest_funcs();
     testcase_print_result();
 

--- a/testcases/crypto/dilithium_func.c
+++ b/testcases/crypto/dilithium_func.c
@@ -745,7 +745,7 @@ int main(int argc, char **argv)
             return rc;
     }
 
-    testcase_setup(total_assertions);
+    testcase_setup();
 
     rv = run_GenerateDilithiumKeyPairSignVerify();
 

--- a/testcases/crypto/dsa_func.c
+++ b/testcases/crypto/dsa_func.c
@@ -470,7 +470,7 @@ int main(int argc, char **argv)
 
     }
 
-    testcase_setup(0);
+    testcase_setup();
 
     rv = dsa_functions();
 

--- a/testcases/crypto/ec_func.c
+++ b/testcases/crypto/ec_func.c
@@ -101,8 +101,6 @@
  *      06032B6571
  */
 
-CK_ULONG total_assertions = 65;
-
 typedef struct ec_struct {
     void const *curve;
     CK_ULONG size;
@@ -2385,7 +2383,7 @@ int main(int argc, char **argv)
             return rc;
     }
 
-    testcase_setup(total_assertions);
+    testcase_setup();
 
     pkey = CK_FALSE;
     rv = run_GenerateECCKeyPairSignVerify();

--- a/testcases/crypto/ec_func.c
+++ b/testcases/crypto/ec_func.c
@@ -671,7 +671,6 @@ CK_RV run_DeriveECDHKey()
 
                 for (m=0; m < (kdfs[j] == CKD_NULL ? 1 : NUM_SHARED_DATA); m++) {
 
-                    testcase_new_assertion();
                     testcase_begin("Starting with curve=%s, kdf=%s, keylen=%lu, "
                                   "shared_data=%u, mech=%s, pkey=%X",
                                   der_ec_supported[i].name,
@@ -777,6 +776,7 @@ CK_RV run_DeriveECDHKey()
                         goto testcase_cleanup;
                     }
 
+                    testcase_new_assertion();
                     rc = run_HMACSign(session, secret_keyB,
                                       secret_key_len[k] > 0 ?
                                           secret_key_len[k] : curve_len(i));
@@ -924,7 +924,6 @@ CK_RV run_DeriveECDHKeyKAT()
 
     for (i=0; i<ECDH_TV_NUM; i++) {
 
-        testcase_new_assertion();
         testcase_begin("Starting with shared secret i=%lu, pkey=%X", i, pkey);
 
         switch (ecdh_tv[i].kdf) {
@@ -1064,8 +1063,6 @@ CK_RV run_DeriveECDHKeyKAT()
         };
         CK_ULONG derive_tmpl_len = sizeof(derive_tmpl) / sizeof(CK_ATTRIBUTE);
 
-        testcase_new_assertion();
-
         // Now, derive a generic secret key using party A's private key
         // and B's public key
         ecdh_parmA.kdf = ecdh_tv[i].kdf;
@@ -1159,6 +1156,8 @@ CK_RV run_DeriveECDHKeyKAT()
             testcase_fail("C_DeriveKey #2: rc = %s", p11_get_ckr(rc));
             goto testcase_cleanup;
         }
+
+        testcase_new_assertion();
 
         // Extract the derived secret A
         rc = funcs->C_GetAttributeValue(session, secret_keyA,
@@ -1566,7 +1565,6 @@ CK_RV run_GenerateECCKeyPairSignVerify()
                                       ec_publ_attr, ec_publ_attr_len,
                                       ec_priv_attr, ec_priv_attr_len,
                                       &publ_key, &priv_key);
-        testcase_new_assertion();
         if (rc != CKR_OK) {
             if (is_rejected_by_policy(rc, session)) {
                 testcase_skip("EC key generation is not allowed by policy");
@@ -1584,6 +1582,7 @@ CK_RV run_GenerateECCKeyPairSignVerify()
                  "rc=%s", i, der_ec_supported[i].name, p11_get_ckr(rc));
             goto testcase_cleanup;
         }
+        testcase_new_assertion();
         testcase_pass("*Generate supported key pair index=%lu passed.", i);
 
         for (j = 0;
@@ -1691,8 +1690,6 @@ CK_RV run_ImportECCKeyPairSignVerify()
                                  ec_tv[i].privkey, ec_tv[i].privkey_len,
                                  ec_tv[i].pubkey, ec_tv[i].pubkey_len,
                                  &priv_key, !pkey);
-
-        testcase_new_assertion();
         if (rc != CKR_OK) {
             if (rc == CKR_POLICY_VIOLATION) {
                 testcase_skip("EC key import is not allowed by policy");
@@ -1718,14 +1715,13 @@ CK_RV run_ImportECCKeyPairSignVerify()
                           "(%s), rc=%s", i, ec_tv[i].name, p11_get_ckr(rc));
             goto testcase_cleanup;
         }
+        testcase_new_assertion();
         testcase_pass("*Import EC private key (%s) index=%lu passed.",
                       ec_tv[i].name, i);
 
         rc = create_ECPublicKey(session, ec_tv[i].params, ec_tv[i].params_len,
                                 ec_tv[i].pubkey, ec_tv[i].pubkey_len,
                                 &publ_key);
-
-        testcase_new_assertion();
         if (rc != CKR_OK) {
             if (rc == CKR_POLICY_VIOLATION) {
                 testcase_skip("EC key import is not allowed by policy");
@@ -1754,6 +1750,7 @@ CK_RV run_ImportECCKeyPairSignVerify()
                           "(%s), rc=%s", i, ec_tv[i].name, p11_get_ckr(rc));
             goto testcase_cleanup;
         }
+        testcase_new_assertion();
         testcase_pass("*Import EC public key (%s) index=%lu passed.",
                       ec_tv[i].name, i);
 
@@ -1903,7 +1900,6 @@ CK_RV run_TransferECCKeyPairSignVerify()
                                  ec_tv[i].pubkey, ec_tv[i].pubkey_len,
                                  &priv_key, CK_TRUE); // key to be wrapped must be extractable
 
-        testcase_new_assertion();
         if (rc != CKR_OK) {
             if (rc == CKR_POLICY_VIOLATION) {
                 testcase_skip("EC key import is not allowed by policy");
@@ -1930,14 +1926,13 @@ CK_RV run_TransferECCKeyPairSignVerify()
                  p11_get_ckr(rc));
             goto testcase_cleanup;
         }
+        testcase_new_assertion();
         testcase_pass("*Import EC private key (%s) index=%lu passed.",
                       ec_tv[i].name, i);
 
         rc = create_ECPublicKey(session, ec_tv[i].params, ec_tv[i].params_len,
                                 ec_tv[i].pubkey, ec_tv[i].pubkey_len,
                                 &publ_key);
-
-        testcase_new_assertion();
         if (rc != CKR_OK) {
             if (rc == CKR_POLICY_VIOLATION) {
                 testcase_skip("EC key import is not allowed by policy");
@@ -1967,6 +1962,7 @@ CK_RV run_TransferECCKeyPairSignVerify()
                  p11_get_ckr(rc));
             goto testcase_cleanup;
         }
+        testcase_new_assertion();
         testcase_pass("*Import EC public key (%s) index=%lu passed.",
                       ec_tv[i].name, i);
 
@@ -2217,8 +2213,6 @@ CK_RV run_ImportSignVerify_Pkey()
                 testcase_begin("Starting Import EC private key (%s) index=%u sign via ep11 card / verify via CPACF",
                                ec_tv[i].name, i);
 
-            testcase_new_assertion();
-
             /* j toggles between sign via protected key / verify via ep11 card
              * and vice versa. */
             if (j == 0) {
@@ -2278,6 +2272,8 @@ CK_RV run_ImportSignVerify_Pkey()
                 testcase_error("C_SignInit rc=%s", p11_get_ckr(rc));
                 goto testcase_cleanup;
             }
+
+            testcase_new_assertion();
 
             rc = funcs->C_Sign(session, data, sizeof(data), NULL, &sig_len);
             if (rc != CKR_OK) {
@@ -2392,13 +2388,15 @@ int main(int argc, char **argv)
     rv += run_DeriveECDHKey();
     rv += run_DeriveECDHKeyKAT();
 
-    pkey = CK_TRUE;
-    rv = run_GenerateECCKeyPairSignVerify();
-    rv += run_ImportECCKeyPairSignVerify();
-    rv += run_TransferECCKeyPairSignVerify();
-    rv += run_DeriveECDHKey();
-    rv += run_DeriveECDHKeyKAT();
-    rv += run_ImportSignVerify_Pkey();
+    if (is_ep11_token(SLOT_ID)) {
+        pkey = CK_TRUE;
+        rv = run_GenerateECCKeyPairSignVerify();
+        rv += run_ImportECCKeyPairSignVerify();
+        rv += run_TransferECCKeyPairSignVerify();
+        rv += run_DeriveECDHKey();
+        rv += run_DeriveECDHKeyKAT();
+        rv += run_ImportSignVerify_Pkey();
+    }
 
     testcase_print_result();
 

--- a/testcases/crypto/rsa_func.c
+++ b/testcases/crypto/rsa_func.c
@@ -1436,7 +1436,6 @@ CK_RV do_WrapUnwrapRSA(struct GENERATED_TEST_SUITE_INFO * tsuite)
             key_type = CKK_GENERIC_SECRET;
         }
 
-        testcase_new_assertion();       /* assertion #1 */
         // wrap key (length only)
         rc = funcs->C_WrapKey(session, &wrap_mech, publ_key, secret_key,
                               NULL, &wrapped_keylen);
@@ -1454,6 +1453,9 @@ CK_RV do_WrapUnwrapRSA(struct GENERATED_TEST_SUITE_INFO * tsuite)
             testcase_error("C_WrapKey(), rc=%s.", p11_get_ckr(rc));
             goto error;
         }
+
+        testcase_new_assertion();       /* assertion #1 */
+
         // allocate memory for wrapped_key
         wrapped_key = calloc(sizeof(CK_BYTE), wrapped_keylen);
         if (wrapped_key == NULL) {

--- a/testcases/crypto/rsa_func.c
+++ b/testcases/crypto/rsa_func.c
@@ -2049,7 +2049,7 @@ int main(int argc, char **argv)
         }
     }
 
-    testcase_setup(0);
+    testcase_setup();
     rv = rsa_funcs();
     testcase_print_result();
 

--- a/testcases/crypto/rsaupdate_func.c
+++ b/testcases/crypto/rsaupdate_func.c
@@ -1133,7 +1133,7 @@ int main(int argc, char **argv)
         }
     }
 
-    testcase_setup(0);
+    testcase_setup();
     rv = rsa_funcs();
     testcase_print_result();
 

--- a/testcases/crypto/ssl3_func.c
+++ b/testcases/crypto/ssl3_func.c
@@ -734,7 +734,7 @@ int main(int argc, char **argv)
 
     }
 
-    testcase_setup(0);
+    testcase_setup();
 
     rv = ssl3_functions();
 

--- a/testcases/include/regress.h
+++ b/testcases/include/regress.h
@@ -119,7 +119,7 @@ int get_user_pin(CK_BYTE_PTR);
             __FILE__, __LINE__, _str, _rc, _rc,                \
             p11_get_ckr(_rc))
 
-#define testcase_setup(total)                                   \
+#define testcase_setup()                                        \
     do {                                                        \
         t_total = 0;                                            \
         t_errors = 0;                                           \

--- a/testcases/misc_tests/cca_export_import_test.c
+++ b/testcases/misc_tests/cca_export_import_test.c
@@ -1481,7 +1481,7 @@ int main(int argc, char **argv)
 
     }
 
-    testcase_setup(0);
+    testcase_setup();
     rv = cca_export_import_tests();
     testcase_print_result();
 

--- a/testcases/misc_tests/events.c
+++ b/testcases/misc_tests/events.c
@@ -61,7 +61,7 @@ int main(int argc, char **argv)
     cinit_args.flags = CKF_OS_LOCKING_OK;
     funcs->C_Initialize(&cinit_args);
 
-    testcase_setup(0);
+    testcase_setup();
     testcase_begin("Starting event tests");
 
     // Test fork before C_Initialize

--- a/testcases/misc_tests/fork.c
+++ b/testcases/misc_tests/fork.c
@@ -98,7 +98,7 @@ CK_RV do_fork(CK_SESSION_HANDLE parent_session, CK_OBJECT_HANDLE parent_object)
     }
 
     // child process flows here
-    testcase_setup(0);
+    testcase_setup();
     t_ran = 0;
     t_passed = 0;
     t_skipped = 0;
@@ -240,7 +240,7 @@ int main(int argc, char **argv)
         goto out;
     }
 
-    testcase_setup(0);
+    testcase_setup();
     testcase_begin("Starting...  Parent process: %u", getpid());
 
     // Test fork before C_Initialize

--- a/testcases/misc_tests/multi_instance.c
+++ b/testcases/misc_tests/multi_instance.c
@@ -131,7 +131,7 @@ int main(int argc, char **argv)
         goto out;
     }
 
-    testcase_setup(0);
+    testcase_setup();
     testcase_begin("Starting...");
 
     // Initialize

--- a/testcases/misc_tests/obj_lock.c
+++ b/testcases/misc_tests/obj_lock.c
@@ -305,7 +305,7 @@ int main(int argc, char **argv)
         goto out;
     }
 
-    testcase_setup(0);
+    testcase_setup();
     testcase_begin("Starting...");
 
     // Initialize

--- a/testcases/misc_tests/obj_mgmt.c
+++ b/testcases/misc_tests/obj_mgmt.c
@@ -1789,7 +1789,7 @@ int main(int argc, char **argv)
 
     }
 
-    testcase_setup(0);
+    testcase_setup();
     rv = obj_mgmt_functions();
     testcase_print_result();
 

--- a/testcases/misc_tests/obj_mgmt_lock.c
+++ b/testcases/misc_tests/obj_mgmt_lock.c
@@ -1343,7 +1343,7 @@ int main(int argc, char **argv)
 
     }
 
-    testcase_setup(0);
+    testcase_setup();
     rv = obj_mgmt_functions();
     testcase_print_result();
 

--- a/testcases/misc_tests/reencrypt.c
+++ b/testcases/misc_tests/reencrypt.c
@@ -819,7 +819,7 @@ int main(int argc, char **argv)
         goto out;
     }
 
-    testcase_setup(0);
+    testcase_setup();
     testcase_begin("Starting...");
 
     // Initialize

--- a/testcases/misc_tests/speed.c
+++ b/testcases/misc_tests/speed.c
@@ -1092,7 +1092,7 @@ int main(int argc, char **argv)
 
     funcs->C_Initialize(&cinit_args);
 
-    testcase_setup(0);
+    testcase_setup();
 
     if (do_rsa_keygen) {
         testsuite_begin("RSA Keygen.");

--- a/testcases/misc_tests/tok2tok_transport.c
+++ b/testcases/misc_tests/tok2tok_transport.c
@@ -1284,7 +1284,7 @@ int main(int argc, char **argv)
         goto out;
     }
 
-    testcase_setup(0);
+    testcase_setup();
     testcase_begin("Starting...");
 
     // Initialize

--- a/testcases/pkcs11/attribute.c
+++ b/testcases/pkcs11/attribute.c
@@ -512,7 +512,7 @@ int main(int argc, char **argv)
             return rv;
     }
 
-    testcase_setup(0);
+    testcase_setup();
     rc = do_TestAttributes();
     testcase_print_result();
 

--- a/testcases/pkcs11/copyobjects.c
+++ b/testcases/pkcs11/copyobjects.c
@@ -378,7 +378,7 @@ int main(int argc, char **argv)
             return rv;
     }
 
-    testcase_setup(0);
+    testcase_setup();
     rc = do_CopyObjects();
     testcase_print_result();
 

--- a/testcases/pkcs11/destroyobjects.c
+++ b/testcases/pkcs11/destroyobjects.c
@@ -305,7 +305,7 @@ int main(int argc, char **argv)
             return rv;
     }
 
-    testcase_setup(0);
+    testcase_setup();
     rc = do_DestroyObjects();
     testcase_print_result();
 

--- a/testcases/pkcs11/findobjects.c
+++ b/testcases/pkcs11/findobjects.c
@@ -300,7 +300,7 @@ int main(int argc, char **argv)
             return rv;
     }
 
-    testcase_setup(0);
+    testcase_setup();
     rc = do_FindObjects();
     testcase_print_result();
 

--- a/testcases/pkcs11/gen_purpose.c
+++ b/testcases/pkcs11/gen_purpose.c
@@ -749,7 +749,7 @@ int main(int argc, char **argv)
             return rv;
     }
 
-    testcase_setup(0);
+    testcase_setup();
     rv = api_driver();
     testcase_print_result();
 

--- a/testcases/pkcs11/generate_keypair.c
+++ b/testcases/pkcs11/generate_keypair.c
@@ -255,7 +255,7 @@ int main(int argc, char **argv)
             return rv;
     }
 
-    testcase_setup(0);
+    testcase_setup();
     rc = do_GenerateKeyPairRSA();
     testcase_print_result();
 

--- a/testcases/pkcs11/get_interface.c
+++ b/testcases/pkcs11/get_interface.c
@@ -447,7 +447,7 @@ int main(void)
 {
     int rc = -1;
 
-    testcase_setup(0);
+    testcase_setup();
 
     if (do_GetFunctionList() != TRUE) {
         testcase_error("%s", "do_GetFunctionList() failed.\n");

--- a/testcases/pkcs11/sess_opstate.c
+++ b/testcases/pkcs11/sess_opstate.c
@@ -302,7 +302,7 @@ int main(int argc, char **argv)
         if (rv != CKR_FUNCTION_NOT_PARALLEL)
             return rv;
     }
-    testcase_setup(0);
+    testcase_setup();
     rc = sess_opstate_funcs(loops);
     testcase_print_result();
 


### PR DESCRIPTION
testcase_new_assertion() increments the number of ran testcases. 
Total number of testcases is ran + skipped. 
So do not call testcase_new_assertion()  before it is sure that the testcase can actually be run, and is not skipped later on. Make sure that all the skip possibilities are handed before testcase_new_assertion(). Once a test is run, it can either fail of pass, but no longer skipped.
