### PR TITLE
config: Add support for bare numbers

### DIFF
--- a/usr/lib/config/cfgparse.y
+++ b/usr/lib/config/cfgparse.y
@@ -106,9 +106,9 @@ commentedconfigelemstar :
 
 /* 0-n configuration elements with comments between them. */
 configelemstar:
-	configelem configelemstar { $$ = confignode_append($1, $2); $1 = $2 = NULL; }
-	|
-	/* empty */ { $$ = NULL; }
+    configelem configelemstar { $$ = confignode_append($1, $2); $1 = $2 = NULL; }
+    |
+    /* empty */ { $$ = NULL; }
 
 /* Valid configuration elements:
 - "version" BARE
@@ -135,80 +135,80 @@ of comments at the end of the element.  The element also has to take
 care of all the positions where it wants to allow comments.
 */
 configelem:
-	/* version somestring*/
+    /* version somestring*/
     FILEVERSION BARE eocstar {
-	    struct ConfigFileVersionNode *n = confignode_allocfileversion($2, @1.first_line);
-	    if (!n) { YYERROR; }
-	    $$ = confignode_append(&(n->base), $3);
-	    $2 = NULL;
+        struct ConfigFileVersionNode *n = confignode_allocfileversion($2, @1.first_line);
+        if (!n) { YYERROR; }
+        $$ = confignode_append(&(n->base), $3);
+        $2 = NULL;
         $3 = NULL;
         }
     |
