### PR TITLE
TESTCASE: Accept CKR_FUNCTION_FAILED for invalid EC signatures with ICA token

### DIFF
--- a/testcases/crypto/ec_func.c
+++ b/testcases/crypto/ec_func.c
@@ -1463,17 +1463,27 @@ CK_RV run_GenerateSignVerifyECC(CK_SESSION_HANDLE session,
 
         rc = funcs->C_VerifyFinal(session, signature, signaturelen);
         if (rc != CKR_SIGNATURE_INVALID) {
-            testcase_error("C_VerifyFinal rc=%s", p11_get_ckr(rc));
-            PRINT_ERR("		Expected CKR_SIGNATURE_INVALID\n");
-            goto testcase_cleanup;
+            if (rc ==  CKR_FUNCTION_FAILED && is_ica_token(SLOT_ID)) {
+                testcase_notice("C_VerifyFinal rc=%s temporarily accepted for ICA token",
+                                p11_get_ckr(rc));
+            } else {
+                testcase_error("C_VerifyFinal rc=%s", p11_get_ckr(rc));
+                PRINT_ERR("		Expected CKR_SIGNATURE_INVALID\n");
+                goto testcase_cleanup;
+            }
         }
     } else {
         rc = funcs->C_Verify(session, data != NULL ? data : (CK_BYTE *)"",
                              inputlen, signature, signaturelen);
         if (rc != CKR_SIGNATURE_INVALID) {
-            testcase_error("C_Verify rc=%s", p11_get_ckr(rc));
-            PRINT_ERR("		Expected CKR_SIGNATURE_INVALID\n");
-            goto testcase_cleanup;
+            if (rc ==  CKR_FUNCTION_FAILED && is_ica_token(SLOT_ID)) {
+                testcase_notice("C_Verify rc=%s temporarily accepted for ICA token",
+                                p11_get_ckr(rc));
+            } else {
+                testcase_error("C_Verify rc=%s", p11_get_ckr(rc));
+                PRINT_ERR("		Expected CKR_SIGNATURE_INVALID\n");
+                goto testcase_cleanup;
+            }
         }
     }
 


### PR DESCRIPTION
Due to improper return code handling in libica, an EC signature verification using an (intentionally) incorrect signature may return CKR_FUNCTION_FAILED when using the ICA token.

This has already been fixed in libica, but it may take a while until the fix arrives in the distro used in the CI. Until then the testcases would continue to fail. Temporarily accept CKR_FUNCTION_FAILED in the test case for this situation.