### PR TITLE
Cleanup OpenSSL context in OpenSSL exit handler

### DIFF
--- a/usr/sbin/pkcsconf/pkcsconf.c
+++ b/usr/sbin/pkcsconf/pkcsconf.c
@@ -418,6 +418,8 @@ done:
         free(newpin2);
     }
 
+    cleanup();
+
     return rv == CKR_OK ? 0 : -1;
 }
 


### PR DESCRIPTION
Usually opencryptoki's own library context is freed during C_Finalize(). However, when an application does not call C_Finalize() before it exits, the cleanup is performed in the library destructor when the library is unloaded (i.e. during exit handlers).

OpenSSL also performs its own cleanup in exit handlers, and it may happen that OpenSSL cleanup is performed before the library destructors are called. This may cause crashes when Opencryptoki's library context has already been freed by OpenSSL cleanup, but the library destructor tries to free it a second time. This causes a double free, and very likely a crash.

Register an OpenSSL cleanup handler to clean up the library context before OpenSSL performs its own cleanup.

While we are at it, make sure pkcsconf calls C_Finalize() at the end of processing, just to be nice :-)