### PR TITLE
config: support number pair lists and bare quoted strings

### DIFF
--- a/testcases/unit/configdump.c
+++ b/testcases/unit/configdump.c
@@ -18,6 +18,12 @@ static const char test7[] = "foo\n(\n  bar,\n  buzz\n)\n";
 static const char nested1[] = "nested {\n  foo (\n        bar,\n        buzz\n      )\n}\n";
 static const char nested2[] = "nested {\n  foo\n  (\n    bar,\n    buzz\n  )\n}\n";
 static const char numpair1[] = "foo\n  1 2\n  3 4\nbar\n";
+static const char bare1[] = "foo\n";
+static const char bare2[] = "foo bar\n";
+static const char bare3[] = "foo\nbar\n";
+static const char bare4[] = "\"foo\"\n";
+static const char bare5[] = "\"foo\"\n\"bar\"\n";
+static const char bare6[] = "foo \"bar\"\n";
 static char outbuf[1024];
 
 static const char *curtest;
@@ -76,5 +82,11 @@ int main(void)
     runparsedumptest(nested1);
     runparsedumptest(nested2);
     runparsedumptest(numpair1);
+    runparsedumptest(bare1);
+    runparsedumptest(bare2);
+    runparsedumptest(bare3);
+    runparsedumptest(bare4);
+    runparsedumptest(bare5);
+    runparsedumptest(bare6);
     return TEST_PASS;
 }

--- a/testcases/unit/configdump.c
+++ b/testcases/unit/configdump.c
@@ -17,6 +17,7 @@ static const char test6[] = "foo (\n      bar,\n      buzz\n    )\n";
 static const char test7[] = "foo\n(\n  bar,\n  buzz\n)\n";
 static const char nested1[] = "nested {\n  foo (\n        bar,\n        buzz\n      )\n}\n";
 static const char nested2[] = "nested {\n  foo\n  (\n    bar,\n    buzz\n  )\n}\n";
+static const char numpair1[] = "foo\n  1 2\n  3 4\nbar\n";
 static char outbuf[1024];
 
 static const char *curtest;
@@ -74,5 +75,6 @@ int main(void)
     runparsedumptest(test7);
     runparsedumptest(nested1);
     runparsedumptest(nested2);
+    runparsedumptest(numpair1);
     return TEST_PASS;
 }

--- a/usr/lib/config/cfgparse.y
+++ b/usr/lib/config/cfgparse.y
@@ -217,15 +217,6 @@ configelem:
         $1 = NULL;
         $2 = NULL;
     }
-    |
-    NUMBER eocstar {
-        
-        struct ConfigBareNumConstNode *n = confignode_allocbarenumconst($1, @1.first_line);
-        if (!n) { YYERROR; }
-        $$ = confignode_append(&(n->base), $2);
-        $2 = NULL;
-    }
-    
 
 /*
 A possibly empty list of barewords or comments.  Two bare words have to be

--- a/usr/lib/config/cfgparse.y
+++ b/usr/lib/config/cfgparse.y
@@ -229,6 +229,13 @@ configelem:
          $4 = NULL;
          $5 = NULL;
     }
+    |
+    STRING_TOK eocstar {
+        struct ConfigBareStringConstNode *n = confignode_allocbarestringconst($1, @1.first_line);
+        if (!n) { YYERROR; }
+        $$ = confignode_append(&(n->base), $2);
+        $2 = NULL;
+    }
 
 /*
 A list of number pairs.

--- a/usr/lib/config/configuration.c
+++ b/usr/lib/config/configuration.c
@@ -521,22 +521,3 @@ confignode_allocbareconstdumpable(char *key, int line, char *comment)
     }
     return res;
 }
-
-struct ConfigBareNumConstNode *
-confignode_allocbarenumconstdumpable(unsigned long num, int line, char *comment)
-{
-    struct ConfigBareNumConstNode *res;
-    struct ConfigEOCNode *eoc;
-
-    res = confignode_allocbarenumconst(num, line);
-    if (res) {
-        eoc = confignode_alloceoc(comment ? strdup(comment) : NULL, line);
-        if (eoc) {
-            confignode_append(&(res->base), &(eoc->base));
-        } else {
-            confignode_freebarenumconst(res);
-            res = NULL;
-        }
-    }
-    return res;
-}

--- a/usr/lib/config/configuration.c
+++ b/usr/lib/config/configuration.c
@@ -59,6 +59,9 @@ void confignode_free(struct ConfigBaseNode *n)
         case CT_NUMPAIRLIST:
             confignode_freenumpairlist(confignode_to_numpairlist(n));
             break;
+        case CT_BARESTRINGCONST:
+            confignode_freebarestringconst(confignode_to_barestringconst(n));
+            break;
         default:
             break;
         }
@@ -304,6 +307,9 @@ static int confignode_dump_i(FILE *fp, struct ConfigBaseNode *n,
             confignode_dumpnumpairlist(fp, confignode_to_numpairlist(i), cb,
                                        flags, indent, curindent);
             newatbol = 1;
+            break;
+        case CT_BARESTRINGCONST:
+            fprintf(fp, "\"%s\"", i->key);
             break;
         default:
             break;
@@ -651,6 +657,25 @@ confignode_allocnumpairlistdumpable(char *key, char* end,
     } else {
         free(dkey);
         free(dend);
+    }
+    return res;
+}
+
+struct ConfigBareStringConstNode *
+confignode_allocbarestringconstdumpable(char *key, int line, char *comment)
+{
+    struct ConfigBareStringConstNode *res;
+    struct ConfigEOCNode *eoc;
+
+    res = confignode_allocbarestringconst(key, line);
+    if (res) {
+        eoc = confignode_alloceoc(comment ? strdup(comment) : NULL, line);
+        if (eoc) {
+            confignode_append(&(res->base), &(eoc->base));
+        } else {
+            confignode_freebarestringconst(res);
+            res = NULL;
+        }
     }
     return res;
 }

--- a/usr/lib/config/configuration.h
+++ b/usr/lib/config/configuration.h
@@ -64,11 +64,6 @@
  * represents its own configuration element.
  */
 #define CT_BARECONST    (1u << 10u)
