### PR TITLE
P11sak updates 2.0

### DIFF
--- a/man/man1/p11sak.1.in
+++ b/man/man1/p11sak.1.in
@@ -238,11 +238,54 @@ attribute of the key and
 can be used to set the binary attributes of the key (see below for detailed description of the attributes).
 .
 .PP
+.SS "Generating IBM Dilithium keys"
+.
+.B p11sak
+.BR generate-key | gen-key | gen
+.BR ibm-dilithium
+.BR VERSION
+.B \-\-slot
+.IR SLOTID
+.B \-\-pin
+.IR PIN
+.B \-\-label
+.IR LABEL
+.B \-\-attr
+.IR [M R L S E D G V W U A X N T]
+.B \-\-help | \-h
+.PP
+Use the
+.B generate-key
+.B ibm-dilithium
+.B VERSION
+command and key argument to generate an IBM Dilithium key, where
+.I VERSION
+specifies the version of the IBM Dilithium keypair. The following arguments can be used for respective keys:
+.B r2_65
+.PP
+The
+.B \-\-slot
+.IR SLOTID
+and
+.B \-\-pin
+.IR PIN
+options are required to set the token to
+.IR SLOTID
+and the token PIN. The
+.B \-\-label
+option allows the user to set the
+.IR LABEL
+attribute of the key and
+.B \-\-attr
+.IR [M R L S E D G V W U A X N T]
+can be used to set the binary attributes of the key (see below for detailed description of the attributes). 
+.
+.PP
 .SS "Listing symmetric and asymmetric keys"
 .
 .B p11sak
 .BR list-key | ls-key | ls
-.BR des | 3des | aes | rsa | ec | public | private | secret | all
+.BR des | 3des | aes | rsa | ec | ibm-dilithium | public | private | secret | all
 .B \-\-slot
 .IR SLOTID
 .B \-\-pin
