### PR TITLE
v4: pkcs11 URI generation support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,8 @@ testcases/unit/configdump
 testcases/unit/hashmaptest
 testcases/unit/mechtabletest
 testcases/unit/policytest
+testcases/unit/buffertest
+testcases/unit/uritest
 usr/sbin/p11sak/p11sak
 usr/sbin/pkcscca/pkcscca
 usr/sbin/pkcsconf/pkcsconf

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,10 @@ testcases/pkcs11/sess_mgmt_tests
 testcases/pkcs11/sess_opstate
 testcases/policy/policytest
 testcases/policy/policytest.sh
+testcases/unit/configdump
+testcases/unit/hashmaptest
+testcases/unit/mechtabletest
+testcases/unit/policytest
 usr/sbin/p11sak/p11sak
 usr/sbin/pkcscca/pkcscca
 usr/sbin/pkcsconf/pkcsconf
@@ -65,6 +69,10 @@ usr/sbin/pkcsstats/pkcsstats
 usr/sbin/pkcstok_migrate/pkcstok_migrate
 tools/policyexamplegen
 tools/tableidxgen
+
+# ignore test logs
+*.log
+*.trs
 
 # ignore build stubs
 *.lai

--- a/Makefile.am
+++ b/Makefile.am
@@ -247,7 +247,12 @@ installcheck-local: all
 ci-installcheck: ci-prepare installcheck
 	killall -HUP pkcsslotd || true
 	@sbindir@/pkcsslotd
-	cd ${srcdir}/testcases && export PKCSLIB=@libdir@/opencryptoki/libopencryptoki.so && export PKCS11_USER_PIN=$(PKCS11_USER_PIN) && ./misc_tests/p11sak_test.sh | tee log-p11sak.txt
+	pushd ${srcdir}/testcases
+	export PKCSLIB=@libdir@/opencryptoki/libopencryptoki.so
+	export PKCS11_USER_PIN=$(PKCS11_USER_PIN)
+	./misc_tests/p11sak_test.sh | tee log-p11sak.txt
+	./misc_tests/pkcsconf_test.sh | tee log-pkcsconf.txt
+	popd
 	@sbindir@/pkcsstats --all
 	killall -HUP pkcsslotd
 	@echo "done"

--- a/testcases/misc_tests/p11sak_test.sh
+++ b/testcases/misc_tests/p11sak_test.sh
@@ -148,19 +148,19 @@ fi
 
 
 # CK_BBOOL
-if [[ $(grep -A 19 'p11sak-des' $P11SAK_DES_LONG | grep -c 'CKA_IBM_PROTKEY_EXTRACTABLE: CK_FALSE') == "1" ]]; then
+if [[ $(grep -A 20 'p11sak-des' $P11SAK_DES_LONG | grep -c 'CKA_IBM_PROTKEY_EXTRACTABLE: CK_FALSE') == "1" ]]; then
 echo "* TESTCASE list-key des PASS Listed random des public keys CK_BBOOL attribute"
 else
 echo "* TESTCASE list-key des FAIL Failed to list des public keys CK_BBOOL attribute"
 fi
 # CK_ULONG
-if [[ $(grep -A 19 'p11sak-des' $P11SAK_DES_LONG | grep -c 'CKA_MODULUS_BITS:') == "0" ]]; then
+if [[ $(grep -A 20 'p11sak-des' $P11SAK_DES_LONG | grep -c 'CKA_MODULUS_BITS:') == "0" ]]; then
 echo "* TESTCASE list-key des PASS Listed random des public keys CK_ULONG attribute"
 else
 echo "* TESTCASE list-key des FAIL Failed to list des public keys CK_ULONG attribute"
 fi
 # CK_BYTE
-if [[ $(grep -A 19 'p11sak-des' $P11SAK_DES_LONG | grep -c 'CKA_MODULUS:') == "0" ]]; then
+if [[ $(grep -A 20 'p11sak-des' $P11SAK_DES_LONG | grep -c 'CKA_MODULUS:') == "0" ]]; then
 echo "* TESTCASE list-key des PASS Listed random des public keys CK_BYTE attribute"
 else
 echo "* TESTCASE list-key des FAIL Failed to list des public keys CK_BYTE attribute"
@@ -185,19 +185,19 @@ fi
 
 
 # CK_BBOOL
-if [[ $(grep -A 19 'p11sak-3des' $P11SAK_3DES_LONG | grep -c 'CKA_IBM_PROTKEY_EXTRACTABLE: CK_FALSE') == "1" ]]; then
+if [[ $(grep -A 20 'p11sak-3des' $P11SAK_3DES_LONG | grep -c 'CKA_IBM_PROTKEY_EXTRACTABLE: CK_FALSE') == "1" ]]; then
 echo "* TESTCASE list-key 3des PASS Listed random 3des public keys CK_BBOOL attribute"
 else
 echo "* TESTCASE list-key 3des FAIL Failed to list 3des public keys CK_BBOOL attribute"
 fi
 # CK_ULONG
-if [[ $(grep -A 19 'p11sak-3des' $P11SAK_3DES_LONG | grep -c 'CKA_MODULUS_BITS:') == "0" ]]; then
+if [[ $(grep -A 20 'p11sak-3des' $P11SAK_3DES_LONG | grep -c 'CKA_MODULUS_BITS:') == "0" ]]; then
 echo "* TESTCASE list-key 3des PASS Listed random 3des public keys CK_ULONG attribute"
 else
 echo "* TESTCASE list-key 3des FAIL Failed to list 3des public keys CK_ULONG attribute"
 fi
 # CK_BYTE
-if [[ $(grep -A 19 'p11sak-3des' $P11SAK_3DES_LONG | grep -c 'CKA_MODULUS:') == "0" ]]; then
+if [[ $(grep -A 20 'p11sak-3des' $P11SAK_3DES_LONG | grep -c 'CKA_MODULUS:') == "0" ]]; then
 echo "* TESTCASE list-key 3des PASS Listed random 3des public keys CK_BYTE attribute"
 else
 echo "* TESTCASE list-key 3des FAIL Failed to list 3des public keys CK_BYTE attribute"
@@ -256,19 +256,19 @@ fi
 
 
 # CK_BBOOL
-if [[ $(grep -A 57 'p11sak-aes-128' $P11SAK_AES_LONG | grep -c 'CKA_IBM_PROTKEY_EXTRACTABLE: CK_FALSE') == "3" ]]; then
+if [[ $(grep -A 60 'p11sak-aes-128' $P11SAK_AES_LONG | grep -c 'CKA_IBM_PROTKEY_EXTRACTABLE: CK_FALSE') == "3" ]]; then
 echo "* TESTCASE list-key aes PASS Listed random aes public keys CK_BBOOL attribute"
 else
 echo "* TESTCASE list-key aes FAIL Failed to list aes public keys CK_BBOOL attribute"
 fi
 # CK_ULONG
-if [[ $(grep -A 57 'p11sak-aes-128' $P11SAK_AES_LONG | grep -c 'CKA_MODULUS_BITS:') == "0" ]]; then
+if [[ $(grep -A 60 'p11sak-aes-128' $P11SAK_AES_LONG | grep -c 'CKA_MODULUS_BITS:') == "0" ]]; then
 echo "* TESTCASE list-key aes PASS Listed random aes public keys CK_ULONG attribute"
 else
 echo "* TESTCASE list-key aes FAIL Failed to list aes public keys CK_ULONG attribute"
 fi
 # CK_BYTE
-if [[ $(grep -A 57 'p11sak-aes-128' $P11SAK_AES_LONG | grep -c 'CKA_MODULUS:') == "0" ]]; then
+if [[ $(grep -A 60 'p11sak-aes-128' $P11SAK_AES_LONG | grep -c 'CKA_MODULUS:') == "0" ]]; then
 echo "* TESTCASE list-key aes PASS Listed random aes public keys CK_BYTE attribute"
 else
 echo "* TESTCASE list-key aes FAIL Failed to list aes public keys CK_BYTE attribute"
@@ -378,19 +378,19 @@ fi
 
 
 # CK_BBOOL
-if [[ $(grep -A 205 'p11sak-rsa-1024:pub' $P11SAK_RSA_LONG | grep -c 'CKA_IBM_PROTKEY_EXTRACTABLE: CK_FALSE') == "6" ]]; then
+if [[ $(grep -A 211 'p11sak-rsa-1024:pub' $P11SAK_RSA_LONG | grep -c 'CKA_IBM_PROTKEY_EXTRACTABLE: CK_FALSE') == "6" ]]; then
 echo "* TESTCASE list-key rsa PASS Listed random rsa public keys CK_BBOOL attribute"
 else
 echo "* TESTCASE list-key rsa FAIL Failed to list rsa public keys CK_BBOOL attribute"
 fi
 # CK_ULONG