-/*
- * A bare number constant, i.e., a bare number outside of a list that
- * represents its own configuration element.
- */
-#define CT_BARENUMCONST (1u << 11u)
 
 /*
  * Mask for all types that have a key.  This excludes FILEVERSION,
@@ -147,12 +142,6 @@ struct ConfigBareConstNode {
     struct ConfigBaseNode base;
 };
 
-struct ConfigBareNumConstNode {
-    /* base.key is not used. */
-    struct ConfigBaseNode base;
-    unsigned long value;
-};
-
 /* Casting from base type functions */
 static inline struct ConfigFileVersionNode *
 confignode_to_fileversion(struct ConfigBaseNode *n)
@@ -229,13 +218,6 @@ confignode_to_bareconst(struct ConfigBaseNode *n)
 {
     return (struct ConfigBareConstNode *)
         (((char *)n) - offsetof(struct ConfigBareConstNode, base));
-}
-
-static inline struct ConfigBareNumConstNode *
-confignode_to_barenumconst(struct ConfigBaseNode *n)
-{
-    return (struct ConfigBareNumConstNode *)
-        (((char *)n) - offsetof(struct ConfigBareNumConstNode, base));
 }
 
 /* Freeing functions */
@@ -342,14 +324,6 @@ static inline void confignode_freeeoc(struct ConfigEOCNode *n)
 }
 
 static inline void confignode_freebareconst(struct ConfigBareConstNode *n)
-{
-    if (n) {
-        free(n->base.key);
-        free(n);
-    }
-}
-
-static inline void confignode_freebarenumconst(struct ConfigBareNumConstNode *n)
 {
     if (n) {
         free(n->base.key);
@@ -544,24 +518,6 @@ static inline struct ConfigBareConstNode *confignode_allocbareconst(char *key,
     return res;
 }
 
-static inline struct ConfigBareNumConstNode *confignode_allocbarenumconst(
-                                                              unsigned long num,
-                                                              int line)
-{
-    struct ConfigBareNumConstNode *res =
-                            malloc(sizeof(struct ConfigBareNumConstNode));
-
-    if (res) {
-        res->base.next = res->base.prev = &(res->base);
-        res->base.key = NULL;
-        res->base.type = CT_BARENUMCONST;
-        res->base.line = line;
-        res->base.flags = 0;
-        res->value = num;
-    }
-    return res;
-}
-
 /* Convenience functions for AST manipulation.  These functions
    automatically append an EOC-node to the correct node which
    optionally includes a comment.  If no comment is desired, simply
@@ -608,9 +564,6 @@ confignode_allocbaredumpable(char *bareval, int line, char *comment);
 
 struct ConfigBareConstNode *
 confignode_allocbareconstdumpable(char *key, int line, char *comment);
-
-struct ConfigBareNumConstNode *
-confignode_allocbarenumconstdumpable(unsigned long num, int line, char *comment);
 
 /* Append the list n2 to the end of the list n1.
    NULL is considered as empty list. */

--- a/usr/lib/config/configuration.h
+++ b/usr/lib/config/configuration.h
@@ -72,6 +72,11 @@
  * A list of number pairs
  */
 #define CT_NUMPAIRLIST  (1u << 12u)
+/*
+ * A bare quoted string constant, i.e., a bare string outside of a list that
+ * represents its own configuration element.
+ */
+#define CT_BARESTRINGCONST (1u << 13u)
 
 /*
  * Mask for all types that have a key.  This excludes FILEVERSION,
@@ -79,7 +84,7 @@
  */
 #define CT_HAS_KEY_MASK (CT_INTVAL | CT_STRINGVAL | CT_VERSIONVAL |  \
 			 CT_BAREVAL | CT_STRINGVAL | CT_IDX_STRUCT | \
-			 CT_BARELIST | CT_BARECONST | CT_NUMPAIRLIST)
+			 CT_BARELIST | CT_BARECONST | CT_NUMPAIRLIST | CT_BARESTRINGCONST)
 
 /***** Node Types *****/
 struct ConfigBaseNode;