@@ -254,17 +297,14 @@ can be used to set the binary attributes of the key (see below for detailed desc
 .PP
 Use the
 .B list-key | ls-key | ls
-command and key argument to list DES, 3DES, AES, RSA or EC keys, respectively. Public, private, secret, or all keys can also be listed irrespective of key type. 
-Keys can be filtered by their given 
-.IR LABEL
-.
+command and key argument to list DES, 3DES, AES, RSA, EC, or IBM Dilithium keys, respectively. Public, private, secret, or all keys can also be listed irrespective of key type.
 .
 .PP
 .SS "Deleting symmetric and asymmetric keys"
 .
 .B p11sak
 .BR remove-key | rm-key | rm
-.BR des | 3des | aes | rsa | ec
+.BR des | 3des | aes | rsa | ec | ibm-dilithium
 .B \-\-slot
 .IR SLOTID
 .B \-\-pin
@@ -276,7 +316,7 @@ Keys can be filtered by their given
 .PP
 Use the
 .B remove-key | rm-key | rm
-command and key argument to delete DES, 3DES, AES, RSA, or EC keys, respectively. All specified cipher keys will be promted to be deleted unless 
+command and key argument to delete DES, 3DES, AES, RSA, EC, or IBM Dilithium keys, respectively. All specified cipher keys will be prompted to be deleted unless 
 a specific key with the 
 .B \-\-label
 .IR LABEL
@@ -290,7 +330,7 @@ option.
 .
 .SH ARGS
 .
-.SS "des | 3des | aes | rsa | ec | public | private | secret | all"
+.SS "des | 3des | aes | rsa | ec | ibm-dilithium | public | private | secret | all"
 
 selects the respective symmetric or asymetric key to be generated or listed. The
 .B public|private|secret|all

--- a/man/man1/p11sak.1.in
+++ b/man/man1/p11sak.1.in
@@ -247,12 +247,17 @@ can be used to set the binary attributes of the key (see below for detailed desc
 .IR SLOTID
 .B \-\-pin
 .IR PIN
+.B \-\-label
+.IR LABEL
 .B \-\-long | \-l
 .B \-\-help | \-h
 .PP
 Use the
 .B list-key | ls-key | ls
-command and key argument to list DES, 3DES, AES, RSA or EC keys, respectively. Public, private, secret, or all keys can also be listed irrespective of key type.
+command and key argument to list DES, 3DES, AES, RSA or EC keys, respectively. Public, private, secret, or all keys can also be listed irrespective of key type. 
+Keys can be filtered by their given 
+.IR LABEL
+.
 .
 .PP
 .SS "Deleting symmetric and asymmetric keys"

--- a/testcases/misc_tests/p11sak_test.sh
+++ b/testcases/misc_tests/p11sak_test.sh
@@ -34,6 +34,9 @@ P11SAK_RSA_POST=p11sak-rsa-post.out
 P11SAK_EC_PRE=p11sak-ec-pre.out
 P11SAK_EC_LONG=p11sak-ec-long.out
 P11SAK_EC_POST=p11sak-ec-post.out
+P11SAK_IBM_DIL_PRE=p11sak-ibm-dil-pre.out
+P11SAK_IBM_DIL_LONG=p11sak-ibm-dil-long.out
+P11SAK_IBM_DIL_POST=p11sak-ibm-dil-post.out
 
 
 echo "** Setting SLOT=30 to the Softtoken unless otherwise set - 'p11sak_test.sh'"
@@ -66,6 +69,8 @@ p11sak generate-key rsa 4096 --slot $SLOT --pin $PKCS11_USER_PIN --label p11sak-
 p11sak generate-key ec prime256v1 --slot $SLOT --pin $PKCS11_USER_PIN --label p11sak-ec-prime256v1
 p11sak generate-key ec secp384r1 --slot $SLOT --pin $PKCS11_USER_PIN --label p11sak-ec-secp384r1
 p11sak generate-key ec secp521r1 --slot $SLOT --pin $PKCS11_USER_PIN --label p11sak-ec-secp521r1
+# ibm-dilithium
+p11sak generate-key ibm-dilithium r2_65 --slot $SLOT --pin $PKCS11_USER_PIN --label p11sak-ibm-dilithium
 
 
 echo "** Now list keys and redirect output to pre-files - 'p11sak_test.sh'"
@@ -77,12 +82,14 @@ p11sak list-key 3des --slot $SLOT --pin $PKCS11_USER_PIN &> $P11SAK_3DES_PRE
 p11sak list-key aes --slot $SLOT --pin $PKCS11_USER_PIN &> $P11SAK_AES_PRE
 p11sak list-key rsa --slot $SLOT --pin $PKCS11_USER_PIN &> $P11SAK_RSA_PRE
 p11sak list-key ec --slot $SLOT --pin $PKCS11_USER_PIN &> $P11SAK_EC_PRE
+p11sak list-key ibm-dilithium --slot $SLOT --pin $PKCS11_USER_PIN &> $P11SAK_IBM_DIL_PRE
 
 p11sak list-key des --slot $SLOT --pin $PKCS11_USER_PIN --long &> $P11SAK_DES_LONG
 p11sak list-key 3des --slot $SLOT --pin $PKCS11_USER_PIN --long &> $P11SAK_3DES_LONG
 p11sak list-key aes --slot $SLOT --pin $PKCS11_USER_PIN --long &> $P11SAK_AES_LONG
 p11sak list-key rsa --slot $SLOT --pin $PKCS11_USER_PIN --long &> $P11SAK_RSA_LONG
 p11sak list-key ec --slot $SLOT --pin $PKCS11_USER_PIN --long &> $P11SAK_EC_LONG
+p11sak list-key ibm-dilithium --slot $SLOT --pin $PKCS11_USER_PIN --long &> $P11SAK_IBM_DIL_LONG
 
 echo "** Now remove keys - 'p11sak_test.sh'"
 
@@ -114,6 +121,9 @@ p11sak remove-key ec --slot $SLOT --pin $PKCS11_USER_PIN --label p11sak-ec-secp5
 p11sak remove-key ec --slot $SLOT --pin $PKCS11_USER_PIN --label p11sak-ec-prime256v1:prv -f
 p11sak remove-key ec --slot $SLOT --pin $PKCS11_USER_PIN --label p11sak-ec-secp384r1:prv -f
 p11sak remove-key ec --slot $SLOT --pin $PKCS11_USER_PIN --label p11sak-ec-secp521r1:prv -f
+# remove ibm dilithium keys
+p11sak remove-key ibm-dilithium --slot $SLOT --pin $PKCS11_USER_PIN --label p11sak-ibm-dilithium:pub -f
+p11sak remove-key ibm-dilithium --slot $SLOT --pin $PKCS11_USER_PIN --label p11sak-ibm-dilithium:prv -f
 
 
 echo "** Now list keys and rediirect to post-files - 'p11sak_test.sh'"
@@ -125,6 +135,7 @@ p11sak list-key 3des --slot $SLOT --pin $PKCS11_USER_PIN &> $P11SAK_3DES_POST
 p11sak list-key aes --slot $SLOT --pin $PKCS11_USER_PIN &> $P11SAK_AES_POST
 p11sak list-key rsa --slot $SLOT --pin $PKCS11_USER_PIN &> $P11SAK_RSA_POST
 p11sak list-key ec --slot $SLOT --pin $PKCS11_USER_PIN &> $P11SAK_EC_POST
+p11sak list-key ibm-dilithium --slot $SLOT --pin $PKCS11_USER_PIN &> $P11SAK_IBM_DIL_POST
 
 
 echo "** Now checking output files to determine PASS/FAIL of tests - 'p11sak_test.sh'"
@@ -549,6 +560,26 @@ echo "* TESTCASE list-key ec FAIL list ec public key pkcs#11 URI"
 fi
 
 
+# CK_BBOOL
+if [[ $(grep -A 32 'p11sak-ibm-dilithium' $P11SAK_IBM_DIL_LONG | grep -c 'CK_TRUE') == "14" ]]; then
+echo "* TESTCASE list-key ibm-dilithium PASS Listed random ibm-dilithium public keys CK_BBOOL attribute"
+else
+echo "* TESTCASE list-key ibm-dilithium FAIL Failed to list ibm-dilithium public keys CK_BBOOL attribute"
+fi
+# CK_ULONG
+if [[ $(grep -A 32 'p11sak-ibm-dilithium' $P11SAK_IBM_DIL_LONG | grep -c 'CKA_MODULUS_BITS:') == "0" ]]; then
+echo "* TESTCASE list-key ibm-dilithium PASS Listed random ibm-dilithium public keys CK_ULONG attribute"
+else
+echo "* TESTCASE list-key ibm-dilithium FAIL Failed to list ibm-dilithium public keys CK_ULONG attribute"
+fi
+# CK_BYTE
+if [[ $(grep -A 32 'p11sak-ibm-dilithium' $P11SAK_IBM_DIL_LONG | grep -c 'CKA_MODULUS:') == "0" ]]; then
+echo "* TESTCASE list-key ibm-dilithium PASS Listed random ibm-dilithium public keys CK_BYTE attribute"
+else
+echo "* TESTCASE list-key ibm-dilithium FAIL Failed to list ibm-dilithium public keys CK_BYTE attribute"
+fi
+
+
 echo "** Now remove temporary output files - 'p11sak_test.sh'"
 
 
@@ -567,6 +598,9 @@ rm -f $P11SAK_RSA_POST
 rm -f $P11SAK_EC_PRE
 rm -f $P11SAK_EC_LONG
 rm -f $P11SAK_EC_POST
+rm -f $P11SAK_IBM_DIL_PRE
+rm -f $P11SAK_IBM_DIL_LONG
+rm -f $P11SAK_IBM_DIL_POST
 
 echo "** Now DONE testing - 'p11sak_test.sh'"
 

--- a/usr/sbin/p11sak/p11sak.c
+++ b/usr/sbin/p11sak/p11sak.c
@@ -1986,32 +1986,26 @@ static CK_RV parse_list_key_args(char *argv[], int argc, p11sak_kt *kt,
 
     for (i = 2; i < argc; i++) {
         /* Get arguments */
-        if (strcmp(argv[i], "DES") == 0 || strcmp(argv[i], "des") == 0) {
+        if (strcasecmp(argv[i], "des") == 0) {
             *kt = kt_DES;
             *keylength = 64;
-        } else if (strcmp(argv[i], "3DES") == 0
-                || strcmp(argv[i], "3des") == 0) {
+        } else if (strcasecmp(argv[i], "3des") == 0) {
             *kt = kt_3DES;
-        } else if (strcmp(argv[i], "AES") == 0 || strcmp(argv[i], "aes") == 0) {
+        } else if (strcasecmp(argv[i], "aes") == 0) {
             *kt = kt_AES;
-        } else if (strcmp(argv[i], "RSA") == 0 || strcmp(argv[i], "rsa") == 0) {
+        } else if (strcasecmp(argv[i], "rsa") == 0) {
             *kt = kt_RSAPKCS;
-        } else if (strcmp(argv[i], "EC") == 0 || strcmp(argv[i], "ec") == 0) {
+        } else if (strcasecmp(argv[i], "ec") == 0) {
             *kt = kt_EC;
-        } else if (strcmp(argv[i], "GENERIC") == 0
-                || strcmp(argv[i], "generic") == 0) {
+        } else if (strcasecmp(argv[i], "generic") == 0) {
             *kt = kt_GENERIC;
-        } else if (strcmp(argv[i], "SECRET") == 0
-                || strcmp(argv[i], "secret") == 0) {
+        } else if (strcasecmp(argv[i], "secret") == 0) {
             *kt = kt_SECRET;
-        } else if (strcmp(argv[i], "PUBLIC") == 0
-                || strcmp(argv[i], "public") == 0) {
+        } else if (strcasecmp(argv[i], "public") == 0) {
             *kt = kt_PUBLIC;
-        } else if (strcmp(argv[i], "PRIVATE") == 0
-                || strcmp(argv[i], "private") == 0) {
+        } else if (strcasecmp(argv[i], "private") == 0) {
             *kt = kt_PRIVATE;
-        } else if (strcmp(argv[i], "ALL") == 0
-                || strcmp(argv[i], "all") == 0) {
+        } else if (strcasecmp(argv[i], "all") == 0) {
             *kt = kt_ALL;
             /* Get options */
         } else if (strcmp(argv[i], "--slot") == 0) {
@@ -2092,22 +2086,21 @@ static CK_RV parse_gen_key_args(char *argv[], int argc, p11sak_kt *kt,
 
     for (i = 2; i < argc; i++) {
         /* Get arguments */
-        if (strcmp(argv[i], "DES") == 0 || strcmp(argv[i], "des") == 0) {
+        if (strcasecmp(argv[i], "des") == 0) {
             *kt = kt_DES;
             *keylength = 64;
-        } else if (strcmp(argv[i], "3DES") == 0
-                || strcmp(argv[i], "3des") == 0) {
+        } else if (strcasecmp(argv[i], "3des") == 0) {
             *kt = kt_3DES;
             *keylength = 192;
-        } else if (strcmp(argv[i], "AES") == 0 || strcmp(argv[i], "aes") == 0) {
+        } else if (strcasecmp(argv[i], "aes") == 0) {
             *kt = kt_AES;
             *keylength = get_ulong_arg(i + 1, argv, argc);
             i++;
-        } else if (strcmp(argv[i], "RSA") == 0 || strcmp(argv[i], "rsa") == 0) {
+        } else if (strcasecmp(argv[i], "rsa") == 0) {
             *kt = kt_RSAPKCS;
             *keylength = get_ulong_arg(i + 1, argv, argc);
             i++;
-        } else if (strcmp(argv[i], "EC") == 0 || strcmp(argv[i], "ec") == 0) {
+        } else if (strcasecmp(argv[i], "ec") == 0) {
             *kt = kt_EC;
             *ECcurve = get_string_arg(i + 1, argv, argc);
             i++;
@@ -2234,17 +2227,16 @@ static CK_RV parse_remove_key_args(char *argv[], int argc, p11sak_kt *kt,
 
     for (i = 2; i < argc; i++) {
         /* Get arguments */
-        if (strcmp(argv[i], "DES") == 0 || strcmp(argv[i], "des") == 0) {
+        if (strcasecmp(argv[i], "des") == 0) {
             *kt = kt_DES;
             *keylength = 64;
-        } else if (strcmp(argv[i], "3DES") == 0
-                || strcmp(argv[i], "3des") == 0) {
+        } else if (strcasecmp(argv[i], "3des") == 0) {
             *kt = kt_3DES;
-        } else if (strcmp(argv[i], "AES") == 0 || strcmp(argv[i], "aes") == 0) {
+        } else if (strcasecmp(argv[i], "aes") == 0) {
             *kt = kt_AES;
-        } else if (strcmp(argv[i], "RSA") == 0 || strcmp(argv[i], "rsa") == 0) {
+        } else if (strcasecmp(argv[i], "rsa") == 0) {
             *kt = kt_RSAPKCS;
-        } else if (strcmp(argv[i], "EC") == 0 || strcmp(argv[i], "ec") == 0) {
+        } else if (strcasecmp(argv[i], "ec") == 0) {
             *kt = kt_EC;
             /* Get options */
         } else if (strcmp(argv[i], "--slot") == 0) {

--- a/usr/sbin/p11sak/p11sak.c
+++ b/usr/sbin/p11sak/p11sak.c
@@ -2678,7 +2678,7 @@ static CK_RV list_ckey(CK_SESSION_HANDLE session, CK_SLOT_ID slot,
             fprintf(stderr, "Retrieval of label failed (error code 0x%lX: %s)\n", rc,
                     p11_get_ckr(rc));
         } else if (long_print) {
-            printf("Label: %s\t\t", label);
+            printf("Label: \"%s\"\t\t", label);
         }
 
         uri = p11_uri_new();
@@ -2777,7 +2777,7 @@ static CK_RV list_ckey(CK_SESSION_HANDLE session, CK_SLOT_ID slot,
                 printf(" %*s | ", CELL_SIZE, tmp);
             } else
                 printf(" %*s | ", CELL_SIZE, keytype);
-            printf("%s\n", label);
+            printf("\"%s\"\n", label);
         }
         free(label);
         label = NULL;

--- a/usr/sbin/p11sak/p11sak.h
+++ b/usr/sbin/p11sak/p11sak.h
@@ -24,6 +24,7 @@ typedef enum {
     kt_AES,
     kt_RSAPKCS,
     kt_EC,
+    kt_IBM_DILITHIUM,
     kt_GENERIC,
     kt_SECRET,
     kt_PUBLIC,

--- a/usr/sbin/p11sak/p11sak_defined_attrs.conf
+++ b/usr/sbin/p11sak/p11sak_defined_attrs.conf
@@ -34,3 +34,9 @@ attribute {
    type = CK_BYTE
 }
 
+attribute {
+   name = CKA_IBM_DILITHIUM_KEYFORM
+   id = 0x800d0001
+   type = CK_ULONG
+}
+


### PR DESCRIPTION
Where it makes sense strcmp() is changed to strcasecmp().
There is a new option --label at list-key command available, to filter by a key label. Closes: https://github.com/opencryptoki/opencryptoki/issues/501
Add support for IBM Dilithium keys.