-if [[ $(grep -A 205 'p11sak-rsa-1024:pub' $P11SAK_RSA_LONG | grep -c 'CKA_MODULUS_BITS:') == "3" ]]; then
+if [[ $(grep -A 211 'p11sak-rsa-1024:pub' $P11SAK_RSA_LONG | grep -c 'CKA_MODULUS_BITS:') == "3" ]]; then
 echo "* TESTCASE list-key rsa PASS Listed random rsa public keys CK_ULONG attribute"
 else
 echo "* TESTCASE list-key rsa FAIL Failed to list rsa public keys CK_ULONG attribute"
 fi
 # CK_BYTE
-if [[ $(grep -A 205 'p11sak-rsa-1024:pub' $P11SAK_RSA_LONG | grep -c 'CKA_MODULUS:') == "6" ]]; then
+if [[ $(grep -A 211 'p11sak-rsa-1024:pub' $P11SAK_RSA_LONG | grep -c 'CKA_MODULUS:') == "6" ]]; then
 echo "* TESTCASE list-key rsa PASS Listed random rsa public keys CK_BYTE attribute"
 else
 echo "* TESTCASE list-key rsa FAIL Failed to list rsa public keys CK_BYTE attribute"
@@ -500,19 +500,19 @@ fi
 
 
 # CK_BBOOL
-if [[ $(grep -A 84 'p11sak-ec-prime256v1:pub' $P11SAK_EC_LONG | grep -c 'CKA_IBM_PROTKEY_EXTRACTABLE: CK_FALSE') == "6" ]]; then
+if [[ $(grep -A 90 'p11sak-ec-prime256v1:pub' $P11SAK_EC_LONG | grep -c 'CKA_IBM_PROTKEY_EXTRACTABLE: CK_FALSE') == "6" ]]; then
 echo "* TESTCASE list-key ec PASS Listed random ec public keys CK_BBOOL attribute"
 else
 echo "* TESTCASE list-key ec FAIL Failed to list ec public keys CK_BBOOL attribute"
 fi
 # CK_ULONG
-if [[ $(grep -A 84 'p11sak-ec-prime256v1:pub' $P11SAK_EC_LONG | grep -c 'CKA_MODULUS_BITS:') == "0" ]]; then
+if [[ $(grep -A 90 'p11sak-ec-prime256v1:pub' $P11SAK_EC_LONG | grep -c 'CKA_MODULUS_BITS:') == "0" ]]; then
 echo "* TESTCASE list-key ec PASS Listed random ec public keys CK_ULONG attribute"
 else
 echo "* TESTCASE list-key ec FAIL Failed to list ec public keys CK_ULONG attribute"
 fi
 # CK_BYTE
-if [[ $(grep -A 84 'p11sak-ec-prime256v1:pub' $P11SAK_EC_LONG | grep -c 'CKA_MODULUS:') == "0" ]]; then
+if [[ $(grep -A 90 'p11sak-ec-prime256v1:pub' $P11SAK_EC_LONG | grep -c 'CKA_MODULUS:') == "0" ]]; then
 echo "* TESTCASE list-key ec PASS Listed random ec public keys CK_BYTE attribute"
 else
 echo "* TESTCASE list-key ec FAIL Failed to list ec public keys CK_BYTE attribute"

--- a/testcases/misc_tests/p11sak_test.sh
+++ b/testcases/misc_tests/p11sak_test.sh
@@ -165,6 +165,12 @@ echo "* TESTCASE list-key des PASS Listed random des public keys CK_BYTE attribu
 else
 echo "* TESTCASE list-key des FAIL Failed to list des public keys CK_BYTE attribute"
 fi
+# URI
+if [[ $(grep -A 20 'p11sak-des' $P11SAK_DES_LONG | grep -c 'URI: pkcs11:.*type=secret-key') == "1" ]]; then
+echo "* TESTCASE list-key des PASS list des key pkcs#11 URI"
+else
+echo "* TESTCASE list-key des FAIL list des key pkcs#11 URI"
+fi
 
 
 # check 3DES
