### PR TITLE
config: Make confignode_foreach() macro more error save

### DIFF
--- a/usr/lib/config/configuration.h
+++ b/usr/lib/config/configuration.h
@@ -756,7 +756,7 @@ void confignode_dump(FILE *fp, struct ConfigBaseNode *n,
  * f is an integer
  */
 #define confignode_foreach(i,c,f) \
-    for((i)=(c),(f)=1;(f)||(i)!=(c);(i)=(i)->next,(f)=0)
+    for((i)=(c),(f)=1;(i)&&((f)||(i)!=(c));(i)=(i)->next,(f)=0)
 
 static inline struct ConfigBaseNode *
 confignode_find(struct ConfigBaseNode *cfg, const char *key)


### PR DESCRIPTION
If macro confignode_foreach() is used with 2nd parameter (c) being NULL, it should not try to dereference it.

This can happen when an empty structure element is parsed and the structure element's value is not checked for NULL before using confignode_foreach(). Since this is an empty structure, confignode_foreach() should simply do
nothing in this case.
