### PR TITLE
config: Fix memory leak for number pair list nodes

### DIFF
--- a/usr/lib/config/cfgparse.y
+++ b/usr/lib/config/cfgparse.y
@@ -216,7 +216,7 @@ configelem:
         $$ = confignode_append(&(n->base), $2);
         $1 = NULL;
         $2 = NULL;
-    }    
+    }
     |
     /* A \n 1 2 B */
     BARE eocplus numpairlist BARE eocstar {
@@ -234,6 +234,7 @@ configelem:
         struct ConfigBareStringConstNode *n = confignode_allocbarestringconst($1, @1.first_line);
         if (!n) { YYERROR; }
         $$ = confignode_append(&(n->base), $2);
+        $1 = NULL;
         $2 = NULL;
     }
 

--- a/usr/lib/config/configuration.h
+++ b/usr/lib/config/configuration.h
@@ -397,6 +397,7 @@ static inline void confignode_freenumpairlist(struct ConfigNumPairListNode *n)
         free(n->base.key);
         confignode_deepfree(n->beforeFirst);
         confignode_deepfree(n->value);
+        free(n->end);
         free(n);
     }
 }


### PR DESCRIPTION
Then end string is not freed in a number pair list node leading to
a memory leak.

Minor unrelated changes in cfgparse.y that were noticed while at it.

Unit test configdump now runs leak free in valgrind or address sanitizer.