@@ -201,6 +207,12 @@ if [[ $(grep -A 20 'p11sak-3des' $P11SAK_3DES_LONG | grep -c 'CKA_MODULUS:') == 
 echo "* TESTCASE list-key 3des PASS Listed random 3des public keys CK_BYTE attribute"
 else
 echo "* TESTCASE list-key 3des FAIL Failed to list 3des public keys CK_BYTE attribute"
+fi
+# URI
+if [[ $(grep -A 20 'p11sak-3des' $P11SAK_3DES_LONG | grep -c 'URI: pkcs11:.*type=secret-key') == "1" ]]; then
+echo "* TESTCASE list-key 3des PASS list 3des key pkcs#11 URI"
+else
+echo "* TESTCASE list-key 3des FAIL list 3des key pkcs#11 URI"
 fi
 
 
@@ -272,6 +284,12 @@ if [[ $(grep -A 60 'p11sak-aes-128' $P11SAK_AES_LONG | grep -c 'CKA_MODULUS:') =
 echo "* TESTCASE list-key aes PASS Listed random aes public keys CK_BYTE attribute"
 else
 echo "* TESTCASE list-key aes FAIL Failed to list aes public keys CK_BYTE attribute"
+fi
+# URI
+if [[ $(grep -A 60 'p11sak-aes-128' $P11SAK_AES_LONG | grep -c 'URI: pkcs11:.*type=secret-key') == "3" ]]; then
+echo "* TESTCASE list-key aes PASS list aes key pkcs#11 URI"
+else
+echo "* TESTCASE list-key aes FAIL list aes key pkcs#11 URI"
 fi
 
 
@@ -395,6 +413,12 @@ echo "* TESTCASE list-key rsa PASS Listed random rsa public keys CK_BYTE attribu
 else
 echo "* TESTCASE list-key rsa FAIL Failed to list rsa public keys CK_BYTE attribute"
 fi
+# URI
+if [[ $(grep -A 211 'p11sak-rsa-1024:pub' $P11SAK_RSA_LONG | grep -c 'URI: pkcs11:.*type=public') == "3" ]]; then
+echo "* TESTCASE list-key rsa PASS list rsa public key pkcs#11 URI"
+else
+echo "* TESTCASE list-key rsa FAIL list rsa public key pkcs#11 URI"
+fi
 
 
 # check EC prime256v1 public key
@@ -516,6 +540,12 @@ if [[ $(grep -A 90 'p11sak-ec-prime256v1:pub' $P11SAK_EC_LONG | grep -c 'CKA_MOD
 echo "* TESTCASE list-key ec PASS Listed random ec public keys CK_BYTE attribute"
 else
 echo "* TESTCASE list-key ec FAIL Failed to list ec public keys CK_BYTE attribute"
+fi
+# URI
+if [[ $(grep -A 90 'p11sak-ec-prime256v1:pub' $P11SAK_EC_LONG | grep -c 'URI: pkcs11:.*type=public') == "3" ]]; then
+echo "* TESTCASE list-key ec PASS list ec public key pkcs#11 URI"
+else
+echo "* TESTCASE list-key ec FAIL list ec public key pkcs#11 URI"
 fi
 
 

--- a/testcases/misc_tests/pkcsconf_test.sh
+++ b/testcases/misc_tests/pkcsconf_test.sh
@@ -1,0 +1,128 @@
+#!/bin/sh
+#
+# COPYRIGHT (c) International Business Machines Corp. 2022
+#
+# This program is provided under the terms of the Common Public License,
+# version 1.0 (CPL-1.0). Any use, reproduction or distribution for this software
+# constitutes recipient's acceptance of CPL-1.0 terms which can be found
+# in the file LICENSE file or at https://opensource.org/licenses/cpl1.0.php
+
+# functions
+print_test_result() {
+	local rc=$1
+	local name=$2
+	local subn=$3
+	local mesg=$4
+
+	if [ ${rc} = 0 ]; then
+		echo "* TESTCASE ${name} ${subn} PASS ${mesg}"
+	else
+		echo "* TESTCASE ${name} ${subn} FAIL ${mesg}"
+	fi
+}
+
+# create temporary directory
+TMP=$(mktemp -d)
+
+# define output files
+PKCSCONF_INFO=${TMP}/pkcsconf-info.out
+PKCSCONF_SLOT=${TMP}/pkcsconf-slot.out
+PKCSCONF_TOKEN=${TMP}/pkcsconf-token.out
+
+# list info/slots/tokens
+pkcsconf -i &> $PKCSCONF_INFO
+pkcsconf -s &> $PKCSCONF_SLOT
+pkcsconf -t &> $PKCSCONF_TOKEN
+
+# extract information elements
+INFO_LIBVERS=$(cat ${PKCSCONF_INFO} | grep -Po 'Library Version:\s+\K[0-9]+.[0-9]+')
+INFO_LIBMANU=$(cat ${PKCSCONF_INFO} | grep -Po 'Manufacturer:\s+\K\S*')
+INFO_LIBDESC=$(cat ${PKCSCONF_INFO} | grep -Po 'Library Description:\s+\K\S*')
+
+# extract information URI elements
+URI_INFO_LIBVERS=$(cat ${PKCSCONF_INFO} | grep -Po 'URI:\s*pkcs11:.*library-version=\K[^;]*')
+URI_INFO_LIBMANU=$(cat ${PKCSCONF_INFO} | grep -Po 'URI:\s*pkcs11:.*library-manufacturer=\K[^;]*')
+URI_INFO_LIBDESC=$(cat ${PKCSCONF_INFO} | grep -Po 'URI:\s*pkcs11:.*library-description=\K[^;]*')
+
+# extract slot elements (only first slot)
+SLOT_ID=$(  cat ${PKCSCONF_SLOT} | grep -Po '^Slot #\K[0-9]+'       | head -n1)
+SLOT_MANU=$(cat ${PKCSCONF_SLOT} | grep -Po 'Manufacturer:\s+\K\S*' | head -n1)
+SLOT_DESC=$(cat ${PKCSCONF_SLOT} | grep -Po 'Description:\s+\K\S*'  | head -n1)
+
+# extract slot URI elements (only first slot)
+URI_SLOT_ID=$(  cat ${PKCSCONF_SLOT} | grep -Po 'URI:\s*pkcs11:.*slot-id=\K[^;]*'           | head -n1)
+URI_SLOT_MANU=$(cat ${PKCSCONF_SLOT} | grep -Po 'URI:\s*pkcs11:.*slot-manufacturer=\K[^;]*' | head -n1)
+URI_SLOT_DESC=$(cat ${PKCSCONF_SLOT} | grep -Po 'URI:\s*pkcs11:.*slot-description=\K[^;]*'  | head -n1)
+
+# extract token elements (only first token)
+TOKEN_LABL=$(cat ${PKCSCONF_TOKEN} | grep -Po 'Label:\s+\K\S*'        | head -n1)
+TOKEN_MANU=$(cat ${PKCSCONF_TOKEN} | grep -Po 'Manufacturer:\s+\K\S*' | head -n1)
+TOKEN_MODL=$(cat ${PKCSCONF_TOKEN} | grep -Po 'Model:\s+\K\S*'        | head -n1)
+
+# extract token URI elements (only first token)
+URI_TOKEN_LABL=$(cat ${PKCSCONF_TOKEN} | grep -Po 'URI:\s*pkcs11:.*token=\K[^;]*'        | head -n1)
+URI_TOKEN_MANU=$(cat ${PKCSCONF_TOKEN} | grep -Po 'URI:\s*pkcs11:.*manufacturer=\K[^;]*' | head -n1)
+URI_TOKEN_MODL=$(cat ${PKCSCONF_TOKEN} | grep -Po 'URI:\s*pkcs11:.*model=\K[^;]*'        | head -n1)
+
+# information test cases
+test -n "${INFO_LIBVERS}" -o \
+     -n "${INFO_LIBMANU}" -o \
+     -n "${INFO_LIBDESC}"
+print_test_result $? "pkcsconf" "info" "check output for all required library fields"
+
+test -n "${URI_INFO_LIBVERS}" -o \
+     -n "${URI_INFO_LIBMANU}" -o \
+     -n "${URI_INFO_LIBDESC}"
+print_test_result $? "pkcsconf" "info" "check URI for all required library fields"
+
+test "${INFO_LIBVERS}" = "${URI_INFO_LIBVERS}"
+print_test_result $? "pkcsconf" "info" "check library version in URI"
+
+test "${INFO_LIBMANU}" = "${URI_INFO_LIBMANU}"
+print_test_result $? "pkcsconf" "info" "check library manufacturer in URI"
+
+test "${INFO_LIBDESC}" = "${URI_INFO_LIBDESC}"
+print_test_result $? "pkcsconf" "info" "check library description in URI"
+
+# slot test cases
+test -n "${SLOT_ID}"   -o \
+     -n "${SLOT_MANU}" -o \
+     -n "${SLOT_DESC}"
+print_test_result $? "pkcsconf" "slot" "check output for all required slot fields"
+
+test -n "${URI_SLOT_ID}"   -o \
+     -n "${URI_SLOT_MANU}" -o \
+     -n "${URI_SLOT_DESC}"
+print_test_result $? "pkcsconf" "slot" "check URI for all required slot fields"
+
+test "${SLOT_ID}" = "${URI_SLOT_ID}"
+print_test_result $? "pkcsconf" "slot" "check slot id in URI"
+
+test "${SLOT_MANU}" = "${URI_SLOT_MANU}"
+print_test_result $? "pkcsconf" "slot" "check slot manufacturer in URI"
+
+test "${SLOT_DESC}" = "${URI_SLOT_DESC}"
+print_test_result $? "pkcsconf" "slot" "check slot description in URI"
+
+# token test cases
+test -n "${TOKEN_LABL}"   -o \
+     -n "${TOKEN_MANU}" -o \
+     -n "${TOKEN_MODL}"
+print_test_result $? "pkcsconf" "token" "check output for all required token fields"
+
+test -n "${URI_TOKEN_LABL}"   -o \
+     -n "${URI_TOKEN_MANU}" -o \
+     -n "${URI_TOKEN_MODL}"
+print_test_result $? "pkcsconf" "token" "check URI for all required token fields"
+
+test "${TOKEN_LABL}" = "${URI_TOKEN_LABL}"
+print_test_result $? "pkcsconf" "token" "check token label in URI"
+
+test "${TOKEN_MANU}" = "${URI_TOKEN_MANU}"
+print_test_result $? "pkcsconf" "token" "check token manufacturer in URI"
+
+test "${TOKEN_MODL}" = "${URI_TOKEN_MODL}"
+print_test_result $? "pkcsconf" "token" "check token model in URI"
+
+# remove tmp
+rm -rf ${TMP} &> /dev/null

--- a/testcases/unit/buffertest.c
+++ b/testcases/unit/buffertest.c
@@ -1,0 +1,123 @@
+/*
+ * COPYRIGHT (c) International Business Machines Corp. 2022
+ *
+ * This program is provided under the terms of the Common Public License,
+ * version 1.0 (CPL-1.0). Any use, reproduction or distribution for this
+ * software constitutes recipient's acceptance of CPL-1.0 terms which can be
+ * found in the file LICENSE file or at
+ * https://opensource.org/licenses/cpl1.0.php
+ */
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <buffer.h>
+#include "unittest.h"
+
+#define STDERR_RC_UNEXP(n, func, rc, exp_rc)                    \
+    fprintf(stderr, "[%d] %s: %s (curr: %ld, expected: %ld)\n", \
+            n, func, "unexpected return value", rc, exp_rc)
+
+static char *short_string = "abc";
+static char *long_string  = "abcdefghijklmnopqrstuvwxyz"
+                            "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                            "abcdefghijklmnopqrstuvwxyz"
+                            "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                            "abcdefghijklmnopqrstuvwxyz"
+                            "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                            "abcdefghijklmnopqrstuvwxyz"
+                            "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                            "abcdefghijklmnopqrstuvwxyz"
+                            "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                            "abcdefghijklmnopqrstuvwxyz"
+                            "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+static int test_buffer_api(char *s)
+{
+    int result = 0;
+    long rc, exp_rc;
+    size_t s_len = strlen(s);
+    p11_buffer_t *buf = p11_buffer_new();
+
+    /* check for buffer length and size */
+    if ((*p11_buffer_char(buf)        != '\0') ||
+        (p11_buffer_char(buf)         == NULL) ||
+        (p11_buffer_size(buf)         == 0)    ||
+        (strlen(p11_buffer_char(buf)) != 0)) {
+        fprintf(stderr, "[%d] %s: %s\n",
+                0, "p11_buffer_new()",
+                "wrong initial buffer values");
+        result++;
+    }
+
+    /* check corner case s == NULL */
+    exp_rc = strlen(p11_buffer_char(buf));
+    rc = p11_buffer_append(buf, NULL);
+    if (rc != exp_rc) {
+        STDERR_RC_UNEXP(1, "p11_buffer_append()", rc, exp_rc);
+        result++;
+    }
+
+    /* check corner case s == NULL, len == 0 */
+    exp_rc = strlen(p11_buffer_char(buf));
+    rc = p11_buffer_append_len(buf, NULL, 0);
+    if (rc != exp_rc) {
+        STDERR_RC_UNEXP(2, "p11_buffer_append_len()", rc, exp_rc);
+        result++;
+    }
+
+    /* check corner case len == 0 */
+    exp_rc = strlen(p11_buffer_char(buf));
+    rc = p11_buffer_append_len(buf, s, 0);
+    if (rc != exp_rc) {
+        STDERR_RC_UNEXP(3, "p11_buffer_append_len()", rc, exp_rc);
+        result++;
+    }
+
+    /* normal append */
+    exp_rc = strlen(p11_buffer_char(buf)) + s_len;
+    rc = p11_buffer_append(buf, s);
+    if (rc != exp_rc) {
+        STDERR_RC_UNEXP(4, "p11_buffer_append()", rc, exp_rc);
+        result++;
+    }
+
+    /* normal append with length */
+    exp_rc = strlen(p11_buffer_char(buf)) + s_len;
+    rc = p11_buffer_append_len(buf, s, s_len);
+    if (rc != exp_rc) {
+        STDERR_RC_UNEXP(5, "p11_buffer_append()", rc, exp_rc);
+        result++;
+    }
+
+    /* normal append with printf */
+    exp_rc = strlen(p11_buffer_char(buf)) + 14 + s_len;
+    rc = p11_buffer_append_printf(buf, "append_prinf(%s)", s);
+    if (rc != exp_rc) {
+        STDERR_RC_UNEXP(6, "p11_buffer_append()", rc, exp_rc);
+        result++;
+    }
+
+    /* reset buffer */
+    p11_buffer_reset(buf);
+    if ((*p11_buffer_char(buf)        != '\0') ||
+        (strlen(p11_buffer_char(buf)) != 0)) {
+        fprintf(stderr, "[%d] %s: %s\n",
+                7, "p11_buffer_reset()",
+                "wrong buffer values after reset");
+        result++;
+    }
+
+    p11_buffer_free(buf);
+    return result;
+}
+
+int main(void)
+{
+    if (test_buffer_api(short_string))
+        return TEST_FAIL;
+    if (test_buffer_api(long_string))
+        return TEST_FAIL;
+
+    return TEST_PASS;
+}

--- a/testcases/unit/unit.mk
+++ b/testcases/unit/unit.mk
@@ -1,8 +1,10 @@
 check_PROGRAMS = testcases/unit/policytest testcases/unit/hashmaptest	\
-	testcases/unit/mechtabletest testcases/unit/configdump
+	testcases/unit/mechtabletest testcases/unit/configdump		\
+	testcases/unit/buffertest testcases/unit/uritest
 
 TESTS = testcases/unit/policytest testcases/unit/hashmaptest		\
-	testcases/unit/mechtabletest testcases/unit/configdump
+	testcases/unit/mechtabletest testcases/unit/configdump		\
+	testcases/unit/buffertest testcases/unit/uritest
 
 testcases_unit_policytest_CFLAGS=-I${top_srcdir}/usr/lib/common		\
 	-I${top_srcdir}/usr/lib/api -I${top_srcdir}/usr/include		\
@@ -42,3 +44,15 @@ testcases_unit_configdump_SOURCES = testcases/unit/configdump.c	\
 
 testcases_unit_configdump_CFLAGS=-I${top_srcdir}/usr/lib/config	\
 	-I${top_builddir}/usr/lib/config
+
+testcases_unit_buffertest_SOURCES=testcases/unit/buffertest.c	\
+	usr/lib/common/buffer.c
+
+testcases_unit_buffertest_CFLAGS=-I${top_srcdir}/usr/lib/common
+
+testcases_unit_uritest_SOURCES=testcases/unit/uritest.c		\
+	usr/lib/common/uri.c usr/lib/common/buffer.c		\
+	usr/lib/common/p11util.c
+
+testcases_unit_uritest_CFLAGS=-I${top_srcdir}/usr/lib/common	\
+	-I${top_srcdir}/usr/include -I${top_builddir}/usr/lib/api

--- a/testcases/unit/uritest.c
+++ b/testcases/unit/uritest.c
@@ -1,0 +1,421 @@
+/*
+ * COPYRIGHT (c) International Business Machines Corp. 2022
+ *
+ * This program is provided under the terms of the Common Public License,
+ * version 1.0 (CPL-1.0). Any use, reproduction or distribution for this
+ * software constitutes recipient's acceptance of CPL-1.0 terms which can be
+ * found in the file LICENSE file or at
+ * https://opensource.org/licenses/cpl1.0.php
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <uri.h>
+#include "unittest.h"
+
+#define BUFLEN         128
+
+#define MIN(a, b)      (a < b) ? (a) : (b)
+#define BINIT(s, e)    memset(s.e, ' ', sizeof(s.e))
+#define SCPY(s, e, c)  _cpy(s.e, sizeof(s.e), c)
+
+static CK_INFO i;
+static CK_SLOT_INFO s;
+static CK_TOKEN_INFO t;
+
+static CK_OBJECT_CLASS cko_data = CKO_DATA;
+static CK_OBJECT_CLASS cko_pubk = CKO_PUBLIC_KEY;
+static CK_OBJECT_CLASS cko_cert = CKO_CERTIFICATE;
+static CK_OBJECT_CLASS cko_prvk = CKO_PRIVATE_KEY;
+static CK_OBJECT_CLASS cko_seck = CKO_SECRET_KEY;
+
+static CK_CHAR ckc_id_buf[BUFLEN];
+static CK_CHAR ckc_label_buf[BUFLEN];
+
+static void _cpy(unsigned char *dest, size_t d_len, char *src)
+{
+    size_t s_len;
+
+    if (!src)
+        return;
+
+    s_len = strlen(src);
+    memcpy(dest, src, MIN(s_len, d_len));
+}
+
+static void _gen_uri(struct p11_uri *uri,
+                     char *i_dsc, char *i_man, int i_vmj, int i_vmi,
+                     int s_id, char *s_dsc, char *s_man,
+                     char *t_lbl, char *t_man, char *t_mod, char *t_ser,
+                     char *o_id, char *o_lbl, CK_OBJECT_CLASS_PTR o_type)
+{
+    /* initialize string fields */
+    BINIT(i, manufacturerID);
+    BINIT(i, libraryDescription);
+
+    BINIT(s, manufacturerID);
+    BINIT(s, slotDescription);
+
+    BINIT(t, label);
+    BINIT(t, manufacturerID);
+    BINIT(t, model);
+    BINIT(t, serialNumber);
+
+    /* initialize attribute templates */
+    memset(ckc_id_buf,    '\0', BUFLEN);
+    memset(ckc_label_buf, '\0', BUFLEN);
+
+    /* info */
+    SCPY(i, manufacturerID,     i_man);
+    SCPY(i, libraryDescription, i_dsc);
+    i.libraryVersion.major = i_vmj;
+    i.libraryVersion.minor = i_vmi;
+
+    /* slot */
+    uri->slot_id = -1;
+    if (s_id >= 0)
+        uri->slot_id = s_id;
+    SCPY(s, manufacturerID,  s_man);
+    SCPY(s, slotDescription, s_dsc);
+
+    /* token */
+    SCPY(t, label,          t_lbl);
+    SCPY(t, manufacturerID, t_man);
+    SCPY(t, model,          t_mod);
+    SCPY(t, serialNumber,   t_ser);
+
+    uri->info = NULL;
+    if (i_man || i_dsc)
+        uri->info = &i;
+
+    uri->slot_info = NULL;
+    if (s_man || s_dsc)
+        uri->slot_info = &s;
+
+    uri->token_info = NULL;
+    if (t_lbl || t_man || t_mod || t_ser)
+        uri->token_info = &t;
+
+    if (o_type) {
+        uri->obj_class[0].type = CKA_CLASS;
+        uri->obj_class[0].pValue = o_type;
+        uri->obj_class[0].ulValueLen = sizeof(CK_OBJECT_CLASS);
+    }
+    if (o_id) {
+        memcpy(ckc_id_buf, o_id, strlen(o_id));
+        uri->obj_id[0].type = CKA_ID;
+        uri->obj_id[0].pValue = ckc_id_buf;
+        uri->obj_id[0].ulValueLen = strlen(o_id);
+    }
+    if (o_lbl) {
+        memcpy(ckc_label_buf, o_lbl, strlen(o_lbl));
+        uri->obj_label[0].type = CKA_LABEL;
+        uri->obj_label[0].pValue = ckc_label_buf;
+        uri->obj_label[0].ulValueLen = strlen(o_lbl);
+    }
+}
+
+static void _alloc_attr(CK_ATTRIBUTE_PTR attr)
+{
+    attr->pValue = malloc(8);
+    if (!attr->pValue)
+        return;
+    attr->ulValueLen = 8;
+}
+
+static void _alloc_attrs(struct p11_uri *uri)
+{
+    _alloc_attr(&uri->obj_id[0]);
+    _alloc_attr(&uri->obj_label[0]);
+    _alloc_attr(&uri->obj_class[0]);
+}
+
+static int test_uri_base(void)
+{
+    int result = 0;
+    struct p11_uri *uri;
+
+    uri = p11_uri_new();
+    if (!uri)
+        return 1;
+    if ((uri == NULL) ||
+        (uri->priv == NULL)) {
+        fprintf(stderr, "[%d] %s: %s\n",
+                0, "p11_uri_new()",
+                "wrong initial uri values");
+        result++;
+    }
+    p11_uri_free(uri);
+
+    uri = p11_uri_new();
+    if (!uri)
+        return 1;
+    _alloc_attrs(uri);
+    p11_uri_attributes_free(uri);
+    if ((uri->obj_id[0].pValue)    || (uri->obj_id[0].ulValueLen)    ||
+        (uri->obj_label[0].pValue) || (uri->obj_label[0].ulValueLen) ||
+        (uri->obj_class[0].pValue) || (uri->obj_class[0].ulValueLen)) {
+        fprintf(stderr, "[%d] %s: %s\n",
+                1, "p11_uri_attributes_free()",
+                "wrong uri attribute values after free");
+        result++;
+    }
+    p11_uri_free(uri);
+
+    return result;
+}
+
+static int test_uri_format()
+{
+    int result = 0;
+    const char *cur_uri, *exp_uri;
+    struct p11_uri *uri;
+
+    uri = p11_uri_new();
+    if (!uri)
+        return 1;
+    exp_uri = "pkcs11:library-description=testLib;library-manufacturer=ACME;library-version=47.11";
+    _gen_uri(uri,
+             "testLib", "ACME", 47, 11,
+             -1, NULL, NULL,
+             NULL, NULL, NULL, NULL,
+             NULL, NULL, NULL);
+    cur_uri = p11_uri_format(uri);
+    if (strcmp(cur_uri, exp_uri) != 0) {
+        fprintf(stderr,"[%d] p11_uri_format(): curr: %s, expected: %s\n",
+                0, cur_uri, exp_uri);
+        result++;
+    }
+    p11_uri_free(uri);
+
+    uri = p11_uri_new();
+    if (!uri)
+        return 1;
+    exp_uri = "pkcs11:slot-id=0;slot-description=testslot;slot-manufacturer=ACME";
+    _gen_uri(uri,
+             NULL, NULL, -1, -1,
+             0, "testslot", "ACME",
+             NULL, NULL, NULL, NULL,
+             NULL, NULL, NULL);
+    cur_uri = p11_uri_format(uri);
+    if (strcmp(cur_uri, exp_uri) != 0) {
+        fprintf(stderr,"[%d] p11_uri_format(): curr: %s, expected: %s\n",
+                1, cur_uri, exp_uri);
+        result++;
+    }
+    p11_uri_free(uri);
+
+    uri = p11_uri_new();
+    if (!uri)
+        return 1;
+    exp_uri = "pkcs11:manufacturer=ACME;model=TestModel;serial=0123456789;token=testtok";
+    _gen_uri(uri,
+             NULL, NULL, -1, -1,
+             -1, NULL, NULL,
+             "testtok", "ACME", "TestModel", "0123456789",
+             NULL, NULL, NULL);
+    cur_uri = p11_uri_format(uri);
+    if (strcmp(cur_uri, exp_uri) != 0) {
+        fprintf(stderr,"[%d] p11_uri_format(): curr: %s, expected: %s\n",
+                2, cur_uri, exp_uri);
+        result++;
+    }
+    p11_uri_free(uri);
+
+    uri = p11_uri_new();
+    if (!uri)
+        return 1;
+    exp_uri = "pkcs11:id=%30%31%32%33%34%35%36%37%38%39%61%62%63;object=testo_data;type=data";
+    _gen_uri(uri,
+             NULL, NULL, -1, -1,
+             -1, NULL, NULL,
+             NULL, NULL, NULL, NULL,
+             "0123456789abc", "testo_data", &cko_data);
+    cur_uri = p11_uri_format(uri);
+    if (strcmp(cur_uri, exp_uri) != 0) {
+        fprintf(stderr,"[%d] p11_uri_format(): curr: %s, expected: %s\n",
+                3, cur_uri, exp_uri);
+        result++;
+    }
+    p11_uri_free(uri);
+
+    uri = p11_uri_new();
+    if (!uri)
+        return 1;
+    exp_uri = "pkcs11:id=%30%31%32%33%34%35%36%37%38%39%61%62%63;object=testo_privk;type=private";
+    _gen_uri(uri,
+             NULL, NULL, -1, -1,
+             -1, NULL, NULL,
+             NULL, NULL, NULL, NULL,
+             "0123456789abc", "testo_privk", &cko_prvk);
+    cur_uri = p11_uri_format(uri);
+    if (strcmp(cur_uri, exp_uri) != 0) {
+        fprintf(stderr,"[%d] p11_uri_format(): curr: %s, expected: %s\n",
+                4, cur_uri, exp_uri);
+        result++;
+    }
+    p11_uri_free(uri);
+
+    uri = p11_uri_new();
+    if (!uri)
+        return 1;
+    exp_uri = "pkcs11:id=%30%31%32%33%34%35%36%37%38%39%61%62%63;object=testo_pubk;type=public";
+    _gen_uri(uri,
+             NULL, NULL, -1, -1,
+             -1, NULL, NULL,
+             NULL, NULL, NULL, NULL,
+             "0123456789abc", "testo_pubk", &cko_pubk);
+    cur_uri = p11_uri_format(uri);
+    if (strcmp(cur_uri, exp_uri) != 0) {
+        fprintf(stderr,"[%d] p11_uri_format(): curr: %s, expected: %s\n",
+                5, cur_uri, exp_uri);
+        result++;
+    }
+    p11_uri_free(uri);
+
+    uri = p11_uri_new();
+    if (!uri)
+        return 1;
+    exp_uri = "pkcs11:id=%30%31%32%33%34%35%36%37%38%39%61%62%63;object=testo_seck;type=secret-key";
+    _gen_uri(uri,
+             NULL, NULL, -1, -1,
+             -1, NULL, NULL,
+             NULL, NULL, NULL, NULL,
+             "0123456789abc", "testo_seck", &cko_seck);
+    cur_uri = p11_uri_format(uri);
+    if (strcmp(cur_uri, exp_uri) != 0) {
+        fprintf(stderr,"[%d] p11_uri_format(): curr: %s, expected: %s\n",
+                6, cur_uri, exp_uri);
+        result++;
+    }
+    p11_uri_free(uri);
+
+    uri = p11_uri_new();
+    if (!uri)
+        return 1;
+    exp_uri = "pkcs11:id=%30%31%32%33%34%35%36%37%38%39%61%62%63;object=testo_cert;type=cert";
+    _gen_uri(uri,
+             NULL, NULL, -1, -1,
+             -1, NULL, NULL,
+             NULL, NULL, NULL, NULL,
+             "0123456789abc", "testo_cert", &cko_cert);
+    cur_uri = p11_uri_format(uri);
+    if (strcmp(cur_uri, exp_uri) != 0) {
+        fprintf(stderr,"[%d] p11_uri_format(): curr: %s, expected: %s\n",
+                7, cur_uri, exp_uri);
+        result++;
+    }
+    p11_uri_free(uri);
+
+    uri = p11_uri_new();
+    if (!uri)
+        return 1;
+    exp_uri = "pkcs11:";
+    _gen_uri(uri,
+             NULL, NULL, -1, -1,
+             -1, NULL, NULL,
+             NULL, NULL, NULL, NULL,
+             NULL, NULL, NULL);
+    cur_uri = p11_uri_format(uri);
+    if (strcmp(cur_uri, exp_uri) != 0) {
+        fprintf(stderr,"[%d] p11_uri_format(): curr: %s, expected: %s\n",
+                8, cur_uri, exp_uri);
+        result++;
+    }
+    p11_uri_free(uri);
+
+    return result;
+}
+
+static int test_uri_encode()
+{
+    int result = 0;
+    const char *cur_uri, *exp_uri;
+    struct p11_uri *uri;
+
+    /* common non-encode characters */
+    uri = p11_uri_new();
+    if (!uri)
+        return 1;
+    exp_uri = "pkcs11:library-description=abcdefghijklmnopqrstuvwxyz;library-manufacturer=ACME;library-version=47.11";
+    _gen_uri(uri,
+             "abcdefghijklmnopqrstuvwxyz", "ACME", 47, 11,
+             -1, NULL, NULL,
+             NULL, NULL, NULL, NULL,
+             NULL, NULL, NULL);
+    cur_uri = p11_uri_format(uri);
+    if (strcmp(cur_uri, exp_uri) != 0) {
+        fprintf(stderr,"[%d] p11_uri_format(): curr: %s, expected: %s\n",
+                0, cur_uri, exp_uri);
+        result++;
+    }
+    p11_uri_free(uri);
+
+    uri = p11_uri_new();
+    if (!uri)
+        return 1;
+    exp_uri = "pkcs11:library-description=ABCDEFGHIJKLMNOPQRSTUVWXYZ;library-manufacturer=ACME;library-version=47.11";
+    _gen_uri(uri,
+             "ABCDEFGHIJKLMNOPQRSTUVWXYZ", "ACME", 47, 11,
+             -1, NULL, NULL,
+             NULL, NULL, NULL, NULL,
+             NULL, NULL, NULL);
+    cur_uri = p11_uri_format(uri);
+    if (strcmp(cur_uri, exp_uri) != 0) {
+        fprintf(stderr,"[%d] p11_uri_format(): curr: %s, expected: %s\n",
+                1, cur_uri, exp_uri);
+        result++;
+    }
+    p11_uri_free(uri);
+
+    uri = p11_uri_new();
+    if (!uri)
+        return 1;
+    exp_uri = "pkcs11:library-description=0123456789_-.;library-manufacturer=ACME;library-version=47.11";
+    _gen_uri(uri,
+             "0123456789_-.", "ACME", 47, 11,
+             -1, NULL, NULL,
+             NULL, NULL, NULL, NULL,
+             NULL, NULL, NULL);
+    cur_uri = p11_uri_format(uri);
+    if (strcmp(cur_uri, exp_uri) != 0) {
+        fprintf(stderr,"[%d] p11_uri_format(): curr: %s, expected: %s\n",
+                2, cur_uri, exp_uri);
+        result++;
+    }
+    p11_uri_free(uri);
+
+    /* reserved non-encode characters */
+    uri = p11_uri_new();
+    if (!uri)
+        return 1;
+    exp_uri = "pkcs11:library-description=:[]@!$\'()*+,=;library-manufacturer=ACME;library-version=47.11";
+    _gen_uri(uri,
+             ":[]@!$\'()*+,=", "ACME", 47, 11,
+             -1, NULL, NULL,
+             NULL, NULL, NULL, NULL,
+             NULL, NULL, NULL);
+    cur_uri = p11_uri_format(uri);
+    if (strcmp(cur_uri, exp_uri) != 0) {
+        fprintf(stderr,"[%d] p11_uri_format(): curr: %s, expected: %s\n",
+                3, cur_uri, exp_uri);
+        result++;
+    }
+    p11_uri_free(uri);
+
+    return result;
+}
+
+int main(void)
+{
+    if (test_uri_base())
+        return TEST_FAIL;
+    if (test_uri_format())
+        return TEST_FAIL;
+    if (test_uri_encode())
+        return TEST_FAIL;
+
+    return TEST_PASS;
+}

--- a/usr/lib/common/buffer.c
+++ b/usr/lib/common/buffer.c
@@ -1,0 +1,128 @@
+/*
+ * COPYRIGHT (c) International Business Machines Corp. 2022
+ *
+ * This program is provided under the terms of the Common Public License,
+ * version 1.0 (CPL-1.0). Any use, reproduction or distribution for this
+ * software constitutes recipient's acceptance of CPL-1.0 terms which can be
+ * found in the file LICENSE file or at
+ * https://opensource.org/licenses/cpl1.0.php
+ */
+#define _GNU_SOURCE
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <buffer.h>
+
+#define BUFFER_INIT_SIZE	(128ul)
+
+struct _buffer {
+    size_t b_size;
+    char *b;
+};
+
+p11_buffer_t *p11_buffer_new(void)
+{
+    p11_buffer_t *ret = malloc(sizeof(p11_buffer_t));
+    if (ret == NULL)
+        goto err;
+
+    ret->b_size = BUFFER_INIT_SIZE;
+    ret->b = calloc(BUFFER_INIT_SIZE, sizeof(char));
+
+    if (ret->b == NULL)
+        goto err_free;
+
+    return ret;
+
+err_free:
+    free(ret);
+err:
+    return NULL;
+}
+
+void p11_buffer_free(p11_buffer_t *buf)
+{
+    free(buf->b);
+    free(buf);
+}
+
+void p11_buffer_reset(p11_buffer_t *buf)
+{
+    memset(buf->b, 0, buf->b_size);
+}
+
+const char *p11_buffer_char(const p11_buffer_t *buf)
+{
+    return (const char *) buf->b;
+}
+
+size_t p11_buffer_size(const p11_buffer_t *buf)
+{
+    return buf->b_size;
+}
+
+long p11_buffer_append_len(p11_buffer_t *buf, const char *s, size_t len)
+{
+    size_t new_len = strlen(buf->b) + len;
+    char *b_end;
+
+    if (!s || (len == 0))
+        return strlen(buf->b);
+
+    /* extend buffer if required */
+    if ((new_len + 1) > buf->b_size) {
+        size_t new_b_size =
+            (((new_len + 1) / BUFFER_INIT_SIZE) + 1) * BUFFER_INIT_SIZE;
+        char *new_b = realloc(buf->b, new_b_size);
+
+        /* ENOMEM */
+        if (new_b == NULL)
+            return -1;
+
+        buf->b = new_b;
+        buf->b_size = new_b_size;
+    }
+
+    /*
+     * workaround: the obvious way to concatenate buf->b and s with
+     * strncat(buf->b, s, len) is insecure, therefore do it manually.
+     */
+
+    /* copy len bytes to the end of buf->b */
+    b_end = buf->b + strnlen(buf->b, buf->b_size);
+    memcpy(b_end, s, len);
+
+    /* terminate with \0 */
+    b_end += len;
+    *b_end = '\0';
+
+    return new_len;
+}
+
+long p11_buffer_append(p11_buffer_t *buf, const char *s)
+{
+    if (!s)
+        return strlen(buf->b);
+    return p11_buffer_append_len(buf, s, strlen(s));
+}
+
+long p11_buffer_append_printf(p11_buffer_t *buf, const char *fmt, ...)
+{
+    va_list ap;
+    int len, rc = 0;
+    char *tmp = NULL;
+
+    va_start(ap, fmt);
+    len = vasprintf(&tmp, fmt, ap);
+    va_end(ap);
+
+    if (len < 0)
+        goto err;
+
+    rc = p11_buffer_append_len(buf, tmp, len);
+err:
+    free(tmp);
+    return rc;
+}

--- a/usr/lib/common/buffer.h
+++ b/usr/lib/common/buffer.h
@@ -1,0 +1,29 @@
+/*
+ * COPYRIGHT (c) International Business Machines Corp. 2022
+ *
+ * This program is provided under the terms of the Common Public License,
+ * version 1.0 (CPL-1.0). Any use, reproduction or distribution for this
+ * software constitutes recipient's acceptance of CPL-1.0 terms which can be
+ * found in the file LICENSE file or at
+ * https://opensource.org/licenses/cpl1.0.php
+ */
+
+#ifndef __BUFFER_H
+#define __BUFFER_H
+
+#include <stddef.h>
+
+typedef struct _buffer p11_buffer_t;
+
+p11_buffer_t *p11_buffer_new(void);
+void p11_buffer_free(p11_buffer_t *buf);
+void p11_buffer_reset(p11_buffer_t *buf);
+
+const char *p11_buffer_char(const p11_buffer_t *buf);
+size_t p11_buffer_size(const p11_buffer_t *buf);
+
+long p11_buffer_append_len(p11_buffer_t *buf, const char *s, size_t len);
+long p11_buffer_append(p11_buffer_t *buf, const char *s);
+long p11_buffer_append_printf(p11_buffer_t *buf, const char *fmt, ...);
+
+#endif                          /* __BUFFER_H */

--- a/usr/lib/common/common.mk
+++ b/usr/lib/common/common.mk
@@ -6,4 +6,5 @@ noinst_HEADERS +=							\
 	usr/lib/common/sw_crypt.h usr/lib/common/defs.h			\
 	usr/lib/common/p11util.h usr/lib/common/event_client.h		\
 	usr/lib/common/list.h usr/lib/common/tok_specific.h		\
+	usr/lib/common/uri_enc.h usr/lib/common/uri.h 			\
 	usr/lib/common/buffer.h

--- a/usr/lib/common/common.mk
+++ b/usr/lib/common/common.mk
@@ -5,4 +5,5 @@ noinst_HEADERS +=							\
 	usr/lib/common/trace.h usr/lib/common/h_extern.h		\
 	usr/lib/common/sw_crypt.h usr/lib/common/defs.h			\
 	usr/lib/common/p11util.h usr/lib/common/event_client.h		\
-	usr/lib/common/list.h usr/lib/common/tok_specific.h
+	usr/lib/common/list.h usr/lib/common/tok_specific.h		\
+	usr/lib/common/buffer.h

--- a/usr/lib/common/p11util.c
+++ b/usr/lib/common/p11util.c
@@ -417,3 +417,17 @@ void p11_attribute_trim(CK_ATTRIBUTE *attr)
         }
     }
 }
+
+/* p11_strlen() - calculate the length of CK_CHAR field, which
+ *          are not '\0' terminated but padded with spaces.
+ * @s       is a pointer to a CK_CHAR string.
+ * @max_len is its maximum length.
+ */
+size_t p11_strlen(const CK_CHAR *s, size_t max_len)
+{
+    size_t len = max_len;
+
+    while (len > 0 && s[len - 1] == ' ')
+        --len;
+    return len;
+}

--- a/usr/lib/common/p11util.h
+++ b/usr/lib/common/p11util.h
@@ -65,4 +65,11 @@ CK_BYTE_PTR p11_bigint_trim(CK_BYTE_PTR in, CK_ULONG_PTR size);
  */
 void p11_attribute_trim(CK_ATTRIBUTE *attr);
 
+/* p11_strlen() - calculate the length of CK_CHAR field, which
+ *          are not '\0' terminated but padded with spaces.
+ * @s       is a pointer to a CK_CHAR string.
+ * @max_len is its maximum length.
+ */
+size_t p11_strlen(const CK_CHAR *s, size_t max_len);
+
 #endif                          // #ifndef _P11UTIL_H_

--- a/usr/lib/common/uri.c
+++ b/usr/lib/common/uri.c
@@ -1,0 +1,270 @@
+/*
+ * COPYRIGHT (c) International Business Machines Corp. 2022
+ *
+ * This program is provided under the terms of the Common Public License,
+ * version 1.0 (CPL-1.0). Any use, reproduction or distribution for this
+ * software constitutes recipient's acceptance of CPL-1.0 terms which can be
+ * found in the file LICENSE file or at
+ * https://opensource.org/licenses/cpl1.0.php
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <pkcs11types.h>
+#include <p11util.h>
+#include <buffer.h>
+#include <uri.h>
+#include <uri_enc.h>
+
+#define buffer_get(u) (p11_buffer_t *)(u)->priv
+
+#define P11_URI_SEP_PROT  ':'
+#define P11_URI_SEP_ATTR  ';'
+#define P11_URI_SEP_QUERY '&'
+
+#define START_END(c, c_max)                                             \
+    (const CK_CHAR *)(c),                                               \
+    (const CK_CHAR *)((CK_CHAR *)c + p11_strlen(c, c_max))
+
+#define FORMAT_STRING(sep, txt, s, buf)                                 \
+    do {                                                                \
+        if (p11_strlen((s), sizeof(s))) {                               \
+            p11_buffer_append_len(buf, sep, 1);                         \
+            p11_buffer_append(buf, txt);                                \
+            p11_url_encode(START_END((s), sizeof(s)),                   \
+                           P11_URI_P_UNRES, buf);                       \
+            *sep = P11_URI_SEP_ATTR;                                    \
+        }                                                               \
+    } while(0)
+
+#define FORMAT_ATTRIBUTE_STRING(sep, txt, a, t, buf)                    \
+    do {                                                                \
+        if (((a)[0].type == (t)) &&                                     \
+            ((a)[0].pValue)) {                                          \
+            p11_buffer_append_len(buf, sep, 1);                         \
+            p11_buffer_append(buf, txt);                                \
+            p11_url_encode(START_END((a)[0].pValue, (a)[0].ulValueLen), \
+                           P11_URI_P_UNRES, buf);                       \
+            *sep = P11_URI_SEP_ATTR;                                    \
+        }                                                               \
+    } while(0)
+
+#define FORMAT_ATTRIBUTE_ALL(sep, txt, a, t, buf)                       \
+    do {                                                                \
+        if (((a)[0].type == (t)) &&                                     \
+            ((a)[0].pValue)) {                                          \
+            p11_buffer_append_len(buf, sep, 1);                         \
+            p11_buffer_append(buf, txt);                                \
+            p11_encode(START_END((a)[0].pValue,                         \
+                                 (a)[0].ulValueLen),                    \
+                       buf);                                            \
+            *sep = P11_URI_SEP_ATTR;                                    \
+        }                                                               \
+    } while(0)
+
+#define FORMAT_ATTRIBUTE_CLASS(sep, txt, a, buf)                        \
+    do {                                                                \
+        if (((a)[0].type == CKA_CLASS) &&                               \
+            ((a)[0].pValue) &&                                          \
+            (rfc7512_get_cko((a)[0].pValue))) {                         \
+            p11_buffer_append_len(buf, sep, 1);                         \
+            p11_buffer_append(buf, txt);                                \
+            p11_buffer_append(buf, rfc7512_get_cko((a)[0].pValue));     \
+            *sep = P11_URI_SEP_ATTR;                                    \
+        }                                                               \
+    } while(0)
+
+#define FORMAT_VERSION(sep, txt, v, buf)                                \
+    do {                                                                \
+        if (((v).major != (CK_BYTE)-1) ||                               \
+            ((v).minor != (CK_BYTE)-1)) {                               \
+            p11_buffer_append_len(buf, sep, 1);                         \
+            p11_buffer_append_printf(buf, txt "%d.%d",                  \
+                                     (v).major, (v).minor);             \
+            *sep = P11_URI_SEP_ATTR;                                    \
+        }                                                               \
+    } while(0)
+
+#define FORMAT_ULONG(sep, txt, ul, buf)                                 \
+    do {                                                                \
+        if ((ul) != (CK_ULONG)-1) {                                     \
+            p11_buffer_append_len(buf, sep, 1);                         \
+            p11_buffer_append_printf(buf, txt "%lu", ul);               \
+            *sep = P11_URI_SEP_ATTR;                                    \
+        }                                                               \
+    } while(0)
+
+static const char HEX_CHARS_LOWER[] = "0123456789abcdef";
+
+static char *rfc7512_get_cko(CK_OBJECT_CLASS *class)
+{
+    switch (*class) {
+    case CKO_CERTIFICATE:
+        return "cert";
+    case CKO_DATA:
+        return "data";
+    case CKO_PRIVATE_KEY:
+        return "private";
+    case CKO_PUBLIC_KEY:
+        return "public";
+    case CKO_SECRET_KEY:
+        return "secret-key";
+    default:
+        break;
+    }
+    return NULL;
+}
+
+static void p11_encode(const unsigned char *start,
+                       const unsigned char *end,
+                       p11_buffer_t *buf)
+{
+    unsigned char hex[3];
+
+    if (end <= start)
+        return;
+
+    while (start != end) {
+        /* encoding required */
+        hex[0] = '%';
+        hex[1] = HEX_CHARS_LOWER[(*start) >> 4];
+        hex[2] = HEX_CHARS_LOWER[(*start) & 0x0F];
+
+        p11_buffer_append_len(buf, (const char *)hex, 3);
+
+        ++start;
+    }
+}
+
+static void p11_url_encode(const unsigned char *start,
+                           const unsigned char *end,
+                           const char *verbatim,
+                           p11_buffer_t *buf)
+{
+    while (start != end) {
+        if (*start && strchr(verbatim, *start) != NULL) {
+            /* no encoding */
+            p11_buffer_append_len(buf, (const char *)start, 1);
+        } else {
+            p11_encode(start, start + 1, buf);
+        }
+
+        ++start;
+    }
+}
+
+static void p11_uri_init(struct p11_uri *uri)
+{
+    uri->slot_id = (CK_ULONG) - 1;
+    uri->obj_id[0].type = CKA_ID;
+    uri->obj_label[0].type = CKA_LABEL;
+    uri->obj_class[0].type = CKA_CLASS;
+
+    p11_buffer_reset(buffer_get(uri));
+}
+
+const char *p11_uri_format(struct p11_uri *uri)
+{
+    p11_buffer_t *buf;
+    char sep;
+
+    if (!uri)
+        return NULL;
+    buf = buffer_get(uri);
+
+    p11_buffer_reset(buf);
+
+    p11_buffer_append(buf, "pkcs11");
+    sep = P11_URI_SEP_PROT;
+
+    /* CK_INFO */
+    if (uri->info) {
+        FORMAT_STRING(&sep, "library-description=",
+                      uri->info->libraryDescription, buf);
+        FORMAT_STRING(&sep, "library-manufacturer=",
+                      uri->info->manufacturerID, buf);
+        FORMAT_VERSION(&sep, "library-version=",
+                       uri->info->libraryVersion, buf);
+    }
+
+    FORMAT_ULONG(&sep, "slot-id=",
+                 uri->slot_id, buf);
+
+    /* CK_SLOT_INFO */
+    if (uri->slot_info) {
+        FORMAT_STRING(&sep, "slot-description=",
+                      uri->slot_info->slotDescription, buf);
+        FORMAT_STRING(&sep, "slot-manufacturer=",
+                      uri->slot_info->manufacturerID, buf);
+    }
+
+    /* CK_TOKEN_INFO */
+    if (uri->token_info) {
+        FORMAT_STRING(&sep, "manufacturer=",
+                      uri->token_info->manufacturerID, buf);
+        FORMAT_STRING(&sep, "model=",
+                      uri->token_info->model, buf);
+        FORMAT_STRING(&sep, "serial=",
+                      uri->token_info->serialNumber, buf);
+        FORMAT_STRING(&sep, "token=",
+                      uri->token_info->label, buf);
+    }
+
+    /* OBJECT */
+    FORMAT_ATTRIBUTE_ALL(&sep, "id=", uri->obj_id, CKA_ID, buf);
+    FORMAT_ATTRIBUTE_STRING(&sep, "object=", uri->obj_label, CKA_LABEL, buf);
+    FORMAT_ATTRIBUTE_CLASS(&sep, "type=", uri->obj_class, buf);
+
+    /* append the protocol separator for empty URI */
+    if (sep == P11_URI_SEP_PROT)
+        p11_buffer_append_len(buf, &sep, 1);
+
+    return p11_buffer_char(buf);
+}
+
+struct p11_uri *p11_uri_new(void)
+{
+    struct p11_uri *uri;
+
+    if (!(uri = calloc(1, sizeof(struct p11_uri))))
+        goto out;
+
+    if (!(uri->priv = (void *) p11_buffer_new()))
+        goto err;
+
+    p11_uri_init(uri);
+out:
+    return uri;
+
+err:
+    free(uri);
+    return NULL_PTR;
+}
+
+static void p11_uri_attribute_free(CK_ATTRIBUTE_PTR attr)
+{
+    if (attr->pValue)
+        free(attr->pValue);
+    attr->pValue = NULL;
+    attr->ulValueLen = 0;
+}
+
+void p11_uri_attributes_free(struct p11_uri *uri)
+{
+    if (!uri)
+        return;
+
+    p11_uri_attribute_free(&uri->obj_id[0]);
+    p11_uri_attribute_free(&uri->obj_label[0]);
+    p11_uri_attribute_free(&uri->obj_class[0]);
+}
+
+void p11_uri_free(struct p11_uri *uri)
+{
+    if (!uri)
+        return;
+
+    p11_buffer_free((p11_buffer_t *) uri->priv);
+    free(uri);
+}

--- a/usr/lib/common/uri.h
+++ b/usr/lib/common/uri.h
@@ -1,0 +1,33 @@
+/*
+ * COPYRIGHT (c) International Business Machines Corp. 2022
+ *
+ * This program is provided under the terms of the Common Public License,
+ * version 1.0 (CPL-1.0). Any use, reproduction or distribution for this
+ * software constitutes recipient's acceptance of CPL-1.0 terms which can be
+ * found in the file LICENSE file or at
+ * https://opensource.org/licenses/cpl1.0.php
+ */
+
+#ifndef __URI_H
+#define __URI_H
+
+#include <pkcs11types.h>
+#include <buffer.h>
+
+struct p11_uri {
+    CK_INFO_PTR info;
+    CK_SLOT_ID slot_id;
+    CK_SLOT_INFO_PTR slot_info;
+    CK_TOKEN_INFO_PTR token_info;
+    CK_ATTRIBUTE obj_id[1];
+    CK_ATTRIBUTE obj_label[1];
+    CK_ATTRIBUTE obj_class[1];
+    void *priv;
+};
+
+const char *p11_uri_format(struct p11_uri *uri);
+struct p11_uri *p11_uri_new(void);
+void p11_uri_attributes_free(struct p11_uri *uri);
+void p11_uri_free(struct p11_uri *uri);
+
+#endif                          /* __URI_H */

--- a/usr/lib/common/uri_enc.h
+++ b/usr/lib/common/uri_enc.h
@@ -1,0 +1,32 @@
+/*
+ * COPYRIGHT (c) International Business Machines Corp. 2022
+ *
+ * This program is provided under the terms of the Common Public License,
+ * version 1.0 (CPL-1.0). Any use, reproduction or distribution for this
+ * software constitutes recipient's acceptance of CPL-1.0 terms which can be
+ * found in the file LICENSE file or at
+ * https://opensource.org/licenses/cpl1.0.php
+ */
+
+#ifndef __URI_ENC_H
+#define __URI_ENC_H
+
+#define URL_UNRES                \
+    "abcdefghijklmnopqrstuvwxyz" \
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ" \
+    "0123456789_-."
+
+#define P11_URI_UNRES            \
+    ":[]@!$\'()*+,="
+
+#define P11_URI_P_UNRES          \
+    URL_UNRES                    \
+    P11_URI_UNRES                \
+    "&"
+
+#define P11_URI_Q_UNRES          \
+    URL_UNRES                    \
+    P11_URI_UNRES                \
+    "/?|"
+
+#endif /* __URI_ENC_H */

--- a/usr/sbin/p11sak/p11sak.mk
+++ b/usr/sbin/p11sak/p11sak.mk
@@ -11,6 +11,7 @@ usr_sbin_p11sak_p11sak_CFLAGS = -DLINUX -DPROGRAM_NAME=\"$(@)\"		\
 
 usr_sbin_p11sak_p11sak_SOURCES = usr/lib/common/p11util.c		\
 	usr/sbin/p11sak/p11sak.c usr/lib/config/configuration.c		\
+	usr/lib/common/uri.c usr/lib/common/buffer.c			\
 	usr/lib/config/cfgparse.y usr/lib/config/cfglex.l
 
 nodist_usr_sbin_p11sak_p11sak_SOURCES = usr/lib/api/mechtable.c

--- a/usr/sbin/pkcsconf/pkcsconf.c
+++ b/usr/sbin/pkcsconf/pkcsconf.c
@@ -31,6 +31,7 @@
 #include "p11util.h"
 #include "defs.h"
 #include "mechtable.h"
+#include "uri.h"
 
 #define LEEDS_DEFAULT_PIN "87654321"
 #define PIN_SIZE 80
@@ -560,6 +561,22 @@ CK_RV check_user_and_group(void)
     return CKR_FUNCTION_FAILED;
 }
 
