### PR TITLE
Add field ulIvBits to CK_GCM_PARAMS, but also accept old version parameter

### DIFF
--- a/testcases/crypto/aes.h
+++ b/testcases/crypto/aes.h
@@ -85,6 +85,7 @@ struct CK_AES_CTR_PARAMS aesctr = {
 
 struct CK_GCM_PARAMS aesgcm = {
     .ulIvLen = AES_BLOCK_SIZE,
+    .ulIvBits = AES_BLOCK_SIZE * 8,
     .ulAADLen = 0,
     .ulTagBits = 16,
 };

--- a/testcases/crypto/aes_func.c
+++ b/testcases/crypto/aes_func.c
@@ -414,6 +414,7 @@ CK_RV alloc_gcm_param(CK_GCM_PARAMS *gcm_param, CK_BYTE *pIV, CK_ULONG ulIVLen,
         return CKR_HOST_MEMORY;
     gcm_param->ulIvLen = ulIVLen;
     memcpy(gcm_param->pIv, pIV, ulIVLen);
+    gcm_param->ulIvBits = ulIVLen * 8;
 
     gcm_param->pAAD = malloc(ulAADLen);
     if (gcm_param->pAAD == NULL) {

--- a/usr/include/pkcs11types.h
+++ b/usr/include/pkcs11types.h
@@ -1287,12 +1287,31 @@ typedef CK_AES_CTR_PARAMS CK_PTR CK_AES_CTR_PARAMS_PTR;
 typedef struct CK_GCM_PARAMS {
     CK_BYTE_PTR pIv;
     CK_ULONG ulIvLen;
+    CK_ULONG ulIvBits;
     CK_BYTE_PTR pAAD;
     CK_ULONG ulAADLen;
     CK_ULONG ulTagBits;
 } CK_GCM_PARAMS;
 
 typedef CK_GCM_PARAMS CK_PTR CK_GCM_PARAMS_PTR;
+
+/*
+ * There is a discrepancy between what the PKCS#11 v2.40 standard states in the
+ * documentation and the official header file about structure CK_GCM_PARAMS:
+ * https://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/errata01/os/include/pkcs11-v2.40/pkcs11t.h
+ * The header file defines field ulIvBits for structure CK_GCM_PARAMS, but the
+ * documentation does not mention that field at all.
+ * Opencryptoki accepts both versions of the CK_GCM_PARAMS structure, with or
+ * without the field. Structure CK_GCM_PARAMS_COMPAT represents the one without
+ * field ulIvBits.
+ */
+typedef struct CK_GCM_PARAMS_COMPAT {
+    CK_BYTE_PTR pIv;
+    CK_ULONG ulIvLen;
+    CK_BYTE_PTR pAAD;
+    CK_ULONG ulAADLen;
+    CK_ULONG ulTagBits;
+} CK_GCM_PARAMS_COMPAT;
 
 /* CK_RC5_CBC_PARAMS provides the parameters to the CKM_RC5_CBC
  * mechanism */

--- a/usr/lib/common/decr_mgr.c
+++ b/usr/lib/common/decr_mgr.c
@@ -43,6 +43,8 @@ CK_RV decr_mgr_init(STDLL_TokData_t *tokdata,
     CK_RV rc;
     int check;
     CK_ULONG strength = POLICY_STRENGTH_IDX_0;
+    CK_GCM_PARAMS gcm_params;
+    CK_MECHANISM temp_mech;
 
     if (!sess) {
         TRACE_ERROR("Invalid function arguments.\n");
@@ -528,11 +530,21 @@ CK_RV decr_mgr_init(STDLL_TokData_t *tokdata,
         memset(ctx->context, 0x0, sizeof(AES_CONTEXT));
         break;
     case CKM_AES_GCM:
-        if (mech->ulParameterLen != sizeof(CK_GCM_PARAMS) ||
+        if ((mech->ulParameterLen != sizeof(CK_GCM_PARAMS) &&
+             mech->ulParameterLen != sizeof(CK_GCM_PARAMS_COMPAT)) ||
             mech->pParameter == NULL) {
             TRACE_ERROR("%s\n", ock_err(ERR_MECHANISM_PARAM_INVALID));
             rc = CKR_MECHANISM_PARAM_INVALID;
             goto done;
+        }
+
+        if (mech->ulParameterLen == sizeof(CK_GCM_PARAMS_COMPAT)) {
+            aes_gcm_param_from_compat((CK_GCM_PARAMS_COMPAT *)mech->pParameter,
+                                      &gcm_params);
+            temp_mech.mechanism = mech->mechanism;
+            temp_mech.pParameter = &gcm_params;
+            temp_mech.ulParameterLen = sizeof(gcm_params);
+            mech = &temp_mech;
         }
 
         rc = template_attribute_get_ulong(key_obj->template, CKA_KEY_TYPE,

--- a/usr/lib/common/h_extern.h
+++ b/usr/lib/common/h_extern.h
@@ -1493,6 +1493,9 @@ CK_RV aes_gcm_dup_param(CK_GCM_PARAMS *from, CK_GCM_PARAMS *to);
 
 CK_RV aes_gcm_free_param(CK_GCM_PARAMS *params);
 
+void aes_gcm_param_from_compat(const CK_GCM_PARAMS_COMPAT *from,
+                               CK_GCM_PARAMS *to);
+
 CK_RV aes_ofb_encrypt(STDLL_TokData_t *tokdata, SESSION *sess,
                       CK_BBOOL length_only,
                       ENCR_DECR_CONTEXT *ctx, CK_BYTE *in_data,

--- a/usr/lib/common/mech_aes.c
+++ b/usr/lib/common/mech_aes.c
@@ -3427,6 +3427,7 @@ CK_RV aes_gcm_dup_param(CK_GCM_PARAMS *from, CK_GCM_PARAMS *to)
 
     to->pIv = NULL;
     to->ulIvLen = 0;
+    to->ulIvBits = 0;
     if (from->ulIvLen != 0 && from->pIv != NULL) {
         to->pIv = malloc(from->ulIvLen);
         if (to->pIv == NULL) {
@@ -3437,6 +3438,7 @@ CK_RV aes_gcm_dup_param(CK_GCM_PARAMS *from, CK_GCM_PARAMS *to)
 
         memcpy(to->pIv, from->pIv, from->ulIvLen);
         to->ulIvLen = from->ulIvLen;
+        to->ulIvBits = from->ulIvBits;
     }
 
     to->pAAD = NULL;
@@ -3470,6 +3472,17 @@ CK_RV aes_gcm_free_param(CK_GCM_PARAMS *params)
     memset(params, 0, sizeof(*params));
 
     return CKR_OK;
+}
+
+void aes_gcm_param_from_compat(const CK_GCM_PARAMS_COMPAT *from,
+                               CK_GCM_PARAMS *to)
+{
+    to->pIv       = from->pIv;
+    to->ulIvLen   = from->ulIvLen;
+    to->ulIvBits  = from->ulIvLen * 8;
+    to->pAAD      = from->pAAD;
+    to->ulAADLen  = from->ulAADLen;
+    to->ulTagBits = from->ulTagBits;
 }
 
 //


### PR DESCRIPTION
There is some confusion in the PKCS#11 standard, where the doc says nothing about this field, while the official C header has it:
https://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/errata01/os/include/pkcs11-v2.40/pkcs11t.h
Nevertheless, the header files contain the normative definition.

Add code to accept both versions of the CK_GCM_PARAMS structure, with or without the ulIvBits field. Detection is based on the size of the mechanism parameter. When a GCM mechanism parameter without the ulIvBits field is encountered, it is translated into a GCM parameter with that field, setting ulIvBits to ulIvLen * 8.