### PR TITLE
testcases: Fix sess_opstate to return zero return code if skipped

### DIFF
--- a/testcases/pkcs11/sess_opstate.c
+++ b/testcases/pkcs11/sess_opstate.c
@@ -133,6 +133,7 @@ int sess_opstate_funcs(int loops)
         if (rc != CKR_OK) {
             if (rc == CKR_STATE_UNSAVEABLE) {
                 testcase_skip("Get/SetOperationState digest test: state unsavable");
+                rc = CKR_OK;
                 goto out;
             }
             testcase_error("C_GetOperationState rc=%s", p11_get_ckr(rc));
@@ -149,6 +150,7 @@ int sess_opstate_funcs(int loops)
         if (rc != CKR_OK) {
             if (rc == CKR_STATE_UNSAVEABLE) {
                 testcase_skip("Get/SetOperationState digest test: state unsavable");
+                rc = CKR_OK;
                 goto out;
             }
             testcase_error("C_GetOperationState rc=%s", p11_get_ckr(rc));


### PR DESCRIPTION
When the operation state is not savable, the testcase is skipped. Make sure to return a zero return code anyway.