+void print_info_uri(CK_INFO_PTR info)
+{
+    struct p11_uri *uri;
+
+    uri = p11_uri_new();
+    if (!uri)
+        return;
+
+    uri->info = info;
+
+    printf("\tURI: %s\n", p11_uri_format(uri));
+
+    p11_uri_free(uri);
+    uri = NULL;
+}
+
 CK_RV display_pkcs11_info(void)
 {
 
@@ -582,6 +599,7 @@ CK_RV display_pkcs11_info(void)
     printf("\tLibrary Description: %.32s \n", CryptokiInfo.libraryDescription);
     printf("\tLibrary Version: %d.%d \n", CryptokiInfo.libraryVersion.major,
            CryptokiInfo.libraryVersion.minor);
+    print_info_uri(&CryptokiInfo);
 
     return rc;
 }
@@ -744,6 +762,23 @@ void print_slot_info(int slot_id, CK_SLOT_INFO *SlotInfo)
            SlotInfo->firmwareVersion.minor);
 }
 
+void print_slot_info_uri(int slot_id, CK_SLOT_INFO_PTR SlotInfo)
+{
+    struct p11_uri *uri;
+
+    uri = p11_uri_new();
+    if (!uri)
+        return;
+
+    uri->slot_id = slot_id;
+    uri->slot_info = SlotInfo;
+
+    printf("\tURI: %s\n", p11_uri_format(uri));
+
+    p11_uri_free(uri);
+    uri = NULL;
+}
+
 CK_RV display_slot_info(int slot_id)
 {
     CK_RV rc;                   // Return Code
@@ -759,6 +794,7 @@ CK_RV display_slot_info(int slot_id)
         }
 
         print_slot_info(slot_id, &SlotInfo);
