### PR TITLE
gitignore: update generated files to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,8 @@ usr/sbin/pkcsicsf/pkcsicsf
 usr/sbin/pkcsslotd/pkcsslotd
 usr/sbin/pkcsstats/pkcsstats
 usr/sbin/pkcstok_migrate/pkcstok_migrate
+usr/sbin/pkcsep11_migrate/pkcsep11_migrate
+usr/sbin/pkcsep11_session/pkcsep11_session
 tools/policyexamplegen
 tools/tableidxgen
 


### PR DESCRIPTION
Tools pkcsep11_migrate and pkcsep11_session must als be ignored.