### PR TITLE
config: Add missing function confignode_to_barenumconst()

### DIFF
--- a/usr/lib/config/configuration.h
+++ b/usr/lib/config/configuration.h
@@ -231,6 +231,13 @@ confignode_to_bareconst(struct ConfigBaseNode *n)
         (((char *)n) - offsetof(struct ConfigBareConstNode, base));
 }
 
+static inline struct ConfigBareNumConstNode *
+confignode_to_barenumconst(struct ConfigBaseNode *n)
+{
+    return (struct ConfigBareNumConstNode *)
+        (((char *)n) - offsetof(struct ConfigBareNumConstNode, base));
+}
+
 /* Freeing functions */
 
 /**


### PR DESCRIPTION
I forgot this with the last PR.....