+        print_slot_info_uri(slot_id, &SlotInfo);
         return CKR_OK;
     }
 
@@ -772,6 +808,7 @@ CK_RV display_slot_info(int slot_id)
         }
 
         print_slot_info(SlotList[lcv], &SlotInfo);
+        print_slot_info_uri(SlotList[lcv], &SlotInfo);
 
     }
     return CKR_OK;
@@ -907,6 +944,21 @@ void print_token_info(int slot_id, CK_TOKEN_INFO *TokenInfo)
     printf("\tTime: %.16s\n", TokenInfo->utcTime);
 }
 
+void print_token_info_uri(const CK_TOKEN_INFO_PTR TokenInfo)
+{
+    struct p11_uri *uri;
+
+    uri = p11_uri_new();
+    if (!uri)
+        return;
+
+    uri->token_info = TokenInfo;
+    printf("\tURI: %s\n", p11_uri_format(uri));
+
+    p11_uri_free(uri);
+    uri = NULL;
+}
+
 CK_RV display_token_info(int slot_id)
 {
     CK_RV rc;                   // Return Code
@@ -922,6 +974,7 @@ CK_RV display_token_info(int slot_id)
         }
 
         print_token_info(slot_id, &TokenInfo);
+        print_token_info_uri(&TokenInfo);
         return CKR_OK;
     }
 
