### PR TITLE
Add MKVPs/WKVP to generated configs for CI runs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -218,7 +218,7 @@ PKCS11_VHSM_PIN ?= 1234567890
 
 ci-prepare:
 	killall -HUP pkcsslotd || true
-	${srcdir}/testcases/ciconfig.sh "$(sysconfdir)/opencryptoki" "$(sysconfdir)/opencryptoki"
+	${srcdir}/testcases/ciconfig.sh "$(sysconfdir)/opencryptoki" "$(sysconfdir)/opencryptoki" "$(sysconfdir)/opencryptoki"
 	@sbindir@/pkcsslotd
 	@sbindir@/pkcsstats --reset-all
 	for slot in `awk '/slot (.*)/ { print $$2; }' $(sysconfdir)/opencryptoki/opencryptoki.conf`; do @sbindir@/pkcsconf -c $$slot -t | grep "Flags:" | grep -q TOKEN_INITIALIZED || PKCS11_USER_PIN=$(PKCS11_USER_PIN) PKCS11_SO_PIN=$(PKCS11_SO_PIN) PKCSLIB=@libdir@/opencryptoki/libopencryptoki.so ${srcdir}/testcases/init_token.sh $$slot; done

--- a/testcases/ock_tests.sh.in
+++ b/testcases/ock_tests.sh.in
@@ -94,19 +94,6 @@ check_tpmtok()
 }
 
 ###
-## check_ccatok() - Check if stuff needed by the CCA token
-##                  are present
-###
-check_ccatok()
-{
-    # Check if catcher.exe is running
-    if ! pgrep catcher.exe; then
-        echo "Error: catcher.exe daemon not running"
-        return 1
-    fi
-}
-
-###
 ## init_slot() - Initialize a specific slot
 ## $1 - The slot number to initialize
 ##
@@ -154,7 +141,6 @@ check_slot()
             ;;
         *CCA*)
             echo "CCA Token type detected"
-            check_ccatok || return
             TOKTYPE="CCA"
             ;;
         *ICA*)


### PR DESCRIPTION
Configure one CCA token and one EP11 token with the expected master/wrapping key verification patterns that are used in the CI. 

Also ensure that the CCA tokens are tested, even if catcher.exe is not currently running (catcher.exe is only needed for communication with the TKE, but not for using the CCA adapters).
