### PR TITLE
doc: Document that 'make prefix=/foo/bar' or similar is not supported

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -96,6 +96,11 @@ find the X include and library files automatically, but if it doesn't,
 you can use the `configure' options `--x-includes=DIR' and
 `--x-libraries=DIR' to specify their locations.
 
+   Note: Do not specify 'prefix=/foo/bar', 'libdir=/foo/bar' with
+the 'make' invocation. Specify them with 'configure' instead. Specifying
+them with 'make' is not supported by the openCryptoki package and may
+produce unexpected results!
+
 Specifying the System Type
 ==========================
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ directory and do the following:
 ```
     $ make
 ```
+   **Note:** Do not specify `prefix=/foo/bar`, `libdir=/foo/bar` with
+   the `make` invocation. Specify them with `configure` instead. Specifying
+   them with `make` is not supported by the openCryptoki package and may
+   produce unexpected results!
 
 4. openCryptoki defaults to be usable by anyone who is in the group ``pkcs11``.
 Add the pkcs11 group before installing it, by typing as root the command:


### PR DESCRIPTION
Variables like 'prefix', 'libdir', or similar should not be specified with 'make', but should be specified with 'configure' instead. Specifying them with 'make' is not supported by the openCryptoki package and may produce unexpected results!

Suggested-by: @juergenchrist 