### PR TITLE
Supply useful information in CK_TOKEN_INFO.ulRwSessionCount

### DIFF
--- a/usr/include/slotmgr.h
+++ b/usr/include/slotmgr.h
@@ -169,11 +169,12 @@ typedef struct Slot_Mgr_Proc_t_64 {
                                  * sleeping on the condition variable to wakeup.
                                  */
     uint32 slot_session_count[NUMBER_SLOTS_MANAGED];    /* Per process session
-                                                         * count for garbage
+                                                         * counts for garbage
                                                          * collection clean up
                                                          * of the global
                                                          * session count.
                                                          */
+    uint32 slot_rw_session_count[NUMBER_SLOTS_MANAGED];
     time_t_64 reg_time;         // Time application registered
 } Slot_Mgr_Proc_t_64;
 
@@ -201,6 +202,7 @@ typedef struct {
 
     /* Information that the API calls will use. */
     uint32 slot_global_sessions[NUMBER_SLOTS_MANAGED];
+    uint32 slot_global_rw_sessions[NUMBER_SLOTS_MANAGED];
     Slot_Mgr_Proc_t_64 proc_table[NUMBER_PROCESSES_ALLOWED];
 } Slot_Mgr_Shr_t;
 

--- a/usr/include/stdll.h
+++ b/usr/include/stdll.h
@@ -29,6 +29,7 @@ typedef struct {
     struct bt_ref_hdr hdr;
     CK_SLOT_ID slotID;
     CK_SESSION_HANDLE sessionh;
+    CK_BBOOL rw_session;
 } ST_SESSION_T;
 
 typedef struct trace_handle_t trace_handle;

--- a/usr/lib/api/apiproto.h
+++ b/usr/lib/api/apiproto.h
@@ -39,9 +39,9 @@ CK_RV ProcUnLock(void);
 CK_RV ProcClose(void);
 
 void _init(void);
-void get_sess_count(CK_SLOT_ID, CK_ULONG *);
-void incr_sess_counts(CK_SLOT_ID);
-void decr_sess_counts(CK_SLOT_ID);
+void get_sess_counts(CK_SLOT_ID, CK_ULONG *, CK_ULONG *);
+void incr_sess_counts(CK_SLOT_ID, CK_BBOOL rw_session);
+void decr_sess_counts(CK_SLOT_ID, CK_BBOOL rw_session);
 unsigned long AddToSessionList(ST_SESSION_T *);
 void RemoveFromSessionList(CK_SESSION_HANDLE);
 int Valid_Session(CK_SESSION_HANDLE, ST_SESSION_T *);

--- a/usr/lib/common/utility.c
+++ b/usr/lib/common/utility.c
@@ -871,6 +871,6 @@ void copy_token_contents_sensibly(CK_TOKEN_INFO_PTR pInfo,
     pInfo->ulMaxSessionCount = CK_EFFECTIVELY_INFINITE;
     /* pInfo->ulSessionCount is set at the API level */
     pInfo->ulMaxRwSessionCount = CK_EFFECTIVELY_INFINITE;
-    pInfo->ulRwSessionCount = CK_UNAVAILABLE_INFORMATION;
+    /* pInfo->ulRwSessionCount is set at the API level */
 }
 

--- a/usr/sbin/pkcsslotd/garbage_linux.c
+++ b/usr/sbin/pkcsslotd/garbage_linux.c
@@ -319,8 +319,12 @@ BOOL CheckForGarbage(Slot_Mgr_Shr_t *MemPtr)
 
                 unsigned int *pGlobalSessions =
                     &(MemPtr->slot_global_sessions[SlotIndex]);
+                unsigned int *pGlobalRWSessions =
+                    &(MemPtr->slot_global_rw_sessions[SlotIndex]);
                 unsigned int *pProcSessions =
                     &(pProc->slot_session_count[SlotIndex]);
+                unsigned int *pProcRWSessions =
+                    &(pProc->slot_rw_session_count[SlotIndex]);
 
                 if (*pProcSessions > 0) {
 
@@ -344,11 +348,14 @@ BOOL CheckForGarbage(Slot_Mgr_Shr_t *MemPtr)
                                SlotIndex, *pGlobalSessions);
 #endif                          /* DEV */
                         *pGlobalSessions = 0;
+                        *pGlobalRWSessions = 0;
                     } else {
                         *pGlobalSessions -= *pProcSessions;
+                        *pGlobalRWSessions -= *pProcRWSessions;
                     }
 
                     *pProcSessions = 0;
+                    *pProcRWSessions = 0;
 
                 }
                 /* end if *pProcSessions */

--- a/usr/sbin/pkcsslotd/shmem.c
+++ b/usr/sbin/pkcsslotd/shmem.c
@@ -319,6 +319,7 @@ int InitSharedMemory(Slot_Mgr_Shr_t *sp)
     uint16 procindex;
 
     memset(sp->slot_global_sessions, 0, NUMBER_SLOTS_MANAGED * sizeof(uint32));
+    memset(sp->slot_global_rw_sessions, 0, NUMBER_SLOTS_MANAGED * sizeof(uint32));
 
     /* Initialize the process side of things. */
     /* for now don't worry about the condition variables */


### PR DESCRIPTION
Currently only CK_TOKEN_INFO.ulSessionCount is maintained with the total number of sessions open by a token, but ulRwSessionCount is set to CK_UNAVAILABLE_INFORMATION.

Besides the total number of sessions also maintain the number of R/W sessions, so that ulRwSessionCount can be returned with accurate information.

Similar as for the total number of sessions, the counter is kept in the shared memory segment of the pkcsslotd. It exists once as global counter, and once per process. When a process dies without unregistering from pkcsslotd, the garbage collector of pkcsslotd decrements the global counter by the amount of the per-process counter to keep the global counter consistent.