@@ -162,6 +167,10 @@ struct ConfigNumPairListNode {
     /* either a ConfigNumPairNode or a ConfigEOCNode */
     struct ConfigBaseNode *value;
     char *end;
+};
+
+struct ConfigBareStringConstNode {
+    struct ConfigBaseNode base;
 };
 
 /* Casting from base type functions */
@@ -254,6 +263,13 @@ confignode_to_numpairlist(struct ConfigBaseNode *n)
 {
     return (struct ConfigNumPairListNode *)
         (((char *)n) - offsetof(struct ConfigNumPairListNode, base));
+}
+
+static inline struct ConfigBareStringConstNode *
+confignode_to_barestringconst(struct ConfigBaseNode *n)
+{
+    return (struct ConfigBareStringConstNode *)
+        (((char *)n) - offsetof(struct ConfigBareStringConstNode, base));
 }
 
 /* Freeing functions */
@@ -381,6 +397,15 @@ static inline void confignode_freenumpairlist(struct ConfigNumPairListNode *n)
         free(n->base.key);
         confignode_deepfree(n->beforeFirst);
         confignode_deepfree(n->value);
+        free(n);
+    }
+}
+
+static inline void confignode_freebarestringconst(
+                                        struct ConfigBareStringConstNode *n)
+{
+    if (n) {
+        free(n->base.key);
         free(n);
     }
 }
@@ -608,6 +633,23 @@ confignode_allocnumpairlist(char *key, char *end,
         res->beforeFirst = beforeFirst;
         res->value = value;
         res->end = end;
+    }
+    return res;
+}
+
+static inline struct ConfigBareStringConstNode *confignode_allocbarestringconst(
+                                                                     char *key,
+                                                                     int line)
+{
+    struct ConfigBareStringConstNode *res =
+                            malloc(sizeof(struct ConfigBareStringConstNode));
+
+    if (res) {
+        res->base.next = res->base.prev = &(res->base);
+        res->base.key = key;
+        res->base.type = CT_BARESTRINGCONST;
+        res->base.line = line;
+        res->base.flags = 0;
     }
     return res;
 }


### PR DESCRIPTION
This is a try to support parsing the EP11 token config file by adding special node types for a number pair list, and a number pair within a list. This can parse something like this:
```
      APQN_ALLOWLIST # comment 1
       8 13 # comment 2
      10 13 # comment 3
      END # comment 4
```
Makes handling in the consumer a little bit easier than just a series bare number constants.

While at it, remove the bare number const config element, as it causes problems and is no longer required, if we remove the `LOGLEVEL <value>` support from the EP11 config file (was removed in OCK v3.3 in 2015, and is since then allowed, but ignored and just produces a SYSLOG warning but has no effect). 

It still shows the one shift/reduce conflict which is caused by the single BARE element. Unfortunately the opencryptoki.conf already requires single BARE elements (so will the EP11 config file), so we cant simply remove this.  It looks like this conflict does not really hurt so far, at least I have not noticed anything except the following:

Once consequence of this is that after the APQN_ALLOWLIST start bare of a number pair list a EOC must follow, otherwise it expects a indexed structure (`conf 42 { subconf = 73 }`.  I guess I could live with that..... Maybe we should then change it to `BARE eocplus numpairlist BARE eocstar` right away?

But at least this change does not make things worse than it was before.....

We would still need the bare quoted string constants from PR https://github.com/opencryptoki/opencryptoki/pull/547 and PR https://github.com/opencryptoki/opencryptoki/pull/545 would need changes to support the number pair lists.