### PR TITLE
Add support for dual-function cryptographic functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ testcases/misc_tests/tok2tok_transport
 testcases/misc_tests/tok_des
 testcases/misc_tests/tok_obj
 testcases/misc_tests/tok_rsa
+testcases/misc_tests/dual_functions
 testcases/ock_tests.sh
 testcases/pkcs11/attribute
 testcases/pkcs11/copyobjects

--- a/testcases/misc_tests/dual_functions.c
+++ b/testcases/misc_tests/dual_functions.c
@@ -1,0 +1,1069 @@
+/*
+ * COPYRIGHT (c) International Business Machines Corp. 2022
+ *
+ * This program is provided under the terms of the Common Public License,
+ * version 1.0 (CPL-1.0). Any use, reproduction or distribution for this
+ * software constitutes recipient's acceptance of CPL-1.0 terms which can be
+ * found in the file LICENSE file or at
+ * https://opensource.org/licenses/cpl1.0.php
+ */
+
+/* File: dual_functions.c
+ *
+ * Test driver.  In-depth regression test for PKCS #11
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <memory.h>
+#include <unistd.h>
+
+#include "pkcs11types.h"
+#include "regress.h"
+#include "common.c"
+#include "mechtable.h"
+#include "mech_to_str.h"
+
+CK_BYTE aes_iv[16] = { 0x00,0x01,0x02,0x03,0x04,0x05,0x06,0x07,
+                       0x08,0x09,0x0a,0x0b,0x0c,0x0d,0x0e,0x0f };
+
+CK_MECHANISM aeskeygen_mech = { CKM_AES_KEY_GEN, NULL, 0 };
+CK_MECHANISM endecrypt_mech = { CKM_AES_CBC, aes_iv, sizeof(aes_iv) };
+CK_MECHANISM signver_mech = { CKM_SHA256_HMAC, NULL, 0 };
+CK_MECHANISM mackeygen_mech = { CKM_GENERIC_SECRET_KEY_GEN, NULL, 0 };
+CK_MECHANISM digest_mech = { CKM_SHA256, NULL, 0 };
+
+CK_BYTE data1[512];
+CK_BYTE data2[512];
+
+
+CK_RV do_digest_encrypt_decrypt_digest()
+{
+    CK_SESSION_HANDLE session;
+    CK_BYTE user_pin[PKCS11_MAX_PIN_LEN];
+    CK_ULONG user_pin_len;
+    CK_RV rc = CKR_OK, loc_rc;
+    CK_FLAGS flags;
+    CK_OBJECT_HANDLE aes_key = CK_INVALID_HANDLE;
+    CK_BYTE encrypted1[sizeof(data1) + 16];
+    CK_ULONG encrypted1_len;
+    CK_BYTE encrypted2[sizeof(data2) + 16];
+    CK_ULONG encrypted2_len;
+    CK_BYTE encrypted3[16];
+    CK_ULONG encrypted3_len;
+    CK_BYTE clear[sizeof(data1) + 16];
+    CK_ULONG clear_len;
+    CK_BYTE digest1[32];
+    CK_ULONG digest1_len;
+    CK_BYTE digest2[32];
+    CK_ULONG digest2_len;
+
+    testcase_begin("C_DigestEncryptUpdate with %s/%s",
+                   mech_to_str(digest_mech.mechanism),
+                   mech_to_str(endecrypt_mech.mechanism));
+
+    testcase_rw_session();
+    testcase_user_login();
+
+    if (!mech_supported(SLOT_ID, digest_mech.mechanism)) {
+        testcase_skip("Slot %u doesn't support %s (0x%x)",
+                      (unsigned int)SLOT_ID,
+                      mech_to_str(digest_mech.mechanism),
+                      (unsigned int)digest_mech.mechanism);
+        goto testcase_cleanup;
+    }
+    if (!mech_supported(SLOT_ID, endecrypt_mech.mechanism)) {
+        testcase_skip("Slot %u doesn't support %s (0x%x)",
+                      (unsigned int)SLOT_ID,
+                      mech_to_str(endecrypt_mech.mechanism),
+                      (unsigned int)endecrypt_mech.mechanism);
+        goto testcase_cleanup;
+    }
+    if (!mech_supported(SLOT_ID, aeskeygen_mech.mechanism)) {
+        testcase_skip("Slot %u doesn't support %s (0x%x)",
+                      (unsigned int)SLOT_ID,
+                      mech_to_str(aeskeygen_mech.mechanism),
+                      (unsigned int)aeskeygen_mech.mechanism);
+        goto testcase_cleanup;
+    }
+
+    /* generate an AES key */
+    rc = generate_AESKey(session, 256 / 8, CK_TRUE, &aeskeygen_mech, &aes_key);
+    if (rc != CKR_OK) {
+        if (rc == CKR_POLICY_VIOLATION) {
+            testcase_skip("generate key with mech %s (%u) in slot %lu "
+                          "is not allowed by policy",
+                          mech_to_str(aeskeygen_mech.mechanism),
+                          (unsigned int)aeskeygen_mech.mechanism,
+                          SLOT_ID);
+            rc = CKR_OK;
+            goto testcase_cleanup;
+        }
+
+        testcase_error("generate key with mech %s (%u) in slot %lu failed, rc=%s",
+                       mech_to_str(aeskeygen_mech.mechanism),
+                       (unsigned int)aeskeygen_mech.mechanism,
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    testcase_new_assertion();
+
+    /* Initialize operations */
+    rc = funcs->C_EncryptInit(session, &endecrypt_mech, aes_key);
+    if (rc != CKR_OK) {
+        testcase_error("C_EncryptInit with mech %s (%u) in slot %lu failed, rc=%s",
+                       mech_to_str(endecrypt_mech.mechanism),
+                       (unsigned int)endecrypt_mech.mechanism,
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    rc = funcs->C_DigestInit(session, &digest_mech);
+    if (rc != CKR_OK) {
+        testcase_error("C_DigestInit with mech %s (%u) in slot %lu failed, rc=%s",
+                       mech_to_str(digest_mech.mechanism),
+                       (unsigned int)digest_mech.mechanism,
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    /* First chunk */
+    encrypted1_len = 0;
+    rc = funcs->C_DigestEncryptUpdate(session, data1, sizeof(data1),
+                                      NULL, &encrypted1_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_DigestEncryptUpdate (1) in slot %lu failed, rc=%s",
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    if (encrypted1_len < sizeof(data1)) {
+        testcase_error("Wrong encrypted length from C_DigestEncryptUpdate (1): %lu",
+                       encrypted1_len);
+        rc = CKR_FUNCTION_FAILED;
+        goto testcase_cleanup;
+    }
+
+    encrypted1_len = sizeof(encrypted1);
+    rc = funcs->C_DigestEncryptUpdate(session, data1, sizeof(data1),
+                                      encrypted1, &encrypted1_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_DigestEncryptUpdate (2) in slot %lu failed, rc=%s",
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    if (encrypted1_len != sizeof(data1)) {
+        testcase_error("Wrong encrypted length from C_DigestEncryptUpdate (2): %lu",
+                       encrypted1_len);
+        rc = CKR_FUNCTION_FAILED;
+        goto testcase_cleanup;
+    }
+
+    /* Second chunk */
+    encrypted2_len = 0;
+    rc = funcs->C_DigestEncryptUpdate(session, data2, sizeof(data2),
+                                      NULL, &encrypted2_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_DigestEncryptUpdate (3) in slot %lu failed, rc=%s",
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    if (encrypted2_len < sizeof(data2)) {
+        testcase_error("Wrong encrypted length from C_DigestEncryptUpdate (3): %lu",
+                       encrypted2_len);
+        rc = CKR_FUNCTION_FAILED;
+        goto testcase_cleanup;
+    }
+
+    encrypted2_len = sizeof(encrypted2);
+    rc = funcs->C_DigestEncryptUpdate(session, data2, sizeof(data2),
+                                      encrypted2, &encrypted2_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_DigestEncryptUpdate (4) in slot %lu failed, rc=%s",
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    if (encrypted2_len != sizeof(data2)) {
+        testcase_error("Wrong encrypted length from C_DigestEncryptUpdate (4): %lu",
+                       encrypted2_len);
+        rc = CKR_FUNCTION_FAILED;
+        goto testcase_cleanup;
+    }
+
+    /* Finalize operations */
+    encrypted3_len = sizeof(encrypted3);
+    rc = funcs->C_EncryptFinal(session, encrypted3, &encrypted3_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_EncryptFinal in slot %lu failed, rc=%s",
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    if (encrypted3_len != 0) {
+        testcase_error("Wrong encrypted length from C_EncryptFinal: %lu",
+                       encrypted3_len);
+        rc = CKR_FUNCTION_FAILED;
+        goto testcase_cleanup;
+    }
+
+    digest1_len = sizeof(digest1);
+    rc = funcs->C_DigestFinal(session, digest1, &digest1_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_DigestFinal in slot %lu failed, rc=%s",
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    testcase_pass("C_DigestEncryptUpdate with %s/%s",
+                  mech_to_str(digest_mech.mechanism),
+                  mech_to_str(endecrypt_mech.mechanism));
+
+    testcase_begin("C_DecryptDigestUpdate with %s/%s",
+                   mech_to_str(endecrypt_mech.mechanism),
+                   mech_to_str(digest_mech.mechanism));
+
+    testcase_new_assertion();
+
+    /* Initialize operations */
+    rc = funcs->C_DecryptInit(session, &endecrypt_mech, aes_key);
+    if (rc != CKR_OK) {
+        testcase_error("C_DecryptInit with mech %s (%u) in slot %lu failed, rc=%s",
+                       mech_to_str(endecrypt_mech.mechanism),
+                       (unsigned int)endecrypt_mech.mechanism,
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    rc = funcs->C_DigestInit(session, &digest_mech);
+    if (rc != CKR_OK) {
+        testcase_error("C_DigestInit with mech %s (%u) in slot %lu failed, rc=%s",
+                       mech_to_str(digest_mech.mechanism),
+                       (unsigned int)digest_mech.mechanism,
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    /* First chunk */
+    clear_len = 0;
+    rc = funcs->C_DecryptDigestUpdate(session, encrypted1, encrypted1_len,
+                                      NULL, &clear_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_DecryptDigestUpdate (1) in slot %lu failed, rc=%s",
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    if (clear_len < sizeof(data1)) {
+        testcase_error("Wrong encrypted length from C_DecryptDigestUpdate (1): %lu",
+                       clear_len);
+        rc = CKR_FUNCTION_FAILED;
+        goto testcase_cleanup;
+    }
+
+    clear_len = sizeof(clear);
+    rc = funcs->C_DecryptDigestUpdate(session, encrypted1, encrypted1_len,
+                                      clear, &clear_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_DecryptDigestUpdate (2) in slot %lu failed, rc=%s",
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    if (clear_len != sizeof(data1)) {
+        testcase_error("Wrong encrypted length from C_DecryptDigestUpdate (2): %lu",
+                       encrypted1_len);
+        rc = CKR_FUNCTION_FAILED;
+        goto testcase_cleanup;
+    }
+    if (memcmp(clear, data1, clear_len) != 0) {
+        testcase_error("Wrong decrypted data from C_DecryptDigestUpdate (2)");
+        rc = CKR_FUNCTION_FAILED;
+        goto testcase_cleanup;
+    }
+
+    /* Second chunk */
+    clear_len = 0;
+    rc = funcs->C_DecryptDigestUpdate(session, encrypted2, encrypted2_len,
+                                      NULL, &clear_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_DecryptDigestUpdate (3) in slot %lu failed, rc=%s",
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    if (clear_len < sizeof(data2)) {
+        testcase_error("Wrong encrypted length from C_DecryptDigestUpdate (3): %lu",
+                       clear_len);
+        rc = CKR_FUNCTION_FAILED;
+        goto testcase_cleanup;
+    }
+
+    clear_len = sizeof(clear);
+    rc = funcs->C_DecryptDigestUpdate(session, encrypted2, encrypted2_len,
+                                      clear, &clear_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_DecryptDigestUpdate (4) in slot %lu failed, rc=%s",
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    if (clear_len != sizeof(data2)) {
+        testcase_error("Wrong encrypted length from C_DecryptDigestUpdate (4): %lu",
+                       encrypted1_len);
+        rc = CKR_FUNCTION_FAILED;
+        goto testcase_cleanup;
+    }
+    if (memcmp(clear, data2, clear_len) != 0) {
+        testcase_error("Wrong decrypted data from C_DecryptDigestUpdate (4)");
+        rc = CKR_FUNCTION_FAILED;
+        goto testcase_cleanup;
+    }
+
+    /* Finalize operations */
+    clear_len = sizeof(clear);
+    rc = funcs->C_DecryptFinal(session, clear, &clear_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_DecryptFinal in slot %lu failed, rc=%s",
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    if (clear_len != 0) {
+        testcase_error("Wrong encrypted length from C_DecryptFinal: %lu",
+                       clear_len);
+        rc = CKR_FUNCTION_FAILED;
+        goto testcase_cleanup;
+    }
+
+    digest2_len = sizeof(digest2);
+    rc = funcs->C_DigestFinal(session, digest2, &digest2_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_DigestFinal in slot %lu failed, rc=%s",
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    if (digest1_len != digest2_len) {
+        testcase_error("Wrong encrypted length from C_DigestFinal: %lu",
+                       digest2_len);
+        rc = CKR_FUNCTION_FAILED;
+        goto testcase_cleanup;
+    }
+
+    if (memcmp(digest1, digest2, digest1_len) != 0) {
+        testcase_error("Wrong digest from C_DigestFinal");
+        rc = CKR_FUNCTION_FAILED;
+        goto testcase_cleanup;
+    }
+
+    testcase_pass("C_DecryptDigestUpdate with %s/%s",
+                  mech_to_str(endecrypt_mech.mechanism),
+                  mech_to_str(digest_mech.mechanism));
+
+testcase_cleanup:
+    if (aes_key != CK_INVALID_HANDLE) {
+        loc_rc = funcs->C_DestroyObject(session, aes_key);
+        if (loc_rc != CKR_OK)
+            testcase_error("C_DestroyObject(), rc=%s.", p11_get_ckr(loc_rc));
+    }
+
+    testcase_user_logout();
+    rc = funcs->C_CloseAllSessions(SLOT_ID);
+    if (rc != CKR_OK) {
+        testcase_error("C_CloseAllSessions rc=%s", p11_get_ckr(rc));
+    }
+
+    return rc;
+}
+
+CK_RV do_sign_encrypt_decrypt_verify()
+{
+    CK_SESSION_HANDLE session;
+    CK_BYTE user_pin[PKCS11_MAX_PIN_LEN];
+    CK_ULONG user_pin_len;
+    CK_RV rc = CKR_OK, loc_rc;
+    CK_FLAGS flags;
+    CK_OBJECT_HANDLE aes_key = CK_INVALID_HANDLE;
+    CK_OBJECT_HANDLE mac_key = CK_INVALID_HANDLE;
+    CK_BYTE encrypted1[sizeof(data1) + 16];
+    CK_ULONG encrypted1_len;
+    CK_BYTE encrypted2[sizeof(data2) + 16];
+    CK_ULONG encrypted2_len;
+    CK_BYTE encrypted3[16];
+    CK_ULONG encrypted3_len;
+    CK_BYTE clear[sizeof(data1) + 16];
+    CK_ULONG clear_len;
+    CK_BYTE signature[32];
+    CK_ULONG signature_len;
+
+    if (is_ica_token(SLOT_ID) || is_tpm_token(SLOT_ID)) {
+        /*
+         * The ICA and TPM tokens do not support CKM_SHA256_HMAC in multi-chunk
+         * mode, only single chunk. Use CKM_AES_CMAC instead.
+         */
+        signver_mech.mechanism = CKM_AES_CMAC;
+        mackeygen_mech.mechanism = CKM_AES_KEY_GEN;
+    }
+
+
+    testcase_begin("C_SignEncryptUpdate with %s/%s",
+                   mech_to_str(signver_mech.mechanism),
+                   mech_to_str(endecrypt_mech.mechanism));
+
+    testcase_rw_session();
+    testcase_user_login();
+
+    if (!mech_supported(SLOT_ID, signver_mech.mechanism)) {
+        testcase_skip("Slot %u doesn't support %s (0x%x)",
+                      (unsigned int)SLOT_ID,
+                      mech_to_str(signver_mech.mechanism),
+                      (unsigned int)signver_mech.mechanism);
+        goto testcase_cleanup;
+    }
+    if (!mech_supported(SLOT_ID, endecrypt_mech.mechanism)) {
+        testcase_skip("Slot %u doesn't support %s (0x%x)",
+                      (unsigned int)SLOT_ID,
+                      mech_to_str(endecrypt_mech.mechanism),
+                      (unsigned int)endecrypt_mech.mechanism);
+        goto testcase_cleanup;
+    }
+    if (!mech_supported(SLOT_ID, aeskeygen_mech.mechanism)) {
+        testcase_skip("Slot %u doesn't support %s (0x%x)",
+                      (unsigned int)SLOT_ID,
+                      mech_to_str(aeskeygen_mech.mechanism),
+                      (unsigned int)aeskeygen_mech.mechanism);
+        goto testcase_cleanup;
+    }
+    if (!mech_supported(SLOT_ID, mackeygen_mech.mechanism)) {
+        testcase_skip("Slot %u doesn't support %s (0x%x)",
+                      (unsigned int)SLOT_ID,
+                      mech_to_str(mackeygen_mech.mechanism),
+                      (unsigned int)mackeygen_mech.mechanism);
+        goto testcase_cleanup;
+    }
+
+    /* generate an AES key */
+    rc = generate_AESKey(session, 256 / 8, CK_TRUE, &aeskeygen_mech, &aes_key);
+    if (rc != CKR_OK) {
+        if (rc == CKR_POLICY_VIOLATION) {
+            testcase_skip("generate key with mech %s (%u) in slot %lu "
+                          "is not allowed by policy",
+                          mech_to_str(aeskeygen_mech.mechanism),
+                          (unsigned int)aeskeygen_mech.mechanism,
+                          SLOT_ID);
+            rc = CKR_OK;
+            goto testcase_cleanup;
+        }
+
+        testcase_error("generate key with mech %s (%u) in slot %lu failed, rc=%s",
+                       mech_to_str(aeskeygen_mech.mechanism),
+                       (unsigned int)aeskeygen_mech.mechanism,
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    /* generate a MAC key */
+    if (mackeygen_mech.mechanism == CKM_AES_KEY_GEN)
+        rc = generate_AESKey(session, 256 / 8, CK_TRUE, &aeskeygen_mech,
+                             &mac_key);
+    else
+        rc = generate_SecretKey(session, 256, &mackeygen_mech, &mac_key);
+    if (rc != CKR_OK) {
+        if (rc == CKR_POLICY_VIOLATION) {
+            testcase_skip("generate key with mech %s (%u) in slot %lu "
+                          "is not allowed by policy",
+                          mech_to_str(mackeygen_mech.mechanism),
+                          (unsigned int)mackeygen_mech.mechanism,
+                          SLOT_ID);
+            rc = CKR_OK;
+            goto testcase_cleanup;
+        }
+
+        testcase_error("generate key with mech %s (%u) in slot %lu failed, rc=%s",
+                       mech_to_str(mackeygen_mech.mechanism),
+                       (unsigned int)mackeygen_mech.mechanism,
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    testcase_new_assertion();
+
+    /* Initialize operations */
+    rc = funcs->C_EncryptInit(session, &endecrypt_mech, aes_key);
+    if (rc != CKR_OK) {
+        testcase_error("C_EncryptInit with mech %s (%u) in slot %lu failed, rc=%s",
+                       mech_to_str(endecrypt_mech.mechanism),
+                       (unsigned int)endecrypt_mech.mechanism,
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    rc = funcs->C_SignInit(session, &signver_mech, mac_key);
+    if (rc != CKR_OK) {
+        testcase_error("C_SignInit with mech %s (%u) in slot %lu failed, rc=%s",
+                       mech_to_str(signver_mech.mechanism),
+                       (unsigned int)signver_mech.mechanism,
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    /* First chunk */
+    encrypted1_len = 0;
+    rc = funcs->C_SignEncryptUpdate(session, data1, sizeof(data1),
+                                    NULL, &encrypted1_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_SignEncryptUpdate (1) in slot %lu failed, rc=%s",
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    if (encrypted1_len < sizeof(data1)) {
+        testcase_error("Wrong encrypted length from C_SignEncryptUpdate (1): %lu",
+                       encrypted1_len);
+        rc = CKR_FUNCTION_FAILED;
+        goto testcase_cleanup;
+    }
+
+    encrypted1_len = sizeof(encrypted1);
+    rc = funcs->C_SignEncryptUpdate(session, data1, sizeof(data1),
+                                    encrypted1, &encrypted1_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_SignEncryptUpdate (2) in slot %lu failed, rc=%s",
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    if (encrypted1_len != sizeof(data1)) {
+        testcase_error("Wrong encrypted length from C_SignEncryptUpdate (2): %lu",
+                       encrypted1_len);
+        rc = CKR_FUNCTION_FAILED;
+        goto testcase_cleanup;
+    }
+
+    /* Second chunk */
+    encrypted2_len = 0;
+    rc = funcs->C_SignEncryptUpdate(session, data2, sizeof(data2),
+                                    NULL, &encrypted2_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_SignEncryptUpdate (3) in slot %lu failed, rc=%s",
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    if (encrypted2_len < sizeof(data2)) {
+        testcase_error("Wrong encrypted length from C_SignEncryptUpdate (3): %lu",
+                       encrypted2_len);
+        rc = CKR_FUNCTION_FAILED;
+        goto testcase_cleanup;
+    }
+
+    encrypted2_len = sizeof(encrypted2);
+    rc = funcs->C_SignEncryptUpdate(session, data2, sizeof(data2),
+                                    encrypted2, &encrypted2_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_SignEncryptUpdate (4) in slot %lu failed, rc=%s",
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    if (encrypted2_len != sizeof(data2)) {
+        testcase_error("Wrong encrypted length from C_SignEncryptUpdate (4): %lu",
+                       encrypted2_len);
+        rc = CKR_FUNCTION_FAILED;
+        goto testcase_cleanup;
+    }
+
+    /* Finalize operations */
+    encrypted3_len = sizeof(encrypted3);
+    rc = funcs->C_EncryptFinal(session, encrypted3, &encrypted3_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_EncryptFinal in slot %lu failed, rc=%s",
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    if (encrypted3_len != 0) {
+        testcase_error("Wrong encrypted length from C_EncryptFinal: %lu",
+                       encrypted3_len);
+        rc = CKR_FUNCTION_FAILED;
+        goto testcase_cleanup;
+    }
+
+    signature_len = sizeof(signature);
+    rc = funcs->C_SignFinal(session, signature, &signature_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_SignFinal in slot %lu failed, rc=%s",
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    testcase_pass("C_SignEncryptUpdate with %s/%s",
+                  mech_to_str(signver_mech.mechanism),
+                  mech_to_str(endecrypt_mech.mechanism));
+
+    testcase_begin("C_DecryptVerifyUpdate with %s/%s",
+                   mech_to_str(endecrypt_mech.mechanism),
+                   mech_to_str(signver_mech.mechanism));
+
+    testcase_new_assertion();
+
+    /* Initialize operations */
+    rc = funcs->C_DecryptInit(session, &endecrypt_mech, aes_key);
+    if (rc != CKR_OK) {
+        testcase_error("C_DecryptInit with mech %s (%u) in slot %lu failed, rc=%s",
+                       mech_to_str(endecrypt_mech.mechanism),
+                       (unsigned int)endecrypt_mech.mechanism,
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    rc = funcs->C_VerifyInit(session, &signver_mech, mac_key);
+    if (rc != CKR_OK) {
+        testcase_error("C_VerifyInit with mech %s (%u) in slot %lu failed, rc=%s",
+                       mech_to_str(digest_mech.mechanism),
+                       (unsigned int)signver_mech.mechanism,
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    /* First chunk */
+    clear_len = 0;
+    rc = funcs->C_DecryptVerifyUpdate(session, encrypted1, encrypted1_len,
+                                      NULL, &clear_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_DecryptVerifyUpdate (1) in slot %lu failed, rc=%s",
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    if (clear_len < sizeof(data1)) {
+        testcase_error("Wrong encrypted length from C_DecryptVerifyUpdate (1): %lu",
+                       clear_len);
+        rc = CKR_FUNCTION_FAILED;
+        goto testcase_cleanup;
+    }
+
+    clear_len = sizeof(clear);
+    rc = funcs->C_DecryptVerifyUpdate(session, encrypted1, encrypted1_len,
+                                      clear, &clear_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_DecryptVerifyUpdate (2) in slot %lu failed, rc=%s",
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    if (clear_len != sizeof(data1)) {
+        testcase_error("Wrong encrypted length from C_DecryptVerifyUpdate (2): %lu",
+                       encrypted1_len);
+        rc = CKR_FUNCTION_FAILED;
+        goto testcase_cleanup;
+    }
+    if (memcmp(clear, data1, clear_len) != 0) {
+        testcase_error("Wrong decrypted data from C_DecryptVerifyUpdate (2)");
+        rc = CKR_FUNCTION_FAILED;
+        goto testcase_cleanup;
+    }
+
+    /* Second chunk */
+    clear_len = 0;
+    rc = funcs->C_DecryptVerifyUpdate(session, encrypted2, encrypted2_len,
+                                      NULL, &clear_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_DecryptVerifyUpdate (3) in slot %lu failed, rc=%s",
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    if (clear_len < sizeof(data2)) {
+        testcase_error("Wrong encrypted length from C_DecryptVerifyUpdate (3): %lu",
+                       clear_len);
+        rc = CKR_FUNCTION_FAILED;
+        goto testcase_cleanup;
+    }
+
+    clear_len = sizeof(clear);
+    rc = funcs->C_DecryptVerifyUpdate(session, encrypted2, encrypted2_len,
+                                      clear, &clear_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_DecryptVerifyUpdate (4) in slot %lu failed, rc=%s",
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    if (clear_len != sizeof(data2)) {
+        testcase_error("Wrong encrypted length from C_DecryptVerifyUpdate (4): %lu",
+                       encrypted1_len);
+        rc = CKR_FUNCTION_FAILED;
+        goto testcase_cleanup;
+    }
+    if (memcmp(clear, data2, clear_len) != 0) {
+        testcase_error("Wrong decrypted data from C_DecryptVerifyUpdate (4)");
+        rc = CKR_FUNCTION_FAILED;
+        goto testcase_cleanup;
+    }
+
+    /* Finalize operations */
+    clear_len = sizeof(clear);
+    rc = funcs->C_DecryptFinal(session, clear, &clear_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_DecryptFinal in slot %lu failed, rc=%s",
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    if (clear_len != 0) {
+        testcase_error("Wrong encrypted length from C_DecryptFinal: %lu",
+                       clear_len);
+        rc = CKR_FUNCTION_FAILED;
+        goto testcase_cleanup;
+    }
+
+    rc = funcs->C_VerifyFinal(session, signature, signature_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_VerifyFinal in slot %lu failed, rc=%s",
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    testcase_pass("C_DecryptVerifyUpdate with %s/%s",
+                  mech_to_str(endecrypt_mech.mechanism),
+                  mech_to_str(signver_mech.mechanism));
+
+testcase_cleanup:
+    if (aes_key != CK_INVALID_HANDLE) {
+        loc_rc = funcs->C_DestroyObject(session, aes_key);
+        if (loc_rc != CKR_OK)
+            testcase_error("C_DestroyObject(), rc=%s.", p11_get_ckr(loc_rc));
+    }
+    if (mac_key != CK_INVALID_HANDLE) {
+        loc_rc = funcs->C_DestroyObject(session, mac_key);
+        if (loc_rc != CKR_OK)
+            testcase_error("C_DestroyObject(), rc=%s.", p11_get_ckr(loc_rc));
+    }
+
+    testcase_user_logout();
+    rc = funcs->C_CloseAllSessions(SLOT_ID);
+    if (rc != CKR_OK) {
+        testcase_error("C_CloseAllSessions rc=%s", p11_get_ckr(rc));
+    }
+
+    return rc;
+
+}
+
+CK_RV do_save_restore_dual_state()
+{
+    CK_SESSION_HANDLE session;
+    CK_BYTE user_pin[PKCS11_MAX_PIN_LEN];
+    CK_ULONG user_pin_len;
+    CK_RV rc = CKR_OK, loc_rc;
+    CK_FLAGS flags;
+    CK_OBJECT_HANDLE aes_key = CK_INVALID_HANDLE;
+    CK_BYTE encrypted1[sizeof(data1) + 16];
+    CK_ULONG encrypted1_len;
+    CK_BYTE encrypted2[sizeof(data2) + 16];
+    CK_ULONG encrypted2_len;
+    CK_BYTE encrypted2a[sizeof(data2) + 16];
+    CK_ULONG encrypted2a_len;
+    CK_BYTE encrypted3[16];
+    CK_ULONG encrypted3_len;
+    CK_BYTE digest1[32];
+    CK_ULONG digest1_len;
+    CK_BYTE digest2[32];
+    CK_ULONG digest2_len;
+    CK_BYTE *state = NULL;
+    CK_ULONG state_len;
+
+    testcase_begin("Save/Restore state with 2 active operations");
+
+    testcase_rw_session();
+    testcase_user_login();
+
+    if (!mech_supported(SLOT_ID, digest_mech.mechanism)) {
+        testcase_skip("Slot %u doesn't support %s (0x%x)",
+                      (unsigned int)SLOT_ID,
+                      mech_to_str(digest_mech.mechanism),
+                      (unsigned int)digest_mech.mechanism);
+        goto testcase_cleanup;
+    }
+    if (!mech_supported(SLOT_ID, endecrypt_mech.mechanism)) {
+        testcase_skip("Slot %u doesn't support %s (0x%x)",
+                      (unsigned int)SLOT_ID,
+                      mech_to_str(endecrypt_mech.mechanism),
+                      (unsigned int)endecrypt_mech.mechanism);
+        goto testcase_cleanup;
+    }
+    if (!mech_supported(SLOT_ID, aeskeygen_mech.mechanism)) {
+        testcase_skip("Slot %u doesn't support %s (0x%x)",
+                      (unsigned int)SLOT_ID,
+                      mech_to_str(aeskeygen_mech.mechanism),
+                      (unsigned int)aeskeygen_mech.mechanism);
+        goto testcase_cleanup;
+    }
+
+    /* generate an AES key */
+    rc = generate_AESKey(session, 256 / 8, CK_TRUE, &aeskeygen_mech, &aes_key);
+    if (rc != CKR_OK) {
+        if (rc == CKR_POLICY_VIOLATION) {
+            testcase_skip("generate key with mech %s (%u) in slot %lu "
+                          "is not allowed by policy",
+                          mech_to_str(aeskeygen_mech.mechanism),
+                          (unsigned int)aeskeygen_mech.mechanism,
+                          SLOT_ID);
+            rc = CKR_OK;
+            goto testcase_cleanup;
+        }
+
+        testcase_error("generate key with mech %s (%u) in slot %lu failed, rc=%s",
+                       mech_to_str(aeskeygen_mech.mechanism),
+                       (unsigned int)aeskeygen_mech.mechanism,
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    /* Initialize operations */
+    rc = funcs->C_EncryptInit(session, &endecrypt_mech, aes_key);
+    if (rc != CKR_OK) {
+        testcase_error("C_EncryptInit with mech %s (%u) in slot %lu failed, rc=%s",
+                       mech_to_str(endecrypt_mech.mechanism),
+                       (unsigned int)endecrypt_mech.mechanism,
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    rc = funcs->C_DigestInit(session, &digest_mech);
+    if (rc != CKR_OK) {
+        testcase_error("C_DigestInit with mech %s (%u) in slot %lu failed, rc=%s",
+                       mech_to_str(digest_mech.mechanism),
+                       (unsigned int)digest_mech.mechanism,
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    /* First chunk */
+    encrypted1_len = sizeof(encrypted1);
+    rc = funcs->C_DigestEncryptUpdate(session, data1, sizeof(data1),
+                                      encrypted1, &encrypted1_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_DigestEncryptUpdate (2) in slot %lu failed, rc=%s",
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    /* Save state of both operations */
+    rc = funcs->C_GetOperationState(session, NULL, &state_len);
+    if (rc != CKR_OK) {
+        if (rc == CKR_STATE_UNSAVEABLE) {
+            testcase_skip("Operation state is not savable");
+            goto testcase_cleanup;
+        }
+
+        testcase_error("C_GetOperationState (1) in slot %lu failed, rc=%s",
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    state = calloc(1, state_len);
+    if (state == NULL) {
+        testcase_fail("malloc for state buffer of size %lu failed", state_len);
+        rc = CKR_HOST_MEMORY;
+        goto testcase_cleanup;
+    }
+
+    rc = funcs->C_GetOperationState(session, state, &state_len);
+    if (rc != CKR_OK) {
+        if (rc == CKR_STATE_UNSAVEABLE) {
+            testcase_skip("Operation state is not savable");
+            goto testcase_cleanup;
+        }
+
+        testcase_error("C_GetOperationState (2) in slot %lu failed, rc=%s",
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    /* Second chunk */
+    encrypted2_len = sizeof(encrypted2);
+    rc = funcs->C_DigestEncryptUpdate(session, data2, sizeof(data2),
+                                      encrypted2, &encrypted2_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_DigestEncryptUpdate (4) in slot %lu failed, rc=%s",
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    /* Finalize operations */
+    encrypted3_len = sizeof(encrypted3);
+    rc = funcs->C_EncryptFinal(session, encrypted3, &encrypted3_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_EncryptFinal in slot %lu failed, rc=%s",
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    digest1_len = sizeof(digest1);
+    rc = funcs->C_DigestFinal(session, digest1, &digest1_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_DigestFinal in slot %lu failed, rc=%s",
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    testcase_new_assertion();
+
+    /* restore state from after first chunk */
+    rc = funcs->C_SetOperationState(session, state, state_len,
+                                    aes_key, CK_INVALID_HANDLE);
+    if (rc != CKR_OK) {
+        testcase_error("C_SetOperationState in slot %lu failed, rc=%s",
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    /* Second chunk again */
+    encrypted2a_len = sizeof(encrypted2a);
+    rc = funcs->C_DigestEncryptUpdate(session, data2, sizeof(data2),
+                                      encrypted2a, &encrypted2a_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_DigestEncryptUpdate (5) in slot %lu failed, rc=%s",
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    if (encrypted2a_len != encrypted2_len) {
+        testcase_error("Wrong encrypted length from C_DigestEncryptUpdate (5): %lu",
+                       encrypted2a_len);
+        rc = CKR_FUNCTION_FAILED;
+        goto testcase_cleanup;
+    }
+
+    if (memcmp(encrypted2, encrypted2a, encrypted2_len) != 0) {
+        testcase_error("Wrong encrypted data from C_DigestEncryptUpdate (5)");
+        rc = CKR_FUNCTION_FAILED;
+        goto testcase_cleanup;
+    }
+
+    /* Finalize operations again */
+    encrypted3_len = sizeof(encrypted3);
+    rc = funcs->C_EncryptFinal(session, encrypted3, &encrypted3_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_EncryptFinal in slot %lu failed, rc=%s",
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    digest2_len = sizeof(digest2);
+    rc = funcs->C_DigestFinal(session, digest2, &digest2_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_DigestFinal (2) in slot %lu failed, rc=%s",
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    if (digest1_len != digest2_len) {
+        testcase_error("Wrong encrypted length from C_DigestFinal (2): %lu",
+                       digest2_len);
+        rc = CKR_FUNCTION_FAILED;
+        goto testcase_cleanup;
+    }
+
+    if (memcmp(digest1, digest2, digest1_len) != 0) {
+        testcase_error("Wrong digest from C_DigestFinal (2)");
+        rc = CKR_FUNCTION_FAILED;
+        goto testcase_cleanup;
+    }
+
+    testcase_pass("Save/Restore state with 2 active operations");
+
+testcase_cleanup:
+    if (aes_key != CK_INVALID_HANDLE) {
+        loc_rc = funcs->C_DestroyObject(session, aes_key);
+        if (loc_rc != CKR_OK)
+            testcase_error("C_DestroyObject(), rc=%s.", p11_get_ckr(loc_rc));
+    }
+
+    testcase_user_logout();
+    rc = funcs->C_CloseAllSessions(SLOT_ID);
+    if (rc != CKR_OK) {
+        testcase_error("C_CloseAllSessions rc=%s", p11_get_ckr(rc));
+    }
+
+    if (state != NULL)
+        free(state);
+
+    return rc;
+
+}
+
+CK_RV do_dual_functions_tests()
+{
+    CK_RV rc = CKR_OK;
+
+    rc |= do_digest_encrypt_decrypt_digest();
+
+    rc |= do_sign_encrypt_decrypt_verify();
+
+    rc |= do_save_restore_dual_state();
+
+    return rc;
+}
+
+
+int main(int argc, char **argv)
+{
+    int rc;
+    CK_C_INITIALIZE_ARGS cinit_args;
+    CK_RV rv = 0;
+    CK_ULONG i;
+
+    rc = do_ParseArgs(argc, argv);
+    if (rc != 1)
+        return rc;
+
+    printf("Using slot #%lu...\n\n", SLOT_ID);
+
+    rc = do_GetFunctionList();
+    if (!rc) {
+        testcase_error("do_getFunctionList(), rc=%s", p11_get_ckr(rc));
+        return rc;
+    }
+
+    memset(&cinit_args, 0x0, sizeof(cinit_args));
+    cinit_args.flags = CKF_OS_LOCKING_OK;
+    funcs->C_Initialize(&cinit_args);
+
+    testcase_setup();
+
+    for (i = 0; i < sizeof(data1); i++)
+        data1[i] = i;
+    for (i = 0; i < sizeof(data1); i++)
+        data2[i] = 255 - i;
+
+    rv = do_dual_functions_tests();
+    if (rv != CKR_OK)
+        goto finalize;
+
+    rv = funcs->C_Finalize(NULL);
+    if (rv != CKR_OK) {
+        testcase_fail("C_Finalize rc = %s", p11_get_ckr(rv));
+        goto out;
+    }
+
+    rv = 0;
+    goto out;
+
+finalize:
+    rv = funcs->C_Finalize(NULL);
+    if (rv != CKR_OK) {
+        testcase_fail("C_Finalize rc = %s", p11_get_ckr(rv));
+        rv = 1;
+    }
+out:
+    testcase_print_result();
+    return testcase_return(rv);
+}

--- a/testcases/misc_tests/misc_tests.mk
+++ b/testcases/misc_tests/misc_tests.mk
@@ -8,7 +8,7 @@ noinst_PROGRAMS +=							\
 	testcases/misc_tests/obj_lock testcases/misc_tests/tok2tok_transport \
 	testcases/misc_tests/obj_lock testcases/misc_tests/reencrypt    \
 	testcases/misc_tests/cca_export_import_test			\
-	testcases/misc_tests/events
+	testcases/misc_tests/events testcases/misc_tests/dual_functions
 
 testcases_misc_tests_obj_mgmt_tests_CFLAGS = ${testcases_inc}
 testcases_misc_tests_obj_mgmt_tests_LDADD =				\
@@ -79,3 +79,8 @@ testcases_misc_tests_events_CFLAGS = ${testcases_inc}
 testcases_misc_tests_events_LDADD = testcases/common/libcommon.la
 testcases_misc_tests_events_SOURCES = testcases/misc_tests/events.c	\
 	usr/lib/common/event_client.c
+
+testcases_misc_tests_dual_functions_CFLAGS = ${testcases_inc}
+testcases_misc_tests_dual_functions_LDADD = testcases/common/libcommon.la
+testcases_misc_tests_dual_functions_SOURCES = 				\
+	testcases/misc_tests/dual_functions.c

--- a/testcases/ock_tests.sh.in
+++ b/testcases/ock_tests.sh.in
@@ -54,6 +54,7 @@ OCK_TESTS+=" pkcs11/get_interface pkcs11/getobjectsize pkcs11/sess_opstate"
 OCK_TESTS+=" misc_tests/fork misc_tests/obj_mgmt_tests" 
 OCK_TESTS+=" misc_tests/obj_mgmt_lock_tests misc_tests/reencrypt"
 OCK_TESTS+=" misc_tests/events misc_tests/cca_export_import_test"
+OCK_TESTS+=" misc_tests/dual_functions"
 OCK_TEST=""
 OCK_BENCHS="pkcs11/*bench"
 

--- a/usr/lib/common/h_extern.h
+++ b/usr/lib/common/h_extern.h
@@ -2070,7 +2070,7 @@ CK_BBOOL session_mgr_so_session_exists(STDLL_TokData_t *tokdata);
 CK_BBOOL session_mgr_user_session_exists(STDLL_TokData_t *tokdata);
 CK_BBOOL session_mgr_public_session_exists(STDLL_TokData_t *tokdata);
 
-CK_RV session_mgr_get_op_state(SESSION *sess,
+CK_RV session_mgr_get_op_state(STDLL_TokData_t *tokdata, SESSION *sess,
                                CK_BBOOL length_only,
                                CK_BYTE *data, CK_ULONG *data_len);
 

--- a/usr/lib/common/host_defs.h
+++ b/usr/lib/common/host_defs.h
@@ -228,6 +228,9 @@ typedef struct _ATTRIBUTE_PARSE_LIST {
 
 
 typedef struct _OP_STATE_DATA {
+    CK_CHAR library_version[16]; /* zero termination does not matter here */
+    CK_CHAR manufacturerID[member_size(CK_TOKEN_INFO_32, manufacturerID)];
+    CK_CHAR model[member_size(CK_TOKEN_INFO_32, manufacturerID)];
     CK_STATE session_state;
     CK_ULONG active_operation;
     CK_ULONG data_len;

--- a/usr/lib/common/lock_sess_mgr.c
+++ b/usr/lib/common/lock_sess_mgr.c
@@ -586,12 +586,14 @@ CK_RV session_mgr_logout_all(STDLL_TokData_t *tokdata)
 
 //
 //
-CK_RV session_mgr_get_op_state(SESSION *sess,
+CK_RV session_mgr_get_op_state(STDLL_TokData_t *tokdata, SESSION *sess,
                                CK_BBOOL length_only,
                                CK_BYTE *data, CK_ULONG *data_len)
 {
     OP_STATE_DATA *op_data = NULL;
-    CK_ULONG op_data_len = 0;
+    CK_ULONG max_data_len = *data_len;
+    CK_ULONG op_data_len;
+    CK_ULONG all_data_len = 0;
     CK_ULONG offset, active_ops;
 
     if (!sess) {
@@ -614,22 +616,29 @@ CK_RV session_mgr_get_op_state(SESSION *sess,
             return CKR_STATE_UNSAVEABLE;
         }
         active_ops++;
-        if (op_data != NULL) {
-            TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
-            return CKR_STATE_UNSAVEABLE;
-        }
         op_data_len = sizeof(OP_STATE_DATA) +
             sizeof(ENCR_DECR_CONTEXT) +
             sess->encr_ctx.context_len + sess->encr_ctx.mech.ulParameterLen;
+        all_data_len += op_data_len;
 
         if (length_only == FALSE) {
             op_data = (OP_STATE_DATA *) data;
 
-            if (*data_len < op_data_len) {
+            if (max_data_len < op_data_len) {
                 TRACE_ERROR("%s\n", ock_err(ERR_BUFFER_TOO_SMALL));
                  return CKR_BUFFER_TOO_SMALL;
             }
 
+            memset(op_data, 0, sizeof(*op_data));
+#ifdef PACKAGE_VERSION
+            strncpy((char *)op_data->library_version, PACKAGE_VERSION,
+                    sizeof(op_data->library_version));
+#endif
+            memcpy(op_data->manufacturerID,
+                   tokdata->nv_token_data->token_info.manufacturerID,
+                   sizeof(op_data->manufacturerID));
+            memcpy(op_data->model, tokdata->nv_token_data->token_info.model,
+                   sizeof(op_data->model));
             op_data->data_len = op_data_len - sizeof(OP_STATE_DATA);
             op_data->session_state = sess->session_info.state;
             op_data->active_operation = STATE_ENCR;
@@ -653,6 +662,9 @@ CK_RV session_mgr_get_op_state(SESSION *sess,
                        sess->encr_ctx.mech.pParameter,
                        sess->encr_ctx.mech.ulParameterLen);
             }
+
+            max_data_len -= op_data_len;
+            data += op_data_len;
         }
     }
 
@@ -662,22 +674,29 @@ CK_RV session_mgr_get_op_state(SESSION *sess,
             return CKR_STATE_UNSAVEABLE;
         }
         active_ops++;
-        if (op_data != NULL) {
-            TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
-            return CKR_STATE_UNSAVEABLE;
-        }
         op_data_len = sizeof(OP_STATE_DATA) +
             sizeof(ENCR_DECR_CONTEXT) +
             sess->decr_ctx.context_len + sess->decr_ctx.mech.ulParameterLen;
+        all_data_len += op_data_len;
 
         if (length_only == FALSE) {
             op_data = (OP_STATE_DATA *) data;
 
-            if (*data_len < op_data_len) {
+            if (max_data_len < op_data_len) {
                 TRACE_ERROR("%s\n", ock_err(ERR_BUFFER_TOO_SMALL));
                  return CKR_BUFFER_TOO_SMALL;
             }
 
+            memset(op_data, 0, sizeof(*op_data));
+#ifdef PACKAGE_VERSION
+            strncpy((char *)op_data->library_version, PACKAGE_VERSION,
+                    sizeof(op_data->library_version));
+#endif
+            memcpy(op_data->manufacturerID,
+                   tokdata->nv_token_data->token_info.manufacturerID,
+                   sizeof(op_data->manufacturerID));
+            memcpy(op_data->model, tokdata->nv_token_data->token_info.model,
+                   sizeof(op_data->model));
             op_data->data_len = op_data_len - sizeof(OP_STATE_DATA);
             op_data->session_state = sess->session_info.state;
             op_data->active_operation = STATE_DECR;
@@ -701,6 +720,9 @@ CK_RV session_mgr_get_op_state(SESSION *sess,
                        sess->decr_ctx.mech.pParameter,
                        sess->decr_ctx.mech.ulParameterLen);
             }
+
+            max_data_len -= op_data_len;
+            data += op_data_len;
         }
     }
 
@@ -710,22 +732,29 @@ CK_RV session_mgr_get_op_state(SESSION *sess,
             return CKR_STATE_UNSAVEABLE;
         }
         active_ops++;
-        if (op_data != NULL) {
-            TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
-            return CKR_STATE_UNSAVEABLE;
-        }
         op_data_len = sizeof(OP_STATE_DATA) +
             sizeof(DIGEST_CONTEXT) +
             sess->digest_ctx.context_len + sess->digest_ctx.mech.ulParameterLen;
+        all_data_len += op_data_len;
 
         if (length_only == FALSE) {
             op_data = (OP_STATE_DATA *) data;
 
-            if (*data_len < op_data_len) {
+            if (max_data_len < op_data_len) {
                 TRACE_ERROR("%s\n", ock_err(ERR_BUFFER_TOO_SMALL));
                  return CKR_BUFFER_TOO_SMALL;
             }
 
+            memset(op_data, 0, sizeof(*op_data));
+#ifdef PACKAGE_VERSION
+            strncpy((char *)op_data->library_version, PACKAGE_VERSION,
+                    sizeof(op_data->library_version));
+#endif
+            memcpy(op_data->manufacturerID,
+                   tokdata->nv_token_data->token_info.manufacturerID,
+                   sizeof(op_data->manufacturerID));
+            memcpy(op_data->model, tokdata->nv_token_data->token_info.model,
+                   sizeof(op_data->model));
             op_data->data_len = op_data_len - sizeof(OP_STATE_DATA);
             op_data->session_state = sess->session_info.state;
             op_data->active_operation = STATE_DIGEST;
@@ -749,6 +778,9 @@ CK_RV session_mgr_get_op_state(SESSION *sess,
                        sess->digest_ctx.mech.pParameter,
                        sess->digest_ctx.mech.ulParameterLen);
             }
+
+            max_data_len -= op_data_len;
+            data += op_data_len;
         }
     }
 
@@ -758,22 +790,29 @@ CK_RV session_mgr_get_op_state(SESSION *sess,
             return CKR_STATE_UNSAVEABLE;
         }
         active_ops++;
-        if (op_data != NULL) {
-            TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
-            return CKR_STATE_UNSAVEABLE;
-        }
         op_data_len = sizeof(OP_STATE_DATA) +
             sizeof(SIGN_VERIFY_CONTEXT) +
             sess->sign_ctx.context_len + sess->sign_ctx.mech.ulParameterLen;
+        all_data_len += op_data_len;
 
         if (length_only == FALSE) {
             op_data = (OP_STATE_DATA *) data;
 
-            if (*data_len < op_data_len) {
+            if (max_data_len < op_data_len) {
                 TRACE_ERROR("%s\n", ock_err(ERR_BUFFER_TOO_SMALL));
                  return CKR_BUFFER_TOO_SMALL;
             }
 
+            memset(op_data, 0, sizeof(*op_data));
+#ifdef PACKAGE_VERSION
+            strncpy((char *)op_data->library_version, PACKAGE_VERSION,
+                    sizeof(op_data->library_version));
+#endif
+            memcpy(op_data->manufacturerID,
+                   tokdata->nv_token_data->token_info.manufacturerID,
+                   sizeof(op_data->manufacturerID));
+            memcpy(op_data->model, tokdata->nv_token_data->token_info.model,
+                   sizeof(op_data->model));
             op_data->data_len = op_data_len - sizeof(OP_STATE_DATA);
             op_data->session_state = sess->session_info.state;
             op_data->active_operation = STATE_SIGN;
@@ -797,6 +836,9 @@ CK_RV session_mgr_get_op_state(SESSION *sess,
                        sess->sign_ctx.mech.pParameter,
                        sess->sign_ctx.mech.ulParameterLen);
             }
+
+            max_data_len -= op_data_len;
+            data += op_data_len;
         }
     }
 
@@ -806,22 +848,29 @@ CK_RV session_mgr_get_op_state(SESSION *sess,
             return CKR_STATE_UNSAVEABLE;
         }
         active_ops++;
-        if (op_data != NULL) {
-            TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
-            return CKR_STATE_UNSAVEABLE;
-        }
         op_data_len = sizeof(OP_STATE_DATA) +
             sizeof(SIGN_VERIFY_CONTEXT) +
             sess->verify_ctx.context_len + sess->verify_ctx.mech.ulParameterLen;
+        all_data_len += op_data_len;
 
         if (length_only == FALSE) {
             op_data = (OP_STATE_DATA *) data;
 
-            if (*data_len < op_data_len) {
+            if (max_data_len < op_data_len) {
                 TRACE_ERROR("%s\n", ock_err(ERR_BUFFER_TOO_SMALL));
                  return CKR_BUFFER_TOO_SMALL;
             }
 
+            memset(op_data, 0, sizeof(*op_data));
+#ifdef PACKAGE_VERSION
+            strncpy((char *)op_data->library_version, PACKAGE_VERSION,
+                    sizeof(op_data->library_version));
+#endif
+            memcpy(op_data->manufacturerID,
+                   tokdata->nv_token_data->token_info.manufacturerID,
+                   sizeof(op_data->manufacturerID));
+            memcpy(op_data->model, tokdata->nv_token_data->token_info.model,
+                   sizeof(op_data->model));
             op_data->data_len = op_data_len - sizeof(OP_STATE_DATA);
             op_data->session_state = sess->session_info.state;
             op_data->active_operation = STATE_VERIFY;
@@ -845,15 +894,18 @@ CK_RV session_mgr_get_op_state(SESSION *sess,
                        sess->verify_ctx.mech.pParameter,
                        sess->verify_ctx.mech.ulParameterLen);
             }
+
+            max_data_len -= op_data_len;
+            data += op_data_len;
         }
     }
 
-    if (!active_ops) {
+    if (active_ops == 0) {
         TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
         return CKR_OPERATION_NOT_INITIALIZED;
     }
 
-    *data_len = op_data_len;
+    *data_len = all_data_len;
     return CKR_OK;
 }
 
@@ -865,6 +917,8 @@ CK_RV session_mgr_set_op_state(STDLL_TokData_t *tokdata, SESSION *sess,
                                CK_OBJECT_HANDLE auth_key,
                                CK_BYTE *data, CK_ULONG data_len)
 {
+    CK_BYTE *cur_data;
+    CK_ULONG cur_data_len;
     OP_STATE_DATA *op_data = NULL;
     CK_BYTE *mech_param = NULL;
     CK_BYTE *context = NULL;
@@ -872,226 +926,329 @@ CK_RV session_mgr_set_op_state(STDLL_TokData_t *tokdata, SESSION *sess,
     CK_BYTE *ptr2 = NULL;
     CK_BYTE *ptr3 = NULL;
     CK_ULONG len;
+    CK_ULONG encr_key_needed = 0;
+    CK_ULONG auth_key_needed = 0;
 
     if (!sess || !data) {
         TRACE_ERROR("%s received bad argument(s)\n", __func__);
         return CKR_FUNCTION_FAILED;
     }
-    op_data = (OP_STATE_DATA *) data;
 
-    if (data_len < op_data->data_len + sizeof(OP_STATE_DATA)) {
+    /*
+     * Validate the new state information. Don't touch the session
+     * until the new state is valid.
+     */
+    cur_data = data;
+    cur_data_len = data_len;
+    while (cur_data_len >= sizeof(OP_STATE_DATA)) {
+        op_data = (OP_STATE_DATA *)cur_data;
+
+        if (cur_data_len < op_data->data_len + sizeof(OP_STATE_DATA)) {
+            TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
+            return CKR_SAVED_STATE_INVALID;
+        }
+
+        /*
+         * Make sure the session states are compatible: same OCK version,
+         * same token model, same session state.
+         */
+#ifdef PACKAGE_VERSION
+        if (strncmp((char *)op_data->library_version, PACKAGE_VERSION,
+                sizeof(op_data->library_version)) != 0) {
+            TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
+            return CKR_SAVED_STATE_INVALID;
+        }
+#endif
+        if (memcmp(op_data->manufacturerID,
+                   tokdata->nv_token_data->token_info.manufacturerID,
+                   sizeof(op_data->manufacturerID)) != 0 ||
+            memcmp(op_data->model, tokdata->nv_token_data->token_info.model,
+                   sizeof(op_data->model)) != 0) {
+            TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
+            return CKR_SAVED_STATE_INVALID;
+        }
+        if (sess->session_info.state != op_data->session_state) {
+            TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
+            return CKR_SAVED_STATE_INVALID;
+        }
+
+        switch (op_data->active_operation) {
+        case STATE_ENCR:
+        case STATE_DECR:
+            {
+                ENCR_DECR_CONTEXT *ctx =
+                    (ENCR_DECR_CONTEXT *)(cur_data + sizeof(OP_STATE_DATA));
+
+                len = sizeof(ENCR_DECR_CONTEXT) + ctx->context_len +
+                                                ctx->mech.ulParameterLen;
+                if (len != op_data->data_len) {
+                    TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
+                    return CKR_SAVED_STATE_INVALID;
+                }
+
+                encr_key_needed++;
+            }
+            break;
+
+        case STATE_SIGN:
+        case STATE_VERIFY:
+            {
+                SIGN_VERIFY_CONTEXT *ctx =
+                    (SIGN_VERIFY_CONTEXT *)(cur_data + sizeof(OP_STATE_DATA));
+
+                len = sizeof(SIGN_VERIFY_CONTEXT) + ctx->context_len +
+                                                ctx->mech.ulParameterLen;
+                if (len != op_data->data_len) {
+                    TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
+                    return CKR_SAVED_STATE_INVALID;
+                }
+
+                auth_key_needed++;
+            }
+            break;
+
+        case STATE_DIGEST:
+            {
+                DIGEST_CONTEXT *ctx =
+                    (DIGEST_CONTEXT *) (cur_data + sizeof(OP_STATE_DATA));
+
+                len = sizeof(DIGEST_CONTEXT) + ctx->context_len +
+                                                ctx->mech.ulParameterLen;
+                if (len != op_data->data_len) {
+                    TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
+                    return CKR_SAVED_STATE_INVALID;
+                }
+            }
+            break;
+        default:
+            TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
+            return CKR_SAVED_STATE_INVALID;
+        }
+
+        /* move on to next operation */
+        cur_data_len -= (op_data->data_len + sizeof(OP_STATE_DATA));
+        cur_data += (op_data->data_len + sizeof(OP_STATE_DATA));
+    }
+    /* nothing must be left over */
+    if (cur_data_len > 0) {
         TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
         return CKR_SAVED_STATE_INVALID;
     }
 
-    // make sure the session states are compatible
-    //
-    if (sess->session_info.state != op_data->session_state) {
-        TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
-        return CKR_SAVED_STATE_INVALID;
+    if (encr_key_needed > 0 && encr_key == CK_INVALID_HANDLE) {
+        TRACE_ERROR("%s\n", ock_err(ERR_KEY_NEEDED));
+        return CKR_KEY_NEEDED;
     }
-    // validate the new state information.  don't touch the session
-    // until the new state is valid.
-    //
-    switch (op_data->active_operation) {
-    case STATE_ENCR:
-    case STATE_DECR:
-        {
-            ENCR_DECR_CONTEXT *ctx =
-                (ENCR_DECR_CONTEXT *) (data + sizeof(OP_STATE_DATA));
-
-            len =
-                sizeof(ENCR_DECR_CONTEXT) + ctx->context_len +
-                ctx->mech.ulParameterLen;
-            if (len != op_data->data_len) {
-                TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
-                return CKR_SAVED_STATE_INVALID;
-            }
-            if (auth_key != CK_INVALID_HANDLE) {
-                TRACE_ERROR("%s\n", ock_err(ERR_KEY_NOT_NEEDED));
-                return CKR_KEY_NOT_NEEDED;
-            }
-            if (encr_key == CK_INVALID_HANDLE) {
-                TRACE_ERROR("%s\n", ock_err(ERR_KEY_NEEDED));
-                return CKR_KEY_NEEDED;
-            }
-            ptr1 = (CK_BYTE *) ctx;
-            ptr2 = ptr1 + sizeof(ENCR_DECR_CONTEXT);
-            ptr3 = ptr2 + ctx->context_len;
-
-            if (ctx->context_len) {
-                context = (CK_BYTE *) malloc(ctx->context_len);
-                if (!context) {
-                    TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
-                    return CKR_HOST_MEMORY;
-                }
-                memcpy(context, ptr2, ctx->context_len);
-            }
-
-            if (ctx->mech.ulParameterLen) {
-                mech_param = (CK_BYTE *) malloc(ctx->mech.ulParameterLen);
-                if (!mech_param) {
-                    if (context)
-                        free(context);
-                    TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
-                    return CKR_HOST_MEMORY;
-                }
-                memcpy(mech_param, ptr3, ctx->mech.ulParameterLen);
-            }
-        }
-        break;
-    case STATE_SIGN:
-    case STATE_VERIFY:
-        {
-            SIGN_VERIFY_CONTEXT *ctx =
-                (SIGN_VERIFY_CONTEXT *) (data + sizeof(OP_STATE_DATA));
-
-            len =
-                sizeof(SIGN_VERIFY_CONTEXT) + ctx->context_len +
-                ctx->mech.ulParameterLen;
-            if (len != op_data->data_len) {
-                TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
-                return CKR_SAVED_STATE_INVALID;
-            }
-            if (auth_key == CK_INVALID_HANDLE) {
-                TRACE_ERROR("%s\n", ock_err(ERR_KEY_NEEDED));
-                return CKR_KEY_NEEDED;
-            }
-            if (encr_key != CK_INVALID_HANDLE) {
-                TRACE_ERROR("%s\n", ock_err(ERR_KEY_NOT_NEEDED));
-                return CKR_KEY_NOT_NEEDED;
-            }
-            ptr1 = (CK_BYTE *) ctx;
-            ptr2 = ptr1 + sizeof(SIGN_VERIFY_CONTEXT);
-            ptr3 = ptr2 + ctx->context_len;
-
-            if (ctx->context_len) {
-                context = (CK_BYTE *) malloc(ctx->context_len);
-                if (!context) {
-                    TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
-                    return CKR_HOST_MEMORY;
-                }
-                memcpy(context, ptr2, ctx->context_len);
-            }
-
-            if (ctx->mech.ulParameterLen) {
-                mech_param = (CK_BYTE *) malloc(ctx->mech.ulParameterLen);
-                if (!mech_param) {
-                    if (context)
-                        free(context);
-                    TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
-                    return CKR_HOST_MEMORY;
-                }
-                memcpy(mech_param, ptr3, ctx->mech.ulParameterLen);
-            }
-        }
-        break;
-    case STATE_DIGEST:
-        {
-            DIGEST_CONTEXT *ctx =
-                (DIGEST_CONTEXT *) (data + sizeof(OP_STATE_DATA));
-
-            len =
-                sizeof(DIGEST_CONTEXT) + ctx->context_len +
-                ctx->mech.ulParameterLen;
-            if (len != op_data->data_len) {
-                TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
-                return CKR_SAVED_STATE_INVALID;
-            }
-            if (auth_key != CK_INVALID_HANDLE) {
-                TRACE_ERROR("%s\n", ock_err(ERR_KEY_NOT_NEEDED));
-                return CKR_KEY_NOT_NEEDED;
-            }
-            if (encr_key != CK_INVALID_HANDLE) {
-                TRACE_ERROR("%s\n", ock_err(ERR_KEY_NOT_NEEDED));
-                return CKR_KEY_NOT_NEEDED;
-            }
-            ptr1 = (CK_BYTE *) ctx;
-            ptr2 = ptr1 + sizeof(DIGEST_CONTEXT);
-            ptr3 = ptr2 + ctx->context_len;
-
-            if (ctx->context_len) {
-                context = (CK_BYTE *) malloc(ctx->context_len);
-                if (!context) {
-                    TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
-                    return CKR_HOST_MEMORY;
-                }
-                memcpy(context, ptr2, ctx->context_len);
-            }
-
-            if (ctx->mech.ulParameterLen) {
-                mech_param = (CK_BYTE *) malloc(ctx->mech.ulParameterLen);
-                if (!mech_param) {
-                    if (context)
-                        free(context);
-                    TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
-                    return CKR_HOST_MEMORY;
-                }
-                memcpy(mech_param, ptr3, ctx->mech.ulParameterLen);
-            }
-        }
-        break;
-    default:
-        TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
-        return CKR_SAVED_STATE_INVALID;
+    if (encr_key_needed == 0 && encr_key != CK_INVALID_HANDLE) {
+        TRACE_ERROR("%s\n", ock_err(ERR_KEY_NOT_NEEDED));
+        return CKR_KEY_NOT_NEEDED;
+    }
+    if (auth_key_needed > 0 && auth_key == CK_INVALID_HANDLE) {
+        TRACE_ERROR("%s\n", ock_err(ERR_KEY_NEEDED));
+        return CKR_KEY_NEEDED;
+    }
+    if (auth_key_needed == 0 && auth_key != CK_INVALID_HANDLE) {
+        TRACE_ERROR("%s\n", ock_err(ERR_KEY_NOT_NEEDED));
+        return CKR_KEY_NOT_NEEDED;
     }
 
-
-    // state information looks okay.  cleanup the current session state, first
-    //
+    /* State information looks okay. Cleanup the current session state, first */
     if (sess->encr_ctx.active)
         encr_mgr_cleanup(tokdata, sess, &sess->encr_ctx);
-
     if (sess->decr_ctx.active)
         decr_mgr_cleanup(tokdata, sess, &sess->decr_ctx);
-
     if (sess->digest_ctx.active)
         digest_mgr_cleanup(tokdata, sess, &sess->digest_ctx);
-
     if (sess->sign_ctx.active)
         sign_mgr_cleanup(tokdata, sess, &sess->sign_ctx);
-
     if (sess->verify_ctx.active)
         verify_mgr_cleanup(tokdata, sess, &sess->verify_ctx);
 
+    /* Now process the saved operation states */
+    cur_data = data;
+    cur_data_len = data_len;
+    while (cur_data_len >= sizeof(OP_STATE_DATA)) {
+        op_data = (OP_STATE_DATA *)cur_data;
 
-    // copy the new state information
-    //
-    switch (op_data->active_operation) {
-    case STATE_ENCR:
-        memcpy(&sess->encr_ctx, ptr1, sizeof(ENCR_DECR_CONTEXT));
+        if (cur_data_len < op_data->data_len + sizeof(OP_STATE_DATA)) {
+            TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
+            return CKR_SAVED_STATE_INVALID;
+        }
 
-        sess->encr_ctx.key = encr_key;
-        sess->encr_ctx.context = context;
-        sess->encr_ctx.mech.pParameter = mech_param;
-        break;
-    case STATE_DECR:
-        memcpy(&sess->decr_ctx, ptr1, sizeof(ENCR_DECR_CONTEXT));
+        switch (op_data->active_operation) {
+        case STATE_ENCR:
+        case STATE_DECR:
+            {
+                ENCR_DECR_CONTEXT *ctx =
+                    (ENCR_DECR_CONTEXT *)(cur_data + sizeof(OP_STATE_DATA));
 
-        sess->decr_ctx.key = encr_key;
-        sess->decr_ctx.context = context;
-        sess->decr_ctx.mech.pParameter = mech_param;
-        break;
-    case STATE_SIGN:
-        memcpy(&sess->sign_ctx, ptr1, sizeof(SIGN_VERIFY_CONTEXT));
+                len = sizeof(ENCR_DECR_CONTEXT) + ctx->context_len +
+                                                ctx->mech.ulParameterLen;
+                if (len != op_data->data_len) {
+                    TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
+                    return CKR_SAVED_STATE_INVALID;
+                }
+                if (encr_key == CK_INVALID_HANDLE) {
+                    TRACE_ERROR("%s\n", ock_err(ERR_KEY_NEEDED));
+                    return CKR_KEY_NEEDED;
+                }
+                ptr1 = (CK_BYTE *) ctx;
+                ptr2 = ptr1 + sizeof(ENCR_DECR_CONTEXT);
+                ptr3 = ptr2 + ctx->context_len;
 
-        sess->sign_ctx.key = auth_key;
-        sess->sign_ctx.context = context;
-        sess->sign_ctx.mech.pParameter = mech_param;
-        break;
-    case STATE_VERIFY:
-        memcpy(&sess->verify_ctx, ptr1, sizeof(SIGN_VERIFY_CONTEXT));
+                if (ctx->context_len) {
+                    context = (CK_BYTE *) malloc(ctx->context_len);
+                    if (!context) {
+                        TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
+                        return CKR_HOST_MEMORY;
+                    }
+                    memcpy(context, ptr2, ctx->context_len);
+                }
 
-        sess->verify_ctx.key = auth_key;
-        sess->verify_ctx.context = context;
-        sess->verify_ctx.mech.pParameter = mech_param;
-        break;
-    case STATE_DIGEST:
-        memcpy(&sess->digest_ctx, ptr1, sizeof(DIGEST_CONTEXT));
+                if (ctx->mech.ulParameterLen) {
+                    mech_param = (CK_BYTE *) malloc(ctx->mech.ulParameterLen);
+                    if (!mech_param) {
+                        if (context)
+                            free(context);
+                        TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
+                        return CKR_HOST_MEMORY;
+                    }
+                    memcpy(mech_param, ptr3, ctx->mech.ulParameterLen);
+                }
+            }
+            break;
 
-        sess->digest_ctx.context = context;
-        sess->digest_ctx.mech.pParameter = mech_param;
-        break;
+        case STATE_SIGN:
+        case STATE_VERIFY:
+            {
+                SIGN_VERIFY_CONTEXT *ctx =
+                    (SIGN_VERIFY_CONTEXT *)(cur_data + sizeof(OP_STATE_DATA));
+
+                len = sizeof(SIGN_VERIFY_CONTEXT) + ctx->context_len +
+                                                    ctx->mech.ulParameterLen;
+                if (len != op_data->data_len) {
+                    TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
+                    return CKR_SAVED_STATE_INVALID;
+                }
+                if (auth_key == CK_INVALID_HANDLE) {
+                    TRACE_ERROR("%s\n", ock_err(ERR_KEY_NEEDED));
+                    return CKR_KEY_NEEDED;
+                }
+                ptr1 = (CK_BYTE *) ctx;
+                ptr2 = ptr1 + sizeof(SIGN_VERIFY_CONTEXT);
+                ptr3 = ptr2 + ctx->context_len;
+
+                if (ctx->context_len) {
+                    context = (CK_BYTE *) malloc(ctx->context_len);
+                    if (!context) {
+                        TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
+                        return CKR_HOST_MEMORY;
+                    }
+                    memcpy(context, ptr2, ctx->context_len);
+                }
+
+                if (ctx->mech.ulParameterLen) {
+                    mech_param = (CK_BYTE *) malloc(ctx->mech.ulParameterLen);
+                    if (!mech_param) {
+                        if (context)
+                            free(context);
+                        TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
+                        return CKR_HOST_MEMORY;
+                    }
+                    memcpy(mech_param, ptr3, ctx->mech.ulParameterLen);
+                }
+            }
+            break;
+
+        case STATE_DIGEST:
+            {
+                DIGEST_CONTEXT *ctx =
+                    (DIGEST_CONTEXT *)(cur_data + sizeof(OP_STATE_DATA));
+
+                len = sizeof(DIGEST_CONTEXT) + ctx->context_len +
+                                                ctx->mech.ulParameterLen;
+                if (len != op_data->data_len) {
+                    TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
+                    return CKR_SAVED_STATE_INVALID;
+                }
+                ptr1 = (CK_BYTE *) ctx;
+                ptr2 = ptr1 + sizeof(DIGEST_CONTEXT);
+                ptr3 = ptr2 + ctx->context_len;
+
+                if (ctx->context_len) {
+                    context = (CK_BYTE *) malloc(ctx->context_len);
+                    if (!context) {
+                        TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
+                        return CKR_HOST_MEMORY;
+                    }
+                    memcpy(context, ptr2, ctx->context_len);
+                }
+
+                if (ctx->mech.ulParameterLen) {
+                    mech_param = (CK_BYTE *) malloc(ctx->mech.ulParameterLen);
+                    if (!mech_param) {
+                        if (context)
+                            free(context);
+                        TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
+                        return CKR_HOST_MEMORY;
+                    }
+                    memcpy(mech_param, ptr3, ctx->mech.ulParameterLen);
+                }
+            }
+            break;
+        default:
+            TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
+            return CKR_SAVED_STATE_INVALID;
+        }
+
+        /* copy the new state information */
+        switch (op_data->active_operation) {
+        case STATE_ENCR:
+            memcpy(&sess->encr_ctx, ptr1, sizeof(ENCR_DECR_CONTEXT));
+
+            sess->encr_ctx.key = encr_key;
+            sess->encr_ctx.context = context;
+            sess->encr_ctx.mech.pParameter = mech_param;
+            break;
+
+        case STATE_DECR:
+            memcpy(&sess->decr_ctx, ptr1, sizeof(ENCR_DECR_CONTEXT));
+
+            sess->decr_ctx.key = encr_key;
+            sess->decr_ctx.context = context;
+            sess->decr_ctx.mech.pParameter = mech_param;
+            break;
+
+        case STATE_SIGN:
+            memcpy(&sess->sign_ctx, ptr1, sizeof(SIGN_VERIFY_CONTEXT));
+
+            sess->sign_ctx.key = auth_key;
+            sess->sign_ctx.context = context;
+            sess->sign_ctx.mech.pParameter = mech_param;
+            break;
+
+        case STATE_VERIFY:
+            memcpy(&sess->verify_ctx, ptr1, sizeof(SIGN_VERIFY_CONTEXT));
+
+            sess->verify_ctx.key = auth_key;
+            sess->verify_ctx.context = context;
+            sess->verify_ctx.mech.pParameter = mech_param;
+            break;
+
+        case STATE_DIGEST:
+            memcpy(&sess->digest_ctx, ptr1, sizeof(DIGEST_CONTEXT));
+
+            sess->digest_ctx.context = context;
+            sess->digest_ctx.mech.pParameter = mech_param;
+            break;
+        }
+
+        context = NULL;
+        mech_param = NULL;
+
+        /* move on to next operation */
+        cur_data_len -= (op_data->data_len + sizeof(OP_STATE_DATA));
+        cur_data += (op_data->data_len + sizeof(OP_STATE_DATA));
     }
 
     return CKR_OK;

--- a/usr/lib/common/new_host.c
+++ b/usr/lib/common/new_host.c
@@ -1141,7 +1141,7 @@ CK_RV SC_GetOperationState(STDLL_TokData_t *tokdata,
         goto done;
     }
 
-    rc = session_mgr_get_op_state(sess, length_only, pOperationState,
+    rc = session_mgr_get_op_state(tokdata, sess, length_only, pOperationState,
                                   pulOperationStateLen);
     if (rc != CKR_OK)
         TRACE_DEVEL("session_mgr_get_op_state() failed.\n");

--- a/usr/lib/common/new_host.c
+++ b/usr/lib/common/new_host.c
@@ -3380,20 +3380,17 @@ CK_RV SC_DigestEncryptUpdate(STDLL_TokData_t *tokdata,
                              CK_ULONG ulPartLen, CK_BYTE_PTR pEncryptedPart,
                              CK_ULONG_PTR pulEncryptedPartLen)
 {
-    UNUSED(sSession);
-    UNUSED(pPart);
-    UNUSED(ulPartLen);
-    UNUSED(pEncryptedPart);
-    UNUSED(pulEncryptedPartLen);
+    CK_RV rc;
 
-    if (tokdata->initialized == FALSE) {
-        TRACE_ERROR("%s\n", ock_err(ERR_CRYPTOKI_NOT_INITIALIZED));
-        return CKR_CRYPTOKI_NOT_INITIALIZED;
-    }
+    rc = SC_EncryptUpdate(tokdata, sSession, pPart, ulPartLen,
+                          pEncryptedPart, pulEncryptedPartLen);
+    if (rc != CKR_OK || pEncryptedPart == NULL)
+        goto out;
 
-    TRACE_ERROR("%s\n", ock_err(ERR_FUNCTION_NOT_SUPPORTED));
+    rc = SC_DigestUpdate(tokdata, sSession, pPart, ulPartLen);
 
-    return CKR_FUNCTION_NOT_SUPPORTED;
+out:
+    return rc;
 }
 
 
@@ -3403,20 +3400,17 @@ CK_RV SC_DecryptDigestUpdate(STDLL_TokData_t *tokdata,
                              CK_ULONG ulEncryptedPartLen, CK_BYTE_PTR pPart,
                              CK_ULONG_PTR pulPartLen)
 {
-    UNUSED(sSession);
-    UNUSED(pEncryptedPart);
-    UNUSED(ulEncryptedPartLen);
-    UNUSED(pPart);
-    UNUSED(pulPartLen);
+    CK_RV rc;
 
-    if (tokdata->initialized == FALSE) {
-        TRACE_ERROR("%s\n", ock_err(ERR_CRYPTOKI_NOT_INITIALIZED));
-        return CKR_CRYPTOKI_NOT_INITIALIZED;
-    }
+    rc = SC_DecryptUpdate(tokdata, sSession, pEncryptedPart,
+                          ulEncryptedPartLen, pPart, pulPartLen);
+    if (rc != CKR_OK || pPart == NULL)
+        goto out;
 
-    TRACE_ERROR("%s\n", ock_err(ERR_FUNCTION_NOT_SUPPORTED));
+    rc = SC_DigestUpdate(tokdata, sSession, pPart, *pulPartLen);
 
-    return CKR_FUNCTION_NOT_SUPPORTED;
+out:
+    return rc;
 }
 
 
@@ -3425,22 +3419,18 @@ CK_RV SC_SignEncryptUpdate(STDLL_TokData_t *tokdata,
                            CK_ULONG ulPartLen, CK_BYTE_PTR pEncryptedPart,
                            CK_ULONG_PTR pulEncryptedPartLen)
 {
-    UNUSED(sSession);
-    UNUSED(pPart);
-    UNUSED(ulPartLen);
-    UNUSED(pEncryptedPart);
-    UNUSED(pulEncryptedPartLen);
+    CK_RV rc;
 
-    if (tokdata->initialized == FALSE) {
-        TRACE_ERROR("%s\n", ock_err(ERR_CRYPTOKI_NOT_INITIALIZED));
-        return CKR_CRYPTOKI_NOT_INITIALIZED;
-    }
+    rc = SC_EncryptUpdate(tokdata, sSession, pPart, ulPartLen,
+                          pEncryptedPart, pulEncryptedPartLen);
+    if (rc != CKR_OK || pEncryptedPart == NULL)
+        goto out;
 
-    TRACE_ERROR("%s\n", ock_err(ERR_FUNCTION_NOT_SUPPORTED));
+    rc = SC_SignUpdate(tokdata, sSession, pPart, ulPartLen);
 
-    return CKR_FUNCTION_NOT_SUPPORTED;
+out:
+    return rc;
 }
-
 
 CK_RV SC_DecryptVerifyUpdate(STDLL_TokData_t *tokdata,
                              ST_SESSION_HANDLE *sSession,
@@ -3448,20 +3438,17 @@ CK_RV SC_DecryptVerifyUpdate(STDLL_TokData_t *tokdata,
                              CK_ULONG ulEncryptedPartLen, CK_BYTE_PTR pPart,
                              CK_ULONG_PTR pulPartLen)
 {
-    UNUSED(sSession);
-    UNUSED(pEncryptedPart);
-    UNUSED(ulEncryptedPartLen);
-    UNUSED(pPart);
-    UNUSED(pulPartLen);
+    CK_RV rc;
 
-    if (tokdata->initialized == FALSE) {
-        TRACE_ERROR("%s\n", ock_err(ERR_CRYPTOKI_NOT_INITIALIZED));
-        return CKR_CRYPTOKI_NOT_INITIALIZED;
-    }
+    rc = SC_DecryptUpdate(tokdata, sSession, pEncryptedPart,
+                          ulEncryptedPartLen, pPart, pulPartLen);
+    if (rc != CKR_OK || pPart == NULL)
+        goto out;
 
-    TRACE_ERROR("%s\n", ock_err(ERR_FUNCTION_NOT_SUPPORTED));
+    rc = SC_VerifyUpdate(tokdata, sSession, pPart, *pulPartLen);
 
-    return CKR_FUNCTION_NOT_SUPPORTED;
+out:
+    return rc;
 }
 
 
@@ -4109,10 +4096,10 @@ void SC_SetFunctionList(void)
     function_list.ST_VerifyFinal = SC_VerifyFinal;
     function_list.ST_VerifyRecoverInit = SC_VerifyRecoverInit;
     function_list.ST_VerifyRecover = SC_VerifyRecover;
-    function_list.ST_DigestEncryptUpdate = NULL;      // SC_DigestEncryptUpdate;
-    function_list.ST_DecryptDigestUpdate = NULL;      // SC_DecryptDigestUpdate;
-    function_list.ST_SignEncryptUpdate = NULL;  //SC_SignEncryptUpdate;
-    function_list.ST_DecryptVerifyUpdate = NULL;      // SC_DecryptVerifyUpdate;
+    function_list.ST_DigestEncryptUpdate = SC_DigestEncryptUpdate;
+    function_list.ST_DecryptDigestUpdate = SC_DecryptDigestUpdate;
+    function_list.ST_SignEncryptUpdate = SC_SignEncryptUpdate;
+    function_list.ST_DecryptVerifyUpdate = SC_DecryptVerifyUpdate;
     function_list.ST_GenerateKey = SC_GenerateKey;
     function_list.ST_GenerateKeyPair = SC_GenerateKeyPair;
     function_list.ST_WrapKey = SC_WrapKey;

--- a/usr/lib/common/sess_mgr.c
+++ b/usr/lib/common/sess_mgr.c
@@ -538,12 +538,14 @@ CK_RV session_mgr_logout_all(STDLL_TokData_t *tokdata)
 
 //
 //
-CK_RV session_mgr_get_op_state(SESSION *sess,
+CK_RV session_mgr_get_op_state(STDLL_TokData_t *tokdata, SESSION *sess,
                                CK_BBOOL length_only,
                                CK_BYTE *data, CK_ULONG *data_len)
 {
     OP_STATE_DATA *op_data = NULL;
-    CK_ULONG op_data_len = 0;
+    CK_ULONG max_data_len = *data_len;
+    CK_ULONG op_data_len;
+    CK_ULONG all_data_len = 0;
     CK_ULONG offset, active_ops;
 
     if (!sess) {
@@ -566,22 +568,29 @@ CK_RV session_mgr_get_op_state(SESSION *sess,
             return CKR_STATE_UNSAVEABLE;
         }
         active_ops++;
-        if (op_data != NULL) {
-            TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
-            return CKR_STATE_UNSAVEABLE;
-        }
         op_data_len = sizeof(OP_STATE_DATA) +
             sizeof(ENCR_DECR_CONTEXT) +
             sess->encr_ctx.context_len + sess->encr_ctx.mech.ulParameterLen;
+        all_data_len += op_data_len;
 
         if (length_only == FALSE) {
             op_data = (OP_STATE_DATA *) data;
 
-            if (*data_len < op_data_len) {
+            if (max_data_len < op_data_len) {
                 TRACE_ERROR("%s\n", ock_err(ERR_BUFFER_TOO_SMALL));
                  return CKR_BUFFER_TOO_SMALL;
             }
 
+            memset(op_data, 0, sizeof(*op_data));
+#ifdef PACKAGE_VERSION
+            strncpy((char *)op_data->library_version, PACKAGE_VERSION,
+                    sizeof(op_data->library_version));
+#endif
+            memcpy(op_data->manufacturerID,
+                   tokdata->nv_token_data->token_info.manufacturerID,
+                   sizeof(op_data->manufacturerID));
+            memcpy(op_data->model, tokdata->nv_token_data->token_info.model,
+                   sizeof(op_data->model));
             op_data->data_len = op_data_len - sizeof(OP_STATE_DATA);
             op_data->session_state = sess->session_info.state;
             op_data->active_operation = STATE_ENCR;
@@ -605,6 +614,9 @@ CK_RV session_mgr_get_op_state(SESSION *sess,
                        sess->encr_ctx.mech.pParameter,
                        sess->encr_ctx.mech.ulParameterLen);
             }
+
+            max_data_len -= op_data_len;
+            data += op_data_len;
         }
     }
 
@@ -614,22 +626,29 @@ CK_RV session_mgr_get_op_state(SESSION *sess,
             return CKR_STATE_UNSAVEABLE;
         }
         active_ops++;
-        if (op_data != NULL) {
-            TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
-            return CKR_STATE_UNSAVEABLE;
-        }
         op_data_len = sizeof(OP_STATE_DATA) +
             sizeof(ENCR_DECR_CONTEXT) +
             sess->decr_ctx.context_len + sess->decr_ctx.mech.ulParameterLen;
+        all_data_len += op_data_len;
 
         if (length_only == FALSE) {
             op_data = (OP_STATE_DATA *) data;
 
-            if (*data_len < op_data_len) {
+            if (max_data_len < op_data_len) {
                 TRACE_ERROR("%s\n", ock_err(ERR_BUFFER_TOO_SMALL));
                  return CKR_BUFFER_TOO_SMALL;
             }
 
+            memset(op_data, 0, sizeof(*op_data));
+#ifdef PACKAGE_VERSION
+            strncpy((char *)op_data->library_version, PACKAGE_VERSION,
+                    sizeof(op_data->library_version));
+#endif
+            memcpy(op_data->manufacturerID,
+                   tokdata->nv_token_data->token_info.manufacturerID,
+                   sizeof(op_data->manufacturerID));
+            memcpy(op_data->model, tokdata->nv_token_data->token_info.model,
+                   sizeof(op_data->model));
             op_data->data_len = op_data_len - sizeof(OP_STATE_DATA);
             op_data->session_state = sess->session_info.state;
             op_data->active_operation = STATE_DECR;
@@ -653,6 +672,9 @@ CK_RV session_mgr_get_op_state(SESSION *sess,
                        sess->decr_ctx.mech.pParameter,
                        sess->decr_ctx.mech.ulParameterLen);
             }
+
+            max_data_len -= op_data_len;
+            data += op_data_len;
         }
     }
 
@@ -662,22 +684,29 @@ CK_RV session_mgr_get_op_state(SESSION *sess,
             return CKR_STATE_UNSAVEABLE;
         }
         active_ops++;
-        if (op_data != NULL) {
-            TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
-            return CKR_STATE_UNSAVEABLE;
-        }
         op_data_len = sizeof(OP_STATE_DATA) +
             sizeof(DIGEST_CONTEXT) +
             sess->digest_ctx.context_len + sess->digest_ctx.mech.ulParameterLen;
+        all_data_len += op_data_len;
 
         if (length_only == FALSE) {
             op_data = (OP_STATE_DATA *) data;
 
-            if (*data_len < op_data_len) {
+            if (max_data_len < op_data_len) {
                 TRACE_ERROR("%s\n", ock_err(ERR_BUFFER_TOO_SMALL));
                  return CKR_BUFFER_TOO_SMALL;
             }
 
+            memset(op_data, 0, sizeof(*op_data));
+#ifdef PACKAGE_VERSION
+            strncpy((char *)op_data->library_version, PACKAGE_VERSION,
+                    sizeof(op_data->library_version));
+#endif
+            memcpy(op_data->manufacturerID,
+                   tokdata->nv_token_data->token_info.manufacturerID,
+                   sizeof(op_data->manufacturerID));
+            memcpy(op_data->model, tokdata->nv_token_data->token_info.model,
+                   sizeof(op_data->model));
             op_data->data_len = op_data_len - sizeof(OP_STATE_DATA);
             op_data->session_state = sess->session_info.state;
             op_data->active_operation = STATE_DIGEST;
@@ -701,6 +730,9 @@ CK_RV session_mgr_get_op_state(SESSION *sess,
                        sess->digest_ctx.mech.pParameter,
                        sess->digest_ctx.mech.ulParameterLen);
             }
+
+            max_data_len -= op_data_len;
+            data += op_data_len;
         }
     }
 
@@ -710,22 +742,29 @@ CK_RV session_mgr_get_op_state(SESSION *sess,
             return CKR_STATE_UNSAVEABLE;
         }
         active_ops++;
-        if (op_data != NULL) {
-            TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
-            return CKR_STATE_UNSAVEABLE;
-        }
         op_data_len = sizeof(OP_STATE_DATA) +
             sizeof(SIGN_VERIFY_CONTEXT) +
             sess->sign_ctx.context_len + sess->sign_ctx.mech.ulParameterLen;
+        all_data_len += op_data_len;
 
         if (length_only == FALSE) {
             op_data = (OP_STATE_DATA *) data;
 
-            if (*data_len < op_data_len) {
+            if (max_data_len < op_data_len) {
                 TRACE_ERROR("%s\n", ock_err(ERR_BUFFER_TOO_SMALL));
                  return CKR_BUFFER_TOO_SMALL;
             }
 
+            memset(op_data, 0, sizeof(*op_data));
+#ifdef PACKAGE_VERSION
+            strncpy((char *)op_data->library_version, PACKAGE_VERSION,
+                    sizeof(op_data->library_version));
+#endif
+            memcpy(op_data->manufacturerID,
+                   tokdata->nv_token_data->token_info.manufacturerID,
+                   sizeof(op_data->manufacturerID));
+            memcpy(op_data->model, tokdata->nv_token_data->token_info.model,
+                   sizeof(op_data->model));
             op_data->data_len = op_data_len - sizeof(OP_STATE_DATA);
             op_data->session_state = sess->session_info.state;
             op_data->active_operation = STATE_SIGN;
@@ -749,6 +788,9 @@ CK_RV session_mgr_get_op_state(SESSION *sess,
                        sess->sign_ctx.mech.pParameter,
                        sess->sign_ctx.mech.ulParameterLen);
             }
+
+            max_data_len -= op_data_len;
+            data += op_data_len;
         }
     }
 
@@ -758,22 +800,29 @@ CK_RV session_mgr_get_op_state(SESSION *sess,
             return CKR_STATE_UNSAVEABLE;
         }
         active_ops++;
-        if (op_data != NULL) {
-            TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
-            return CKR_STATE_UNSAVEABLE;
-        }
         op_data_len = sizeof(OP_STATE_DATA) +
             sizeof(SIGN_VERIFY_CONTEXT) +
             sess->verify_ctx.context_len + sess->verify_ctx.mech.ulParameterLen;
+        all_data_len += op_data_len;
 
         if (length_only == FALSE) {
             op_data = (OP_STATE_DATA *) data;
 
-            if (*data_len < op_data_len) {
+            if (max_data_len < op_data_len) {
                 TRACE_ERROR("%s\n", ock_err(ERR_BUFFER_TOO_SMALL));
                  return CKR_BUFFER_TOO_SMALL;
             }
 
+            memset(op_data, 0, sizeof(*op_data));
+#ifdef PACKAGE_VERSION
+            strncpy((char *)op_data->library_version, PACKAGE_VERSION,
+                    sizeof(op_data->library_version));
+#endif
+            memcpy(op_data->manufacturerID,
+                   tokdata->nv_token_data->token_info.manufacturerID,
+                   sizeof(op_data->manufacturerID));
+            memcpy(op_data->model, tokdata->nv_token_data->token_info.model,
+                   sizeof(op_data->model));
             op_data->data_len = op_data_len - sizeof(OP_STATE_DATA);
             op_data->session_state = sess->session_info.state;
             op_data->active_operation = STATE_VERIFY;
@@ -797,15 +846,18 @@ CK_RV session_mgr_get_op_state(SESSION *sess,
                        sess->verify_ctx.mech.pParameter,
                        sess->verify_ctx.mech.ulParameterLen);
             }
+
+            max_data_len -= op_data_len;
+            data += op_data_len;
         }
     }
 
-    if (!active_ops) {
+    if (active_ops == 0) {
         TRACE_ERROR("%s\n", ock_err(ERR_STATE_UNSAVEABLE));
         return CKR_OPERATION_NOT_INITIALIZED;
     }
 
-    *data_len = op_data_len;
+    *data_len = all_data_len;
     return CKR_OK;
 }
 
@@ -817,6 +869,8 @@ CK_RV session_mgr_set_op_state(STDLL_TokData_t *tokdata, SESSION *sess,
                                CK_OBJECT_HANDLE auth_key,
                                CK_BYTE *data, CK_ULONG data_len)
 {
+    CK_BYTE *cur_data;
+    CK_ULONG cur_data_len;
     OP_STATE_DATA *op_data = NULL;
     CK_BYTE *mech_param = NULL;
     CK_BYTE *context = NULL;
@@ -824,226 +878,329 @@ CK_RV session_mgr_set_op_state(STDLL_TokData_t *tokdata, SESSION *sess,
     CK_BYTE *ptr2 = NULL;
     CK_BYTE *ptr3 = NULL;
     CK_ULONG len;
+    CK_ULONG encr_key_needed = 0;
+    CK_ULONG auth_key_needed = 0;
 
     if (!sess || !data) {
         TRACE_ERROR("%s received bad argument(s)\n", __func__);
         return CKR_FUNCTION_FAILED;
     }
-    op_data = (OP_STATE_DATA *) data;
 
-    if (data_len < op_data->data_len + sizeof(OP_STATE_DATA)) {
+    /*
+     * Validate the new state information. Don't touch the session
+     * until the new state is valid.
+     */
+    cur_data = data;
+    cur_data_len = data_len;
+    while (cur_data_len >= sizeof(OP_STATE_DATA)) {
+        op_data = (OP_STATE_DATA *)cur_data;
+
+        if (cur_data_len < op_data->data_len + sizeof(OP_STATE_DATA)) {
+            TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
+            return CKR_SAVED_STATE_INVALID;
+        }
+
+        /*
+         * Make sure the session states are compatible: same OCK version,
+         * same token model, same session state.
+         */
+#ifdef PACKAGE_VERSION
+        if (strncmp((char *)op_data->library_version, PACKAGE_VERSION,
+                sizeof(op_data->library_version)) != 0) {
+            TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
+            return CKR_SAVED_STATE_INVALID;
+        }
+#endif
+        if (memcmp(op_data->manufacturerID,
+                   tokdata->nv_token_data->token_info.manufacturerID,
+                   sizeof(op_data->manufacturerID)) != 0 ||
+            memcmp(op_data->model, tokdata->nv_token_data->token_info.model,
+                   sizeof(op_data->model)) != 0) {
+            TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
+            return CKR_SAVED_STATE_INVALID;
+        }
+        if (sess->session_info.state != op_data->session_state) {
+            TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
+            return CKR_SAVED_STATE_INVALID;
+        }
+
+        switch (op_data->active_operation) {
+        case STATE_ENCR:
+        case STATE_DECR:
+            {
+                ENCR_DECR_CONTEXT *ctx =
+                    (ENCR_DECR_CONTEXT *)(cur_data + sizeof(OP_STATE_DATA));
+
+                len = sizeof(ENCR_DECR_CONTEXT) + ctx->context_len +
+                                                ctx->mech.ulParameterLen;
+                if (len != op_data->data_len) {
+                    TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
+                    return CKR_SAVED_STATE_INVALID;
+                }
+
+                encr_key_needed++;
+            }
+            break;
+
+        case STATE_SIGN:
+        case STATE_VERIFY:
+            {
+                SIGN_VERIFY_CONTEXT *ctx =
+                    (SIGN_VERIFY_CONTEXT *)(cur_data + sizeof(OP_STATE_DATA));
+
+                len = sizeof(SIGN_VERIFY_CONTEXT) + ctx->context_len +
+                                                ctx->mech.ulParameterLen;
+                if (len != op_data->data_len) {
+                    TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
+                    return CKR_SAVED_STATE_INVALID;
+                }
+
+                auth_key_needed++;
+            }
+            break;
+
+        case STATE_DIGEST:
+            {
+                DIGEST_CONTEXT *ctx =
+                    (DIGEST_CONTEXT *) (cur_data + sizeof(OP_STATE_DATA));
+
+                len = sizeof(DIGEST_CONTEXT) + ctx->context_len +
+                                                ctx->mech.ulParameterLen;
+                if (len != op_data->data_len) {
+                    TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
+                    return CKR_SAVED_STATE_INVALID;
+                }
+            }
+            break;
+        default:
+            TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
+            return CKR_SAVED_STATE_INVALID;
+        }
+
+        /* move on to next operation */
+        cur_data_len -= (op_data->data_len + sizeof(OP_STATE_DATA));
+        cur_data += (op_data->data_len + sizeof(OP_STATE_DATA));
+    }
+    /* nothing must be left over */
+    if (cur_data_len > 0) {
         TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
         return CKR_SAVED_STATE_INVALID;
     }
 
-    // make sure the session states are compatible
-    //
-    if (sess->session_info.state != op_data->session_state) {
-        TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
-        return CKR_SAVED_STATE_INVALID;
+    if (encr_key_needed > 0 && encr_key == CK_INVALID_HANDLE) {
+        TRACE_ERROR("%s\n", ock_err(ERR_KEY_NEEDED));
+        return CKR_KEY_NEEDED;
     }
-    // validate the new state information.  don't touch the session
-    // until the new state is valid.
-    //
-    switch (op_data->active_operation) {
-    case STATE_ENCR:
-    case STATE_DECR:
-        {
-            ENCR_DECR_CONTEXT *ctx =
-                (ENCR_DECR_CONTEXT *) (data + sizeof(OP_STATE_DATA));
-
-            len =
-                sizeof(ENCR_DECR_CONTEXT) + ctx->context_len +
-                ctx->mech.ulParameterLen;
-            if (len != op_data->data_len) {
-                TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
-                return CKR_SAVED_STATE_INVALID;
-            }
-            if (auth_key != CK_INVALID_HANDLE) {
-                TRACE_ERROR("%s\n", ock_err(ERR_KEY_NOT_NEEDED));
-                return CKR_KEY_NOT_NEEDED;
-            }
-            if (encr_key == CK_INVALID_HANDLE) {
-                TRACE_ERROR("%s\n", ock_err(ERR_KEY_NEEDED));
-                return CKR_KEY_NEEDED;
-            }
-            ptr1 = (CK_BYTE *) ctx;
-            ptr2 = ptr1 + sizeof(ENCR_DECR_CONTEXT);
-            ptr3 = ptr2 + ctx->context_len;
-
-            if (ctx->context_len) {
-                context = (CK_BYTE *) malloc(ctx->context_len);
-                if (!context) {
-                    TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
-                    return CKR_HOST_MEMORY;
-                }
-                memcpy(context, ptr2, ctx->context_len);
-            }
-
-            if (ctx->mech.ulParameterLen) {
-                mech_param = (CK_BYTE *) malloc(ctx->mech.ulParameterLen);
-                if (!mech_param) {
-                    if (context)
-                        free(context);
-                    TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
-                    return CKR_HOST_MEMORY;
-                }
-                memcpy(mech_param, ptr3, ctx->mech.ulParameterLen);
-            }
-        }
-        break;
-    case STATE_SIGN:
-    case STATE_VERIFY:
-        {
-            SIGN_VERIFY_CONTEXT *ctx =
-                (SIGN_VERIFY_CONTEXT *) (data + sizeof(OP_STATE_DATA));
-
-            len =
-                sizeof(SIGN_VERIFY_CONTEXT) + ctx->context_len +
-                ctx->mech.ulParameterLen;
-            if (len != op_data->data_len) {
-                TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
-                return CKR_SAVED_STATE_INVALID;
-            }
-            if (auth_key == CK_INVALID_HANDLE) {
-                TRACE_ERROR("%s\n", ock_err(ERR_KEY_NEEDED));
-                return CKR_KEY_NEEDED;
-            }
-            if (encr_key != CK_INVALID_HANDLE) {
-                TRACE_ERROR("%s\n", ock_err(ERR_KEY_NOT_NEEDED));
-                return CKR_KEY_NOT_NEEDED;
-            }
-            ptr1 = (CK_BYTE *) ctx;
-            ptr2 = ptr1 + sizeof(SIGN_VERIFY_CONTEXT);
-            ptr3 = ptr2 + ctx->context_len;
-
-            if (ctx->context_len) {
-                context = (CK_BYTE *) malloc(ctx->context_len);
-                if (!context) {
-                    TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
-                    return CKR_HOST_MEMORY;
-                }
-                memcpy(context, ptr2, ctx->context_len);
-            }
-
-            if (ctx->mech.ulParameterLen) {
-                mech_param = (CK_BYTE *) malloc(ctx->mech.ulParameterLen);
-                if (!mech_param) {
-                    if (context)
-                        free(context);
-                    TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
-                    return CKR_HOST_MEMORY;
-                }
-                memcpy(mech_param, ptr3, ctx->mech.ulParameterLen);
-            }
-        }
-        break;
-    case STATE_DIGEST:
-        {
-            DIGEST_CONTEXT *ctx =
-                (DIGEST_CONTEXT *) (data + sizeof(OP_STATE_DATA));
-
-            len =
-                sizeof(DIGEST_CONTEXT) + ctx->context_len +
-                ctx->mech.ulParameterLen;
-            if (len != op_data->data_len) {
-                TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
-                return CKR_SAVED_STATE_INVALID;
-            }
-            if (auth_key != CK_INVALID_HANDLE) {
-                TRACE_ERROR("%s\n", ock_err(ERR_KEY_NOT_NEEDED));
-                return CKR_KEY_NOT_NEEDED;
-            }
-            if (encr_key != CK_INVALID_HANDLE) {
-                TRACE_ERROR("%s\n", ock_err(ERR_KEY_NOT_NEEDED));
-                return CKR_KEY_NOT_NEEDED;
-            }
-            ptr1 = (CK_BYTE *) ctx;
-            ptr2 = ptr1 + sizeof(DIGEST_CONTEXT);
-            ptr3 = ptr2 + ctx->context_len;
-
-            if (ctx->context_len) {
-                context = (CK_BYTE *) malloc(ctx->context_len);
-                if (!context) {
-                    TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
-                    return CKR_HOST_MEMORY;
-                }
-                memcpy(context, ptr2, ctx->context_len);
-            }
-
-            if (ctx->mech.ulParameterLen) {
-                mech_param = (CK_BYTE *) malloc(ctx->mech.ulParameterLen);
-                if (!mech_param) {
-                    if (context)
-                        free(context);
-                    TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
-                    return CKR_HOST_MEMORY;
-                }
-                memcpy(mech_param, ptr3, ctx->mech.ulParameterLen);
-            }
-        }
-        break;
-    default:
-        TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
-        return CKR_SAVED_STATE_INVALID;
+    if (encr_key_needed == 0 && encr_key != CK_INVALID_HANDLE) {
+        TRACE_ERROR("%s\n", ock_err(ERR_KEY_NOT_NEEDED));
+        return CKR_KEY_NOT_NEEDED;
+    }
+    if (auth_key_needed > 0 && auth_key == CK_INVALID_HANDLE) {
+        TRACE_ERROR("%s\n", ock_err(ERR_KEY_NEEDED));
+        return CKR_KEY_NEEDED;
+    }
+    if (auth_key_needed == 0 && auth_key != CK_INVALID_HANDLE) {
+        TRACE_ERROR("%s\n", ock_err(ERR_KEY_NOT_NEEDED));
+        return CKR_KEY_NOT_NEEDED;
     }
 
-
-    // state information looks okay.  cleanup the current session state, first
-    //
+    /* State information looks okay. Cleanup the current session state, first */
     if (sess->encr_ctx.active)
         encr_mgr_cleanup(tokdata, sess, &sess->encr_ctx);
-
     if (sess->decr_ctx.active)
         decr_mgr_cleanup(tokdata, sess, &sess->decr_ctx);
-
     if (sess->digest_ctx.active)
         digest_mgr_cleanup(tokdata, sess, &sess->digest_ctx);
-
     if (sess->sign_ctx.active)
         sign_mgr_cleanup(tokdata, sess, &sess->sign_ctx);
-
     if (sess->verify_ctx.active)
         verify_mgr_cleanup(tokdata, sess, &sess->verify_ctx);
 
+    /* Now process the saved operation states */
+    cur_data = data;
+    cur_data_len = data_len;
+    while (cur_data_len >= sizeof(OP_STATE_DATA)) {
+        op_data = (OP_STATE_DATA *)cur_data;
 
-    // copy the new state information
-    //
-    switch (op_data->active_operation) {
-    case STATE_ENCR:
-        memcpy(&sess->encr_ctx, ptr1, sizeof(ENCR_DECR_CONTEXT));
+        if (cur_data_len < op_data->data_len + sizeof(OP_STATE_DATA)) {
+            TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
+            return CKR_SAVED_STATE_INVALID;
+        }
 
-        sess->encr_ctx.key = encr_key;
-        sess->encr_ctx.context = context;
-        sess->encr_ctx.mech.pParameter = mech_param;
-        break;
-    case STATE_DECR:
-        memcpy(&sess->decr_ctx, ptr1, sizeof(ENCR_DECR_CONTEXT));
+        switch (op_data->active_operation) {
+        case STATE_ENCR:
+        case STATE_DECR:
+            {
+                ENCR_DECR_CONTEXT *ctx =
+                    (ENCR_DECR_CONTEXT *)(cur_data + sizeof(OP_STATE_DATA));
 
-        sess->decr_ctx.key = encr_key;
-        sess->decr_ctx.context = context;
-        sess->decr_ctx.mech.pParameter = mech_param;
-        break;
-    case STATE_SIGN:
-        memcpy(&sess->sign_ctx, ptr1, sizeof(SIGN_VERIFY_CONTEXT));
+                len = sizeof(ENCR_DECR_CONTEXT) + ctx->context_len +
+                                                ctx->mech.ulParameterLen;
+                if (len != op_data->data_len) {
+                    TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
+                    return CKR_SAVED_STATE_INVALID;
+                }
+                if (encr_key == CK_INVALID_HANDLE) {
+                    TRACE_ERROR("%s\n", ock_err(ERR_KEY_NEEDED));
+                    return CKR_KEY_NEEDED;
+                }
+                ptr1 = (CK_BYTE *) ctx;
+                ptr2 = ptr1 + sizeof(ENCR_DECR_CONTEXT);
+                ptr3 = ptr2 + ctx->context_len;
 
-        sess->sign_ctx.key = auth_key;
-        sess->sign_ctx.context = context;
-        sess->sign_ctx.mech.pParameter = mech_param;
-        break;
-    case STATE_VERIFY:
-        memcpy(&sess->verify_ctx, ptr1, sizeof(SIGN_VERIFY_CONTEXT));
+                if (ctx->context_len) {
+                    context = (CK_BYTE *) malloc(ctx->context_len);
+                    if (!context) {
+                        TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
+                        return CKR_HOST_MEMORY;
+                    }
+                    memcpy(context, ptr2, ctx->context_len);
+                }
 
-        sess->verify_ctx.key = auth_key;
-        sess->verify_ctx.context = context;
-        sess->verify_ctx.mech.pParameter = mech_param;
-        break;
-    case STATE_DIGEST:
-        memcpy(&sess->digest_ctx, ptr1, sizeof(DIGEST_CONTEXT));
+                if (ctx->mech.ulParameterLen) {
+                    mech_param = (CK_BYTE *) malloc(ctx->mech.ulParameterLen);
+                    if (!mech_param) {
+                        if (context)
+                            free(context);
+                        TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
+                        return CKR_HOST_MEMORY;
+                    }
+                    memcpy(mech_param, ptr3, ctx->mech.ulParameterLen);
+                }
+            }
+            break;
 
-        sess->digest_ctx.context = context;
-        sess->digest_ctx.mech.pParameter = mech_param;
-        break;
+        case STATE_SIGN:
+        case STATE_VERIFY:
+            {
+                SIGN_VERIFY_CONTEXT *ctx =
+                    (SIGN_VERIFY_CONTEXT *)(cur_data + sizeof(OP_STATE_DATA));
+
+                len = sizeof(SIGN_VERIFY_CONTEXT) + ctx->context_len +
+                                                    ctx->mech.ulParameterLen;
+                if (len != op_data->data_len) {
+                    TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
+                    return CKR_SAVED_STATE_INVALID;
+                }
+                if (auth_key == CK_INVALID_HANDLE) {
+                    TRACE_ERROR("%s\n", ock_err(ERR_KEY_NEEDED));
+                    return CKR_KEY_NEEDED;
+                }
+                ptr1 = (CK_BYTE *) ctx;
+                ptr2 = ptr1 + sizeof(SIGN_VERIFY_CONTEXT);
+                ptr3 = ptr2 + ctx->context_len;
+
+                if (ctx->context_len) {
+                    context = (CK_BYTE *) malloc(ctx->context_len);
+                    if (!context) {
+                        TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
+                        return CKR_HOST_MEMORY;
+                    }
+                    memcpy(context, ptr2, ctx->context_len);
+                }
+
+                if (ctx->mech.ulParameterLen) {
+                    mech_param = (CK_BYTE *) malloc(ctx->mech.ulParameterLen);
+                    if (!mech_param) {
+                        if (context)
+                            free(context);
+                        TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
+                        return CKR_HOST_MEMORY;
+                    }
+                    memcpy(mech_param, ptr3, ctx->mech.ulParameterLen);
+                }
+            }
+            break;
+
+        case STATE_DIGEST:
+            {
+                DIGEST_CONTEXT *ctx =
+                    (DIGEST_CONTEXT *)(cur_data + sizeof(OP_STATE_DATA));
+
+                len = sizeof(DIGEST_CONTEXT) + ctx->context_len +
+                                                ctx->mech.ulParameterLen;
+                if (len != op_data->data_len) {
+                    TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
+                    return CKR_SAVED_STATE_INVALID;
+                }
+                ptr1 = (CK_BYTE *) ctx;
+                ptr2 = ptr1 + sizeof(DIGEST_CONTEXT);
+                ptr3 = ptr2 + ctx->context_len;
+
+                if (ctx->context_len) {
+                    context = (CK_BYTE *) malloc(ctx->context_len);
+                    if (!context) {
+                        TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
+                        return CKR_HOST_MEMORY;
+                    }
+                    memcpy(context, ptr2, ctx->context_len);
+                }
+
+                if (ctx->mech.ulParameterLen) {
+                    mech_param = (CK_BYTE *) malloc(ctx->mech.ulParameterLen);
+                    if (!mech_param) {
+                        if (context)
+                            free(context);
+                        TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
+                        return CKR_HOST_MEMORY;
+                    }
+                    memcpy(mech_param, ptr3, ctx->mech.ulParameterLen);
+                }
+            }
+            break;
+        default:
+            TRACE_ERROR("%s\n", ock_err(ERR_SAVED_STATE_INVALID));
+            return CKR_SAVED_STATE_INVALID;
+        }
+
+        /* copy the new state information */
+        switch (op_data->active_operation) {
+        case STATE_ENCR:
+            memcpy(&sess->encr_ctx, ptr1, sizeof(ENCR_DECR_CONTEXT));
+
+            sess->encr_ctx.key = encr_key;
+            sess->encr_ctx.context = context;
+            sess->encr_ctx.mech.pParameter = mech_param;
+            break;
+
+        case STATE_DECR:
+            memcpy(&sess->decr_ctx, ptr1, sizeof(ENCR_DECR_CONTEXT));
+
+            sess->decr_ctx.key = encr_key;
+            sess->decr_ctx.context = context;
+            sess->decr_ctx.mech.pParameter = mech_param;
+            break;
+
+        case STATE_SIGN:
+            memcpy(&sess->sign_ctx, ptr1, sizeof(SIGN_VERIFY_CONTEXT));
+
+            sess->sign_ctx.key = auth_key;
+            sess->sign_ctx.context = context;
+            sess->sign_ctx.mech.pParameter = mech_param;
+            break;
+
+        case STATE_VERIFY:
+            memcpy(&sess->verify_ctx, ptr1, sizeof(SIGN_VERIFY_CONTEXT));
+
+            sess->verify_ctx.key = auth_key;
+            sess->verify_ctx.context = context;
+            sess->verify_ctx.mech.pParameter = mech_param;
+            break;
+
+        case STATE_DIGEST:
+            memcpy(&sess->digest_ctx, ptr1, sizeof(DIGEST_CONTEXT));
+
+            sess->digest_ctx.context = context;
+            sess->digest_ctx.mech.pParameter = mech_param;
+            break;
+        }
+
+        context = NULL;
+        mech_param = NULL;
+
+        /* move on to next operation */
+        cur_data_len -= (op_data->data_len + sizeof(OP_STATE_DATA));
+        cur_data += (op_data->data_len + sizeof(OP_STATE_DATA));
     }
 
     return CKR_OK;

--- a/usr/lib/ep11_stdll/new_host.c
+++ b/usr/lib/ep11_stdll/new_host.c
@@ -3611,20 +3611,17 @@ CK_RV SC_DigestEncryptUpdate(STDLL_TokData_t *tokdata,
                              CK_ULONG ulPartLen, CK_BYTE_PTR pEncryptedPart,
                              CK_ULONG_PTR pulEncryptedPartLen)
 {
-    UNUSED(sSession);
-    UNUSED(pPart);
-    UNUSED(ulPartLen);
-    UNUSED(pEncryptedPart);
-    UNUSED(pulEncryptedPartLen);
+    CK_RV rc;
 
-    if (tokdata->initialized == FALSE) {
-        TRACE_ERROR("%s\n", ock_err(ERR_CRYPTOKI_NOT_INITIALIZED));
-        return CKR_CRYPTOKI_NOT_INITIALIZED;
-    }
+    rc = SC_EncryptUpdate(tokdata, sSession, pPart, ulPartLen,
+                          pEncryptedPart, pulEncryptedPartLen);
+    if (rc != CKR_OK || pEncryptedPart == NULL)
+        goto out;
 
-    TRACE_ERROR("%s\n", ock_err(ERR_FUNCTION_NOT_SUPPORTED));
+    rc = SC_DigestUpdate(tokdata, sSession, pPart, ulPartLen);
 
-    return CKR_FUNCTION_NOT_SUPPORTED;
+out:
+    return rc;
 }
 
 
@@ -3634,20 +3631,17 @@ CK_RV SC_DecryptDigestUpdate(STDLL_TokData_t *tokdata,
                              CK_ULONG ulEncryptedPartLen, CK_BYTE_PTR pPart,
                              CK_ULONG_PTR pulPartLen)
 {
-    UNUSED(sSession);
-    UNUSED(pEncryptedPart);
-    UNUSED(ulEncryptedPartLen);
-    UNUSED(pPart);
-    UNUSED(pulPartLen);
+    CK_RV rc;
 
-    if (tokdata->initialized == FALSE) {
-        TRACE_ERROR("%s\n", ock_err(ERR_CRYPTOKI_NOT_INITIALIZED));
-        return CKR_CRYPTOKI_NOT_INITIALIZED;
-    }
+    rc = SC_DecryptUpdate(tokdata, sSession, pEncryptedPart,
+                          ulEncryptedPartLen, pPart, pulPartLen);
+    if (rc != CKR_OK || pPart == NULL)
+        goto out;
 
-    TRACE_ERROR("%s\n", ock_err(ERR_FUNCTION_NOT_SUPPORTED));
+    rc = SC_DigestUpdate(tokdata, sSession, pPart, *pulPartLen);
 
-    return CKR_FUNCTION_NOT_SUPPORTED;
+out:
+    return rc;
 }
 
 
@@ -3656,22 +3650,18 @@ CK_RV SC_SignEncryptUpdate(STDLL_TokData_t *tokdata,
                            CK_ULONG ulPartLen, CK_BYTE_PTR pEncryptedPart,
                            CK_ULONG_PTR pulEncryptedPartLen)
 {
-    UNUSED(sSession);
-    UNUSED(pPart);
-    UNUSED(ulPartLen);
-    UNUSED(pEncryptedPart);
-    UNUSED(pulEncryptedPartLen);
+    CK_RV rc;
 
-    if (tokdata->initialized == FALSE) {
-        TRACE_ERROR("%s\n", ock_err(ERR_CRYPTOKI_NOT_INITIALIZED));
-        return CKR_CRYPTOKI_NOT_INITIALIZED;
-    }
+    rc = SC_EncryptUpdate(tokdata, sSession, pPart, ulPartLen,
+                          pEncryptedPart, pulEncryptedPartLen);
+    if (rc != CKR_OK || pEncryptedPart == NULL)
+        goto out;
 
-    TRACE_ERROR("%s\n", ock_err(ERR_FUNCTION_NOT_SUPPORTED));
+    rc = SC_SignUpdate(tokdata, sSession, pPart, ulPartLen);
 
-    return CKR_FUNCTION_NOT_SUPPORTED;
+out:
+    return rc;
 }
-
 
 CK_RV SC_DecryptVerifyUpdate(STDLL_TokData_t *tokdata,
                              ST_SESSION_HANDLE *sSession,
@@ -3679,20 +3669,17 @@ CK_RV SC_DecryptVerifyUpdate(STDLL_TokData_t *tokdata,
                              CK_ULONG ulEncryptedPartLen, CK_BYTE_PTR pPart,
                              CK_ULONG_PTR pulPartLen)
 {
-    UNUSED(sSession);
-    UNUSED(pEncryptedPart);
-    UNUSED(ulEncryptedPartLen);
-    UNUSED(pPart);
-    UNUSED(pulPartLen);
+    CK_RV rc;
 
-    if (tokdata->initialized == FALSE) {
-        TRACE_ERROR("%s\n", ock_err(ERR_CRYPTOKI_NOT_INITIALIZED));
-        return CKR_CRYPTOKI_NOT_INITIALIZED;
-    }
+    rc = SC_DecryptUpdate(tokdata, sSession, pEncryptedPart,
+                          ulEncryptedPartLen, pPart, pulPartLen);
+    if (rc != CKR_OK || pPart == NULL)
+        goto out;
 
-    TRACE_ERROR("%s\n", ock_err(ERR_FUNCTION_NOT_SUPPORTED));
+    rc = SC_VerifyUpdate(tokdata, sSession, pPart, *pulPartLen);
 
-    return CKR_FUNCTION_NOT_SUPPORTED;
+out:
+    return rc;
 }
 
 
@@ -4336,10 +4323,10 @@ void SC_SetFunctionList(void)
     function_list.ST_VerifyFinal = SC_VerifyFinal;
     function_list.ST_VerifyRecoverInit = SC_VerifyRecoverInit;
     function_list.ST_VerifyRecover = SC_VerifyRecover;
-    function_list.ST_DigestEncryptUpdate = NULL;      // SC_DigestEncryptUpdate;
-    function_list.ST_DecryptDigestUpdate = NULL;      // SC_DecryptDigestUpdate;
-    function_list.ST_SignEncryptUpdate = NULL;  //SC_SignEncryptUpdate;
-    function_list.ST_DecryptVerifyUpdate = NULL;      // SC_DecryptVerifyUpdate;
+    function_list.ST_DigestEncryptUpdate = SC_DigestEncryptUpdate;
+    function_list.ST_DecryptDigestUpdate = SC_DecryptDigestUpdate;
+    function_list.ST_SignEncryptUpdate = SC_SignEncryptUpdate;
+    function_list.ST_DecryptVerifyUpdate = SC_DecryptVerifyUpdate;
     function_list.ST_GenerateKey = SC_GenerateKey;
     function_list.ST_GenerateKeyPair = SC_GenerateKeyPair;
     function_list.ST_WrapKey = SC_WrapKey;

--- a/usr/lib/ep11_stdll/new_host.c
+++ b/usr/lib/ep11_stdll/new_host.c
@@ -1150,7 +1150,7 @@ CK_RV SC_GetOperationState(STDLL_TokData_t *tokdata,
         goto done;
     }
 
-    rc = session_mgr_get_op_state(sess, length_only, pOperationState,
+    rc = session_mgr_get_op_state(tokdata, sess, length_only, pOperationState,
                                   pulOperationStateLen);
     if (rc != CKR_OK)
         TRACE_DEVEL("session_mgr_get_op_state() failed.\n");

--- a/usr/lib/icsf_stdll/new_host.c
+++ b/usr/lib/icsf_stdll/new_host.c
@@ -702,7 +702,7 @@ CK_RV SC_GetOperationState(STDLL_TokData_t *tokdata,
     //set the handle into the session.
     sess->handle = sSession->sessionh;
 
-    rc = session_mgr_get_op_state(sess, length_only, pOperationState,
+    rc = session_mgr_get_op_state(tokdata, sess, length_only, pOperationState,
                                   pulOperationStateLen);
     if (rc != CKR_OK)
         TRACE_DEVEL("session_mgr_get_op_state() failed.\n");

--- a/usr/lib/icsf_stdll/new_host.c
+++ b/usr/lib/icsf_stdll/new_host.c
@@ -2655,20 +2655,17 @@ CK_RV SC_DigestEncryptUpdate(STDLL_TokData_t *tokdata,
                              CK_ULONG ulPartLen, CK_BYTE_PTR pEncryptedPart,
                              CK_ULONG_PTR pulEncryptedPartLen)
 {
-    UNUSED(sSession);
-    UNUSED(pPart);
-    UNUSED(ulPartLen);
-    UNUSED(pEncryptedPart);
-    UNUSED(pulEncryptedPartLen);
+    CK_RV rc;
 
-    if (tokdata->initialized == FALSE) {
-        TRACE_ERROR("%s\n", ock_err(ERR_CRYPTOKI_NOT_INITIALIZED));
-        return CKR_CRYPTOKI_NOT_INITIALIZED;
-    }
+    rc = SC_EncryptUpdate(tokdata, sSession, pPart, ulPartLen,
+                          pEncryptedPart, pulEncryptedPartLen);
+    if (rc != CKR_OK || pEncryptedPart == NULL)
+        goto out;
 
-    TRACE_ERROR("%s\n", ock_err(ERR_FUNCTION_NOT_SUPPORTED));
+    rc = SC_DigestUpdate(tokdata, sSession, pPart, ulPartLen);
 
-    return CKR_FUNCTION_NOT_SUPPORTED;
+out:
+    return rc;
 }
 
 
@@ -2678,20 +2675,17 @@ CK_RV SC_DecryptDigestUpdate(STDLL_TokData_t *tokdata,
                              CK_ULONG ulEncryptedPartLen, CK_BYTE_PTR pPart,
                              CK_ULONG_PTR pulPartLen)
 {
-    UNUSED(sSession);
-    UNUSED(pEncryptedPart);
-    UNUSED(ulEncryptedPartLen);
-    UNUSED(pPart);
-    UNUSED(pulPartLen);
+    CK_RV rc;
 
-    if (tokdata->initialized == FALSE) {
-        TRACE_ERROR("%s\n", ock_err(ERR_CRYPTOKI_NOT_INITIALIZED));
-        return CKR_CRYPTOKI_NOT_INITIALIZED;
-    }
+    rc = SC_DecryptUpdate(tokdata, sSession, pEncryptedPart,
+                          ulEncryptedPartLen, pPart, pulPartLen);
+    if (rc != CKR_OK || pPart == NULL)
+        goto out;
 
-    TRACE_ERROR("%s\n", ock_err(ERR_FUNCTION_NOT_SUPPORTED));
+    rc = SC_DigestUpdate(tokdata, sSession, pPart, *pulPartLen);
 
-    return CKR_FUNCTION_NOT_SUPPORTED;
+out:
+    return rc;
 }
 
 
@@ -2700,22 +2694,18 @@ CK_RV SC_SignEncryptUpdate(STDLL_TokData_t *tokdata,
                            CK_ULONG ulPartLen, CK_BYTE_PTR pEncryptedPart,
                            CK_ULONG_PTR pulEncryptedPartLen)
 {
-    UNUSED(sSession);
-    UNUSED(pPart);
-    UNUSED(ulPartLen);
-    UNUSED(pEncryptedPart);
-    UNUSED(pulEncryptedPartLen);
+    CK_RV rc;
 
-    if (tokdata->initialized == FALSE) {
-        TRACE_ERROR("%s\n", ock_err(ERR_CRYPTOKI_NOT_INITIALIZED));
-        return CKR_CRYPTOKI_NOT_INITIALIZED;
-    }
+    rc = SC_EncryptUpdate(tokdata, sSession, pPart, ulPartLen,
+                          pEncryptedPart, pulEncryptedPartLen);
+    if (rc != CKR_OK || pEncryptedPart == NULL)
+        goto out;
 
-    TRACE_ERROR("%s\n", ock_err(ERR_FUNCTION_NOT_SUPPORTED));
+    rc = SC_SignUpdate(tokdata, sSession, pPart, ulPartLen);
 
-    return CKR_FUNCTION_NOT_SUPPORTED;
+out:
+    return rc;
 }
-
 
 CK_RV SC_DecryptVerifyUpdate(STDLL_TokData_t *tokdata,
                              ST_SESSION_HANDLE *sSession,
@@ -2723,20 +2713,17 @@ CK_RV SC_DecryptVerifyUpdate(STDLL_TokData_t *tokdata,
                              CK_ULONG ulEncryptedPartLen, CK_BYTE_PTR pPart,
                              CK_ULONG_PTR pulPartLen)
 {
-    UNUSED(sSession);
-    UNUSED(pEncryptedPart);
-    UNUSED(ulEncryptedPartLen);
-    UNUSED(pPart);
-    UNUSED(pulPartLen);
+    CK_RV rc;
 
-    if (tokdata->initialized == FALSE) {
-        TRACE_ERROR("%s\n", ock_err(ERR_CRYPTOKI_NOT_INITIALIZED));
-        return CKR_CRYPTOKI_NOT_INITIALIZED;
-    }
+    rc = SC_DecryptUpdate(tokdata, sSession, pEncryptedPart,
+                          ulEncryptedPartLen, pPart, pulPartLen);
+    if (rc != CKR_OK || pPart == NULL)
+        goto out;
 
-    TRACE_ERROR("%s\n", ock_err(ERR_FUNCTION_NOT_SUPPORTED));
+    rc = SC_VerifyUpdate(tokdata, sSession, pPart, *pulPartLen);
 
-    return CKR_FUNCTION_NOT_SUPPORTED;
+out:
+    return rc;
 }
 
 
@@ -3391,10 +3378,10 @@ void SC_SetFunctionList(void)
     function_list.ST_VerifyFinal = SC_VerifyFinal;
     function_list.ST_VerifyRecoverInit = SC_VerifyRecoverInit;
     function_list.ST_VerifyRecover = SC_VerifyRecover;
-    function_list.ST_DigestEncryptUpdate = NULL;      // SC_DigestEncryptUpdate;
-    function_list.ST_DecryptDigestUpdate = NULL;      // SC_DecryptDigestUpdate;
-    function_list.ST_SignEncryptUpdate = NULL;  //SC_SignEncryptUpdate;
-    function_list.ST_DecryptVerifyUpdate = NULL;      // SC_DecryptVerifyUpdate;
+    function_list.ST_DigestEncryptUpdate = SC_DigestEncryptUpdate;
+    function_list.ST_DecryptDigestUpdate = SC_DecryptDigestUpdate;
+    function_list.ST_SignEncryptUpdate = SC_SignEncryptUpdate;
+    function_list.ST_DecryptVerifyUpdate = SC_DecryptVerifyUpdate;
     function_list.ST_GenerateKey = SC_GenerateKey;
     function_list.ST_GenerateKeyPair = SC_GenerateKeyPair;
     function_list.ST_WrapKey = SC_WrapKey;


### PR DESCRIPTION
- Add support for functions C_DigestEncryptUpdate, C_DecryptDigestUpdate,
C_SignEncryptUpdate, and C_DecryptVerifyUpdate
- Fix C_Get/SetOperationState with multiple operations active
- Add a testcase for dual-function cryptographic functions

FYI: 
- For the first patch you only need to review one of the new_host.c file updates. The changes in the other 2 new_host.c files are exactly the same.
- For the second patch you only need to review the changes in lock_sess_mgr.c, the updates in sess_mgr.c are exactly the same.
- These semi-duplicated files are required because the files are not 100% the same, but the places where the updates of these commits are done are 100% the same.

