### PR TITLE
Config: support bare string constants, and other fixes

### DIFF
--- a/testcases/unit/configdump.c
+++ b/testcases/unit/configdump.c
@@ -17,6 +17,11 @@ static const char test6[] = "foo (\n      bar,\n      buzz\n    )\n";
 static const char test7[] = "foo\n(\n  bar,\n  buzz\n)\n";
 static const char nested1[] = "nested {\n  foo (\n        bar,\n        buzz\n      )\n}\n";
 static const char nested2[] = "nested {\n  foo\n  (\n    bar,\n    buzz\n  )\n}\n";
+static const char bare1[] = "foo\nbar\n";
+static const char bare2[] = "foo bar\n";
+static const char bare3[] = "foo\n1234\n";
+static const char bare4[] = "foo\n\"bar\"\n";
+static const char bare5[] = "foo \"bar\"\n";
 static char outbuf[1024];
 
 static const char *curtest;
@@ -74,5 +79,10 @@ int main(void)
     runparsedumptest(test7);
     runparsedumptest(nested1);
     runparsedumptest(nested2);
+    runparsedumptest(bare1);
+    runparsedumptest(bare2);
+    runparsedumptest(bare3);
+    runparsedumptest(bare4);
+    runparsedumptest(bare5);
     return TEST_PASS;
 }

--- a/usr/lib/config/cfgparse.y
+++ b/usr/lib/config/cfgparse.y
@@ -219,13 +219,18 @@ configelem:
     }
     |
     NUMBER eocstar {
-        
         struct ConfigBareNumConstNode *n = confignode_allocbarenumconst($1, @1.first_line);
         if (!n) { YYERROR; }
         $$ = confignode_append(&(n->base), $2);
         $2 = NULL;
     }
-    
+    |
+    STRING_TOK eocstar {
+        struct ConfigBareStringConstNode *n = confignode_allocbarestringconst($1, @1.first_line);
+        if (!n) { YYERROR; }
+        $$ = confignode_append(&(n->base), $2);
+        $2 = NULL;
+    }
 
 /*
 A possibly empty list of barewords or comments.  Two bare words have to be

--- a/usr/lib/config/configuration.c
+++ b/usr/lib/config/configuration.c
@@ -229,6 +229,9 @@ static int confignode_dump_i(FILE *fp, struct ConfigBaseNode *n,
         case CT_BARECONST:
             fputs(i->key, fp);
             break;
+        case CT_BARENUMCONST:
+            fprintf(fp, "%lu", confignode_to_barenumconst(i)->value);
+            break;
         default:
             break;
         }

--- a/usr/lib/config/configuration.c
+++ b/usr/lib/config/configuration.c
@@ -56,6 +56,9 @@ void confignode_free(struct ConfigBaseNode *n)
         case CT_BARENUMCONST:
             confignode_freebarenumconst(confignode_to_barenumconst(n));
             break;
+        case CT_BARESTRINGCONST:
+            confignode_freebarestringconst(confignode_to_barestringconst(n));
+            break;
         default:
             break;
         }
@@ -234,6 +237,9 @@ static int confignode_dump_i(FILE *fp, struct ConfigBaseNode *n,
             break;
         case CT_BARENUMCONST:
             fprintf(fp, "%lu", confignode_to_barenumconst(i)->value);
+            break;
+        case CT_BARESTRINGCONST:
+            fprintf(fp, "\"%s\"", i->key);
             break;
         default:
             break;
@@ -541,6 +547,25 @@ confignode_allocbarenumconstdumpable(unsigned long num, int line, char *comment)
             confignode_append(&(res->base), &(eoc->base));
         } else {
             confignode_freebarenumconst(res);
+            res = NULL;
+        }
+    }
+    return res;
+}
+
+struct ConfigBareStringConstNode *
+confignode_allocbarestringconstdumpable(char *key, int line, char *comment)
+{
+    struct ConfigBareStringConstNode *res;
+    struct ConfigEOCNode *eoc;
+
+    res = confignode_allocbarestringconst(key, line);
+    if (res) {
+        eoc = confignode_alloceoc(comment ? strdup(comment) : NULL, line);
+        if (eoc) {
+            confignode_append(&(res->base), &(eoc->base));
+        } else {
+            confignode_freebarestringconst(res);
             res = NULL;
         }
     }

--- a/usr/lib/config/configuration.c
+++ b/usr/lib/config/configuration.c
@@ -53,6 +53,9 @@ void confignode_free(struct ConfigBaseNode *n)
         case CT_BARECONST:
             confignode_freebareconst(confignode_to_bareconst(n));
             break;
+        case CT_BARENUMCONST:
+            confignode_freebarenumconst(confignode_to_barenumconst(n));
+            break;
         default:
             break;
         }


### PR DESCRIPTION
Add support for a bare quoted string in the generic config parser. This is similar to a bare constant, but allows blanks within the value. 

@juergenchrist Same question again: do you think this could cause problems with the parser? From what I can tell it should not get in the way of other config elements.....

Also fix some things that I have missed with some previous commits.