### PR TITLE
p11sak fixes

### DIFF
--- a/usr/sbin/p11sak/p11sak.c
+++ b/usr/sbin/p11sak/p11sak.c
@@ -1768,10 +1768,8 @@ static CK_RV tok_key_get_key_type(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE hk
         strcpy(buffer, "private ");
         break;
     default:
-        // FIXIT - return code to represent object class invalid
-        rc = CKR_KEY_HANDLE_INVALID;
-        fprintf(stderr, "Object handle invalid (error code 0x%lX: %s)\n",
-               rc, p11_get_ckr(rc));
+        /* its not a key */
+        rc = CKR_KEY_TYPE_INCONSISTENT;
         free(buffer);
         return rc;
     }
@@ -2604,8 +2602,10 @@ static CK_RV list_ckey(CK_SESSION_HANDLE session, CK_SLOT_ID slot,
         rc = tok_key_get_key_type(session, hkey, &keyclass, &keytype,
                 &keylength);
         if (rc != CKR_OK) {
-            fprintf(stderr, "Invalid key type (error code 0x%lX: %s)\n", rc,
-                    p11_get_ckr(rc));
+            if (rc != CKR_KEY_TYPE_INCONSISTENT)
+                fprintf(stderr,
+                        "Retrieval of key type failed (error code 0x%lX: %s)\n",
+                        rc, p11_get_ckr(rc));
             continue;
         }
 
@@ -2846,8 +2846,10 @@ static CK_RV delete_key(CK_SESSION_HANDLE session, p11sak_kt kt, char *rm_label,
         rc = tok_key_get_key_type(session, hkey, &keyclass, &keytype,
                 &keylength);
         if (rc != CKR_OK) {
-            fprintf(stderr, "Invalid key type (error code 0x%lX: %s)\n", rc,
-                    p11_get_ckr(rc));
+            if (rc != CKR_KEY_TYPE_INCONSISTENT)
+                fprintf(stderr,
+                        "Retrieval of key type failed (error code 0x%lX: %s)\n",
+                        rc, p11_get_ckr(rc));
             continue;
         }
 

--- a/usr/sbin/p11sak/p11sak.c
+++ b/usr/sbin/p11sak/p11sak.c
@@ -931,12 +931,10 @@ static CK_RV set_battr(const char *attr_string, CK_ATTRIBUTE *attr,
         for (i = 0; i < (int) strlen(attr_string); i++) {
             // attr_string length is checked in parse_gen_key_args to avoid memory problems
             if (prv == 1 && attr_na(char2attrtype(toupper(attr_string[i])), kt_PRIVATE) == 0) {
-                printf("private: %d\n", attr_string[i]);
                 set_bool_attr_from_string(&attr[*count], attr_string[i]);
                 (*count)++;
             } 
             if (prv == 0 && attr_na(char2attrtype(toupper(attr_string[i])), kt_PUBLIC) == 0) {
-                printf("public: %d\n", attr_string[i]);
                 set_bool_attr_from_string(&attr[*count], attr_string[i]);
                 (*count)++;
             }


### PR DESCRIPTION
- remove leftover debug printf.
- skip non-key objects during list-keys and remove-key, don't print ugly errors.