-	/* conf = 42 */
-	BARE EQUAL NUMBER eocstar {
-	    struct ConfigIntValNode *n = confignode_allocintval($1, $3, @1.first_line);
-	    if (!n) { YYERROR; }
-	    $$ = confignode_append(&(n->base), $4);
-	    $1 = NULL;
+    /* conf = 42 */
+    BARE EQUAL NUMBER eocstar {
+        struct ConfigIntValNode *n = confignode_allocintval($1, $3, @1.first_line);
+        if (!n) { YYERROR; }
+        $$ = confignode_append(&(n->base), $4);
+        $1 = NULL;
         $4 = NULL;
-	}
-	|
-	/* conf = 1.0 */
-	BARE EQUAL VERSION_TOK eocstar {
-	    struct ConfigVersionValNode *n = confignode_allocversionval($1, $3, @1.first_line);
-	    if (!n) { YYERROR; }
-	    $$ = confignode_append(&(n->base), $4);
-	    $1 = NULL;
+    }
+    |
+    /* conf = 1.0 */
+    BARE EQUAL VERSION_TOK eocstar {
+        struct ConfigVersionValNode *n = confignode_allocversionval($1, $3, @1.first_line);
+        if (!n) { YYERROR; }
+        $$ = confignode_append(&(n->base), $4);
+        $1 = NULL;
         $4 = NULL;
-	}
-	|
-	/* conf = "A string" */
-	BARE EQUAL STRING_TOK eocstar {
-	    struct ConfigStringValNode *n = confignode_allocstringval($1, $3, @1.first_line);
-	    if (!n) { YYERROR; }
-	    $$ = confignode_append(&(n->base), $4);
-	    $1 = NULL;
-	    $3 = NULL;
+    }
+    |
+    /* conf = "A string" */
+    BARE EQUAL STRING_TOK eocstar {
+        struct ConfigStringValNode *n = confignode_allocstringval($1, $3, @1.first_line);
+        if (!n) { YYERROR; }
+        $$ = confignode_append(&(n->base), $4);
+        $1 = NULL;
+        $3 = NULL;
         $4 = NULL;
-	}
-	|
-	/* conf = configuration */
-	BARE EQUAL BARE eocstar {
-	    struct ConfigBareValNode *n = confignode_allocbareval($1, $3, @1.first_line);
-	    if (!n) { YYERROR; }
-	    $$ = confignode_append(&(n->base), $4);
-	    $1 = NULL;
-	    $3 = NULL;
+    }
+    |
+    /* conf = configuration */
+    BARE EQUAL BARE eocstar {
+        struct ConfigBareValNode *n = confignode_allocbareval($1, $3, @1.first_line);
+        if (!n) { YYERROR; }
+        $$ = confignode_append(&(n->base), $4);
+        $1 = NULL;
+        $3 = NULL;
         $4 = NULL;
-	}
-	|
-	/* conf 42 { subconf = 73 } */
-	BARE NUMBER eocstar BEGIN_DEF commentedconfigelemstar END_DEF eocstar {
-	     struct ConfigIdxStructNode *n = confignode_allocidxstruct($1, $2, $3, $5, @1.first_line);
+    }
+    |
+    /* conf 42 { subconf = 73 } */
+    BARE NUMBER eocstar BEGIN_DEF commentedconfigelemstar END_DEF eocstar {
+         struct ConfigIdxStructNode *n = confignode_allocidxstruct($1, $2, $3, $5, @1.first_line);
          if (!n) { YYERROR; }
-	     $$ = confignode_append(&(n->base), $7);
-	     $1 = NULL;
-	     $3 = $5 = $7 = NULL;
-	}
-	|
-	/* conf { subconf = 73 } */
-	BARE eocstar BEGIN_DEF commentedconfigelemstar END_DEF eocstar {
+         $$ = confignode_append(&(n->base), $7);
+         $1 = NULL;
+         $3 = $5 = $7 = NULL;
+    }
+    |
+    /* conf { subconf = 73 } */
+    BARE eocstar BEGIN_DEF commentedconfigelemstar END_DEF eocstar {
         
-	     struct ConfigStructNode *n = confignode_allocstruct($1, $2, $4, @1.first_line);
+         struct ConfigStructNode *n = confignode_allocstruct($1, $2, $4, @1.first_line);
          if (!n) { YYERROR; }
-	     $$ = confignode_append(&(n->base), $6);
-	     $1 = NULL;
-	     $2 = $4 = $6 = NULL;
-	}
-	|
-	/* conf ( A, B, C ) */
-	BARE eocstar BEGIN_LIST barelist END_LIST eocstar {
-	     struct ConfigBareListNode *n = confignode_allocbarelist($1, $2, $4, @1.first_line);
+         $$ = confignode_append(&(n->base), $6);
+         $1 = NULL;
+         $2 = $4 = $6 = NULL;
+    }
+    |
+    /* conf ( A, B, C ) */
+    BARE eocstar BEGIN_LIST barelist END_LIST eocstar {
+         struct ConfigBareListNode *n = confignode_allocbarelist($1, $2, $4, @1.first_line);
          if (!n) { YYERROR; }
-	     $$ = confignode_append(&(n->base), $6);
-	     $1 = NULL;
-	     $2 = $4 = $6 = NULL;
-	}
+         $$ = confignode_append(&(n->base), $6);
+         $1 = NULL;
+         $2 = $4 = $6 = NULL;
+    }
     |
     BARE eocstar {
         struct ConfigBareConstNode *n = confignode_allocbareconst($1, @1.first_line);
@@ -232,12 +232,12 @@ A possibly empty list of barewords or comments.  Two bare words have to be
 separated by a comma (see barelist_ne).
 */
 barelist:
-	eocstar { $$ = $1; $1 = NULL; }
-	|
-	eocstar barelist_ne eocstar {
-		$$ = confignode_append($1, confignode_append($2, $3));
-		$1 = $2 = $3 = NULL;
-	}
+    eocstar { $$ = $1; $1 = NULL; }
+    |
+    eocstar barelist_ne eocstar {
+        $$ = confignode_append($1, confignode_append($2, $3));
+        $1 = $2 = $3 = NULL;
+    }
 
 /* Nonempty list of bare words.  If the list contains multiple elements, they
 are separated by a comma.  After a comma you can optionally add as many
@@ -245,57 +245,57 @@ end-of-line comments as you wish (see eocstar).  Note that the list may not end
 with a comma!
 */
 barelist_ne:
-	BARE COMMA eocstar barelist_ne {
-	    struct ConfigBareNode *n = confignode_allocbare($1, @1.first_line);
-	    if (!n) { YYERROR; }
-	    $1 = NULL;
-	    $$ = confignode_append(&n->base, confignode_append($3, $4));
-	    $3 = $4 = NULL;
-	}
-	|
-	BARE {
-	    struct ConfigBareNode *n = confignode_allocbare($1, @1.first_line);
-	    if (!n) { YYERROR; }
-	    $1 = NULL;
-	    $$ = &n->base;
-	}
+    BARE COMMA eocstar barelist_ne {
+        struct ConfigBareNode *n = confignode_allocbare($1, @1.first_line);
+        if (!n) { YYERROR; }
+        $1 = NULL;
+        $$ = confignode_append(&n->base, confignode_append($3, $4));
+        $3 = $4 = NULL;
+    }
+    |
+    BARE {
+        struct ConfigBareNode *n = confignode_allocbare($1, @1.first_line);
+        if (!n) { YYERROR; }
+        $1 = NULL;
+        $$ = &n->base;
+    }
 
 /* Either end of line comment or just end of line token.  Either way, a line
 ends with this non-terminal.
 */
 eoc:
-	COMMENT_TOK EOL {
-	    if (trackComments) {
-	        struct ConfigEOCNode *eocn = confignode_alloceoc($1, @1.first_line);
-	        if (!eocn) { YYERROR; };
-		$1 = NULL;
-		$$ = &eocn->base;
+    COMMENT_TOK EOL {
+        if (trackComments) {
+            struct ConfigEOCNode *eocn = confignode_alloceoc($1, @1.first_line);
+            if (!eocn) { YYERROR; };
+        $1 = NULL;
+        $$ = &eocn->base;
             } else {
-	        $$ = NULL;
-	    }
-	}
-	|
-	EOL {
-	    if (trackComments) {
-	        struct ConfigEOCNode *eocn = confignode_alloceoc(NULL, @1.first_line);
-	        if (!eocn) { YYERROR; };
-		$$ = &eocn->base;
+            $$ = NULL;
+        }
+    }
+    |
+    EOL {
+        if (trackComments) {
+            struct ConfigEOCNode *eocn = confignode_alloceoc(NULL, @1.first_line);
+            if (!eocn) { YYERROR; };
+        $$ = &eocn->base;
             } else {
-	        $$ = NULL;
-	    }
-	}
+            $$ = NULL;
+        }
+    }
 
 /* BNF form of eoc* */
 eocstar:
-	eocplus { $$ = $1; $1 = NULL; }
-	|
-	/* empty */ { $$ = NULL; }
+    eocplus { $$ = $1; $1 = NULL; }
+    |
+    /* empty */ { $$ = NULL; }
 
 /* BNF form of eoc+ */
 eocplus:
-	eoc { $$ = $1; $1 = NULL; }
-	|
-	eoc eocplus { $$ = confignode_append($1, $2); $1 = $2 = NULL; }
+    eoc { $$ = $1; $1 = NULL; }
+    |
+    eoc eocplus { $$ = confignode_append($1, $2); $1 = $2 = NULL; }
 
 %%
 
@@ -304,13 +304,13 @@ eocplus:
 int parse_configlib_file(FILE *conf, struct ConfigBaseNode **res,
                          error_hook_f error_hook, int trackComments)
 {
-	configscan_t scanner;
-	int ret;
+    configscan_t scanner;
+    int ret;
 
-	configlex_init_extra(trackComments, &scanner);
-	configset_in(conf, scanner);
-	ret = configparse(scanner, res, error_hook, trackComments) ? -1 : 0;
+    configlex_init_extra(trackComments, &scanner);
+    configset_in(conf, scanner);
+    ret = configparse(scanner, res, error_hook, trackComments) ? -1 : 0;
 
-	configlex_destroy(scanner);
-	return ret;
+    configlex_destroy(scanner);
+    return ret;
 }

--- a/usr/lib/config/cfgparse.y
+++ b/usr/lib/config/cfgparse.y
@@ -217,6 +217,15 @@ configelem:
         $1 = NULL;
         $2 = NULL;
     }
