### PR TITLE
EP11: Fix C_GetMechanismList returning CKR_BUFFER_TOO_SMALL

### DIFF
--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -8977,6 +8977,8 @@ CK_RV ep11tok_get_mechanism_list(STDLL_TokData_t * tokdata,
                 if (rc != CKR_BUFFER_TOO_SMALL)
                     goto out;
             }
+            /* counter was updated in case of CKR_BUFFER_TOO_SMALL */
+            *pulCount = counter;
         } while (rc == CKR_BUFFER_TOO_SMALL);
 
         for (i = 0; i < counter; i++) {


### PR DESCRIPTION
For mixed card levels, the size query call and the call to obtain the list may run on different cards. When the size query call runs on a card with less mechanisms than the second call, will fail, but it returns the larger larger number of mechanisms.

The code already re-allocates the buffer for retrieving the mechanism list, but does not return the larger number in pulCount. This will lead to a CKR_BUFFER_TOO_SMALL when the application calls C_GetMechanismList
again to obtain the list of mechanisms, because the applications buffer is too small.