### PR TITLE
CCA/EP11/ICA: Do not use dlclose when in atfork handler

### DIFF
--- a/usr/lib/cca_stdll/cca_specific.c
+++ b/usr/lib/cca_stdll/cca_specific.c
@@ -640,7 +640,7 @@ CK_RV token_specific_final(STDLL_TokData_t *tokdata,
 
     free(tokdata->mech_list);
 
-    if (tokdata->private_data != NULL)
+    if (tokdata->private_data != NULL && !in_fork_initializer)
         dlclose(tokdata->private_data);
     tokdata->private_data = NULL;
 

--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -2440,12 +2440,12 @@ CK_RV ep11tok_init(STDLL_TokData_t * tokdata, CK_SLOT_ID SlotNumber,
     return CKR_OK;
 
 error:
-    ep11tok_final(tokdata);
+    ep11tok_final(tokdata, FALSE);
     TRACE_INFO("%s init failed with rc: 0x%lx\n", __func__, rc);
     return rc;
 }
 
-CK_RV ep11tok_final(STDLL_TokData_t * tokdata)
+CK_RV ep11tok_final(STDLL_TokData_t * tokdata, CK_BBOOL in_fork_initializer)
 {
     ep11_private_data_t *ep11_data = tokdata->private_data;
 
@@ -2460,11 +2460,11 @@ CK_RV ep11tok_final(STDLL_TokData_t * tokdata)
         }
         pthread_rwlock_destroy(&ep11_data->target_rwlock);
         free_cp_config(ep11_data->cp_config);
-        if (ep11_data->libica.ica_cleanup != NULL)
+        if (ep11_data->libica.ica_cleanup != NULL && !in_fork_initializer)
             ep11_data->libica.ica_cleanup();
-        if (ep11_data->libica.library != NULL)
+        if (ep11_data->libica.library != NULL && !in_fork_initializer)
             dlclose(ep11_data->libica.library);
-        if (ep11_data->lib_ep11 != NULL)
+        if (ep11_data->lib_ep11 != NULL && !in_fork_initializer)
             dlclose(ep11_data->lib_ep11);
         free(ep11_data);
         tokdata->private_data = NULL;

--- a/usr/lib/ep11_stdll/ep11_specific.h
+++ b/usr/lib/ep11_stdll/ep11_specific.h
@@ -33,7 +33,7 @@ CK_RV ep11tok_is_mechanism_supported_ex(STDLL_TokData_t *tokdata,
 CK_RV ep11tok_init(STDLL_TokData_t * tokdata, CK_SLOT_ID SlotNumber,
                    char *conf_name);
 
-CK_RV ep11tok_final(STDLL_TokData_t * tokdata);
+CK_RV ep11tok_final(STDLL_TokData_t * tokdata, CK_BBOOL in_fork_initializer);
 
 CK_RV ep11tok_generate_key(STDLL_TokData_t * tokdata, SESSION * session,
                            CK_MECHANISM_PTR mech, CK_ATTRIBUTE_PTR attrs,

--- a/usr/lib/ep11_stdll/new_host.c
+++ b/usr/lib/ep11_stdll/new_host.c
@@ -241,7 +241,7 @@ CK_RV SC_Finalize(STDLL_TokData_t *tokdata, CK_SLOT_ID sid, SLOT_INFO *sinfp,
     detach_shm(tokdata, in_fork_initializer);
     /* close spin lock file */
     CloseXProcLock(tokdata);
-    rc = ep11tok_final(tokdata);
+    rc = ep11tok_final(tokdata, in_fork_initializer);
     if (rc != CKR_OK) {
         TRACE_ERROR("Token specific final call failed.\n");
         return rc;

--- a/usr/lib/ica_s390_stdll/ica_specific.c
+++ b/usr/lib/ica_s390_stdll/ica_specific.c
@@ -365,9 +365,9 @@ CK_RV token_specific_final(STDLL_TokData_t *tokdata,
     TRACE_INFO("ica %s running\n", __func__);
     ica_close_adapter(ica_data->adapter_handle);
 
-    if (p_ica_cleanup != NULL)
+    if (p_ica_cleanup != NULL && !in_fork_initializer)
         p_ica_cleanup();
-    if (ica_data->libica_dso != NULL)
+    if (ica_data->libica_dso != NULL && !in_fork_initializer)
         dlclose(ica_data->libica_dso);
 
     free(tokdata->mech_list);


### PR DESCRIPTION
Calling dlclose() in a atfork handler may cause a deadlock. dlclose() may itself modify the atfork handler table to remove any fork handlers that the to be unloaded library has registered. Since the atfork handler table is currently locked when we are in an atfork handler, this would produce a deadlock.