+    |
+    NUMBER eocstar {
+        
+        struct ConfigBareNumConstNode *n = confignode_allocbarenumconst($1, @1.first_line);
+        if (!n) { YYERROR; }
+        $$ = confignode_append(&(n->base), $2);
+        $2 = NULL;
+    }
+    
 
 /*
 A possibly empty list of barewords or comments.  Two bare words have to be

--- a/usr/lib/config/configuration.c
+++ b/usr/lib/config/configuration.c
@@ -521,3 +521,22 @@ confignode_allocbareconstdumpable(char *key, int line, char *comment)
     }
     return res;
 }
+
+struct ConfigBareNumConstNode *
+confignode_allocbarenumconstdumpable(unsigned long num, int line, char *comment)
+{
+    struct ConfigBareNumConstNode *res;
+    struct ConfigEOCNode *eoc;
+
+    res = confignode_allocbarenumconst(num, line);
+    if (res) {
+        eoc = confignode_alloceoc(comment ? strdup(comment) : NULL, line);
+        if (eoc) {
+            confignode_append(&(res->base), &(eoc->base));
+        } else {
+            confignode_freebarenumconst(res);
+            res = NULL;
+        }
+    }
+    return res;
+}

--- a/usr/lib/config/configuration.h
+++ b/usr/lib/config/configuration.h
@@ -64,6 +64,11 @@
  * represents its own configuration element.
  */
 #define CT_BARECONST    (1u << 10u)
