### PR TITLE
CCA: EC signature verify may also return 12 / 769 for bad signatures

### DIFF
--- a/usr/lib/cca_stdll/cca_specific.c
+++ b/usr/lib/cca_stdll/cca_specific.c
@@ -2767,6 +2767,8 @@ CK_RV token_specific_ec_verify(STDLL_TokData_t * tokdata,
 
     if (return_code == 4 && reason_code == 429) {
         return CKR_SIGNATURE_INVALID;
+    } else if (return_code == 12 && reason_code == 769) {
+        return CKR_SIGNATURE_INVALID;
     } else if (return_code != CCA_SUCCESS) {
         TRACE_ERROR("CSNDDSV (EC VERIFY) failed. return:%ld,"
                     " reason:%ld\n", return_code, reason_code);


### PR DESCRIPTION
According to the description of CCA verb "Digital Signature Verify" (CSNDDSV) in "Secure Key Solution with the Common Cryptographic Architecture Application Programmer's Guide Version 7.1" the signature verify request may also return 12 / 769 for bad signatures, in addition to 4 / 429. Treat both return codes as bad signature indication.