@@ -935,6 +988,7 @@ CK_RV display_token_info(int slot_id)
         }
 
         print_token_info(SlotList[lcv], &TokenInfo);
+        print_token_info_uri(&TokenInfo);
     }
     return CKR_OK;
 }

--- a/usr/sbin/pkcsconf/pkcsconf.mk
+++ b/usr/sbin/pkcsconf/pkcsconf.mk
@@ -10,6 +10,8 @@ usr_sbin_pkcsconf_pkcsconf_CFLAGS = -D_THREAD_SAFE -DDEBUG -DDEV	\
 
 usr_sbin_pkcsconf_pkcsconf_SOURCES =					\
 	usr/lib/common/p11util.c					\
+	usr/lib/common/buffer.c						\
+	usr/lib/common/uri.c						\
 	usr/sbin/pkcsconf/pkcsconf.c
 
 nodist_usr_sbin_pkcsconf_pkcsconf_SOURCES = usr/lib/api/mechtable.c


### PR DESCRIPTION
This PR contains a first implementation of the PKCS#11 URI generation support. It applies on top of my latest maint/autotools-cleanup branch. So please ignore patches 1-9/15.

First, a few generic helper functions are added, like a strlen-helper for non-null terminated strings in CK-structs and a string buffer with a dynamic memory management. Patch 12/15 contains the pkcs11 URI implementation. Patch 13-15/15 make use of it in the related tools.

As soon as maint/autotools-cleanup has been accepted and mergen into master, I'll provice a rebased version of this branch.