+/*
+ * A bare number constant, i.e., a bare number outside of a list that
+ * represents its own configuration element.
+ */
+#define CT_BARENUMCONST (1u << 11u)
 
 /*
  * Mask for all types that have a key.  This excludes FILEVERSION,
@@ -140,6 +145,12 @@ struct ConfigEOCNode {
 
 struct ConfigBareConstNode {
     struct ConfigBaseNode base;
+};
+
+struct ConfigBareNumConstNode {
+    /* base.key is not used. */
+    struct ConfigBaseNode base;
+    unsigned long value;
 };
 
 /* Casting from base type functions */
@@ -324,6 +335,14 @@ static inline void confignode_freeeoc(struct ConfigEOCNode *n)
 }
 
 static inline void confignode_freebareconst(struct ConfigBareConstNode *n)
+{
+    if (n) {
+        free(n->base.key);
+        free(n);
+    }
+}
+
+static inline void confignode_freebarenumconst(struct ConfigBareNumConstNode *n)
 {
     if (n) {
         free(n->base.key);
@@ -518,6 +537,24 @@ static inline struct ConfigBareConstNode *confignode_allocbareconst(char *key,
     return res;
 }
 
+static inline struct ConfigBareNumConstNode *confignode_allocbarenumconst(
+                                                              unsigned long num,
+                                                              int line)
+{
+    struct ConfigBareNumConstNode *res =
+                            malloc(sizeof(struct ConfigBareNumConstNode));
+
+    if (res) {
+        res->base.next = res->base.prev = &(res->base);
+        res->base.key = NULL;
+        res->base.type = CT_BARENUMCONST;
+        res->base.line = line;
+        res->base.flags = 0;
+        res->value = num;
+    }
+    return res;
+}
+
 /* Convenience functions for AST manipulation.  These functions
    automatically append an EOC-node to the correct node which
    optionally includes a comment.  If no comment is desired, simply
@@ -564,6 +601,9 @@ confignode_allocbaredumpable(char *bareval, int line, char *comment);
 
 struct ConfigBareConstNode *
 confignode_allocbareconstdumpable(char *key, int line, char *comment);
+
+struct ConfigBareNumConstNode *
+confignode_allocbarenumconstdumpable(unsigned long num, int line, char *comment);
 
 /* Append the list n2 to the end of the list n1.
    NULL is considered as empty list. */


### PR DESCRIPTION
Similar to bare words, a bare number can appear outside of a list and represents its own configuration element.

With that the EP11 config file could also be parsed with the generic config file parser, instead of parsing it 'by hand'.

@juergenchrist Do you see any 'hidden' problems with adding this? 