### PR TITLE
COMMON: Deep copy the AES-GCM mechanism parameter

### DIFF
--- a/usr/lib/common/encr_mgr.c
+++ b/usr/lib/common/encr_mgr.c
@@ -612,6 +612,21 @@ CK_RV encr_mgr_init(STDLL_TokData_t *tokdata,
             goto done;
         }
         memcpy(ptr, mech->pParameter, mech->ulParameterLen);
+
+        /* Deep copy mechanism parameter, if required */
+        switch (mech->mechanism)
+        {
+        case CKM_AES_GCM:
+            rc = aes_gcm_dup_param((CK_GCM_PARAMS *)mech->pParameter,
+                                   (CK_GCM_PARAMS *)ptr);
+            if (rc != CKR_OK) {
+                TRACE_ERROR("aes_gcm_dup_param failed\n");
+                goto done;
+            }
+            break;
+        default:
+            break;
+        }
     }
 
     ctx->key = key_handle;
@@ -645,8 +660,6 @@ CK_RV encr_mgr_cleanup(STDLL_TokData_t *tokdata, SESSION *sess,
         return CKR_FUNCTION_FAILED;
     }
     ctx->key = 0;
-    ctx->mech.ulParameterLen = 0;
-    ctx->mech.mechanism = 0;
     ctx->multi_init = FALSE;
     ctx->multi = FALSE;
     ctx->active = FALSE;
@@ -657,9 +670,21 @@ CK_RV encr_mgr_cleanup(STDLL_TokData_t *tokdata, SESSION *sess,
     ctx->count_statistics = FALSE;
 
     if (ctx->mech.pParameter) {
+        /* Deep free mechanism parameter, if required */
+        switch (ctx->mech.mechanism)
+        {
+        case CKM_AES_GCM:
+            aes_gcm_free_param((CK_GCM_PARAMS *)ctx->mech.pParameter);
+            break;
+        default:
+            break;
+        }
+
         free(ctx->mech.pParameter);
         ctx->mech.pParameter = NULL;
     }
+    ctx->mech.ulParameterLen = 0;
+    ctx->mech.mechanism = 0;
 
     if (ctx->context) {
         if (ctx->context_free_func != NULL)

--- a/usr/lib/common/h_extern.h
+++ b/usr/lib/common/h_extern.h
@@ -1489,6 +1489,10 @@ CK_RV aes_gcm_decrypt_update(STDLL_TokData_t *tokdata, SESSION *, CK_BBOOL,
 CK_RV aes_gcm_decrypt_final(STDLL_TokData_t *tokdata, SESSION *, CK_BBOOL,
                             ENCR_DECR_CONTEXT *, CK_BYTE *, CK_ULONG *);
 
+CK_RV aes_gcm_dup_param(CK_GCM_PARAMS *from, CK_GCM_PARAMS *to);
+
+CK_RV aes_gcm_free_param(CK_GCM_PARAMS *params);
+
 CK_RV aes_ofb_encrypt(STDLL_TokData_t *tokdata, SESSION *sess,
                       CK_BBOOL length_only,
                       ENCR_DECR_CONTEXT *ctx, CK_BYTE *in_data,

--- a/usr/lib/common/mech_aes.c
+++ b/usr/lib/common/mech_aes.c
@@ -3420,6 +3420,58 @@ CK_RV aes_gcm_decrypt_final(STDLL_TokData_t *tokdata, SESSION *sess,
     return rc;
 }
 
+CK_RV aes_gcm_dup_param(CK_GCM_PARAMS *from, CK_GCM_PARAMS *to)
+{
+    if (from == NULL || to == NULL)
+        return CKR_ARGUMENTS_BAD;
+
+    to->pIv = NULL;
+    to->ulIvLen = 0;
+    if (from->ulIvLen != 0 && from->pIv != NULL) {
+        to->pIv = malloc(from->ulIvLen);
+        if (to->pIv == NULL) {
+            TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
+            aes_gcm_free_param(to);
+            return CKR_HOST_MEMORY;
+        }
+
+        memcpy(to->pIv, from->pIv, from->ulIvLen);
+        to->ulIvLen = from->ulIvLen;
+    }
+
+    to->pAAD = NULL;
+    to->ulAADLen = 0;
+    if (from->ulAADLen != 0 && from->pAAD) {
+        to->pAAD = malloc(from->ulAADLen);
+        if (to->pAAD == NULL) {
+            TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
+            aes_gcm_free_param(to);
+            return CKR_HOST_MEMORY;
+        }
+
+        memcpy(to->pAAD, from->pAAD, from->ulAADLen);
+        to->ulAADLen = from->ulAADLen;
+    }
+
+    return CKR_OK;
+}
+
+CK_RV aes_gcm_free_param(CK_GCM_PARAMS *params)
+{
+    if (params == NULL)
+        return CKR_ARGUMENTS_BAD;
+
+    if (params->pIv != NULL)
+        free(params->pIv);
+
+    if (params->pAAD != NULL)
+        free(params->pAAD);
+
+    memset(params, 0, sizeof(*params));
+
+    return CKR_OK;
+}
+
 //
 // mechanisms
 //


### PR DESCRIPTION
During C_EncryptInit and C_DecryptInit the AES-GCM mechanism parameter CK_GCM_PARAMS must be deep-copied into the operation context. The areas pointed to by fields pIv and pAAD may only be valid during C_EncryptInit/C_DecryptInit, but may be no longer valid for C_EncryptUpdate/C_DecryptUpdate and C_EncryptFinal/C_DecryptFinal. When the context is freed, the GCM parameter is also be deep-freed.

As far as I can tell AES-GCM is the only mechanism that needs this special handling at the moment. Mechanisms that have complex mechanism parameter structures but are used in single shot calls only (e.g. C_DeriveKey, C_WrapKey/C_UnwrapKey do not need a special handling, since its mechanism parameter is not copied into the context. Only mechanisms that are used with Init-Update-Final calls are subject to special handling.