### PR TITLE
COMMON: Fix rsa_convert_private_key() for OpenSSL 3.0

### DIFF
--- a/usr/lib/common/mech_openssl.c
+++ b/usr/lib/common/mech_openssl.c
@@ -802,7 +802,7 @@ static EVP_PKEY *rsa_convert_private_key(OBJECT *key_obj)
         goto out;
 
     if (!EVP_PKEY_fromdata_init(pctx) ||
-        !EVP_PKEY_fromdata(pctx, &pkey, EVP_PKEY_PUBLIC_KEY, params))
+        !EVP_PKEY_fromdata(pctx, &pkey, EVP_PKEY_KEYPAIR, params))
         goto out;
 
     EVP_PKEY_CTX_free(pctx);


### PR DESCRIPTION
Need to import a KEYPAIR via EVP_PKEY_fromdata() when converting a RSA private key to an OpenSSL PKEY, not just the public key.

Having only the public key may cause failures when crypto operations are performed that require the private key, e.g. openssl_specific_rsa_decrypt().

Before OpenSSL commit https://github.com/openssl/openssl/commit/944f822aadc88b2e25f7695366810c73a53a00c8
this did work because it always imported all key parts, regardless of the selector specified.