### PR TITLE
testcases: abfunc: Print BEGIN message even if entire test is skipped

### DIFF
--- a/testcases/crypto/abfunc.c
+++ b/testcases/crypto/abfunc.c
@@ -1191,6 +1191,7 @@ int main(int argc, char **argv)
         }
     } else {
         rc = 0;
+        testcase_begin("%s\n", __func__);
         testcase_skip("%s only supported on the EP11 token.\n", argv[0]);
     }
 


### PR DESCRIPTION
Attribute bound keys are only supported by the EP11 token. When the abfunc testcase is run against a non-EP11 token, the entire testcase is skipped.

Print a "BEGIN xxx TESTCASE" message anyway, because otherwise the output post-processor for the CI will not see this as a new testcase, and report this skipped testcase under the testcase name from the previously run testcase.