### PR TITLE
Use generic config parser for parsing EP11 token config file

### DIFF
--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -9526,19 +9526,12 @@ static CK_RV read_adapter_config_file(STDLL_TokData_t * tokdata,
         }
     } else {
         if (conf_name && strlen(conf_name) > 0) {
-            strncpy(fname, conf_name, sizeof(fname) - 1);
+            snprintf(fname, sizeof(fname), "%s/%s", OCK_CONFDIR, conf_name);
             fname[sizeof(fname) - 1] = '\0';
             ap_fp = fopen(fname, "r");
-            if (!ap_fp) {
+            if (!ap_fp)
                 TRACE_DEVEL("%s fopen('%s') failed with errno %d\n",
                             __func__, fname, errno);
-                snprintf(fname, sizeof(fname), "%s/%s", OCK_CONFDIR, conf_name);
-                fname[sizeof(fname) - 1] = '\0';
-                ap_fp = fopen(fname, "r");
-                if (!ap_fp)
-                    TRACE_DEVEL("%s fopen('%s') failed with errno %d\n",
-                                __func__, fname, errno);
-            }
         } else {
             snprintf(fname, sizeof(fname), "%s/%s", OCK_CONFDIR,
                      EP11_DEFAULT_CFG_FILE);

--- a/usr/lib/ep11_stdll/ep11_stdll.mk
+++ b/usr/lib/ep11_stdll/ep11_stdll.mk
@@ -12,7 +12,8 @@ opencryptoki_stdll_libpkcs11_ep11_la_CFLAGS =				\
 	-DSTDLL_NAME=\"ep11tok\"					\
 	-I${srcdir}/usr/lib/ep11_stdll -I${srcdir}/usr/lib/common	\
 	-I${srcdir}/usr/include -I${top_builddir}/usr/lib/api		\
-	-I${srcdir}/usr/lib/api
+	-I${srcdir}/usr/lib/api -I${top_builddir}/usr/lib/config	\
+	-I${srcdir}/usr/lib/config
 
 opencryptoki_stdll_libpkcs11_ep11_la_LDFLAGS =				\
 	-shared -Wl,-z,defs,-Bsymbolic -lc -lpthread -lcrypto -lrt	\
@@ -41,7 +42,8 @@ opencryptoki_stdll_libpkcs11_ep11_la_SOURCES = usr/lib/common/asn1.c	\
 	usr/lib/ep11_stdll/new_host.c					\
 	usr/lib/ep11_stdll/ep11_specific.c				\
 	usr/lib/common/utility_common.c usr/lib/common/ec_supported.c	\
-	usr/lib/api/policyhelper.c
+	usr/lib/api/policyhelper.c usr/lib/config/configuration.c	\
+	usr/lib/config/cfgparse.y usr/lib/config/cfglex.l
 
 if ENABLE_LOCKS
 opencryptoki_stdll_libpkcs11_ep11_la_SOURCES +=				\


### PR DESCRIPTION
The syntax of the EP11 token file stays the same, but for the following keywords the 'key = value' and 'key = "value"' form is also accepted:
CPFILTER, PKEY_MODE, DIGEST_LIBICA.

Furthermore, end of line comments (using '#') are now accepted at any places. Previously such comments were only accepted at the beginning of a line.

With this, only the EP11 CP-filter config file is still 'hand-parsed', all other config files use the generic config parser.