### PR TITLE
common: CKF_USER_PIN_TO_BE_CHANGED must be set on a uninitialized token

### DIFF
--- a/usr/lib/common/utility.c
+++ b/usr/lib/common/utility.c
@@ -298,15 +298,7 @@ void init_tokenInfo(TOKEN_DATA *nv_token_data)
     //
 
     token_info->flags = CKF_RNG | CKF_LOGIN_REQUIRED | CKF_CLOCK_ON_TOKEN |
-        CKF_SO_PIN_TO_BE_CHANGED;
-    // XXX New in v2.11 - KEY
-
-    if (memcmp(nv_token_data->user_pin_sha, "00000000000000000000",
-               SHA1_HASH_SIZE) != 0)
-        token_info->flags |= CKF_USER_PIN_INITIALIZED;
-    else
-        token_info->flags |= CKF_USER_PIN_TO_BE_CHANGED;
-    // XXX New in v2.11 - KEY
+        CKF_SO_PIN_TO_BE_CHANGED | CKF_USER_PIN_TO_BE_CHANGED;
 
     // For the release, we made these
     // values as CK_UNAVAILABLE_INFORMATION or CK_EFFECTIVELY_INFINITE


### PR DESCRIPTION
Function init_tokenInfo() is called when NVTOK.DAT is not existing when the token is initialized during C_Initialize. It then sets up the initial NV data. Always set flag CKF_USER_PIN_TO_BE_CHANGED in that case.

The code did check if the user pin was still uninitialized (i.e user_pin_sha all ASCII '0's) and set flag CKF_USER_PIN_TO_BE_CHANGED only if it was not initialized, but sets flag CKF_USER_PIN_INITIALIZED otherwise.

Unfortunately, with the new token data format, user_pin_sha is initialized to binary zeros from the initial memset, and thus init_tokenInfo() erroneously treated the user pin to be already initialized (binary zeros != ASCII '0's), and thus set flag CKF_USER_PIN_INITIALIZED instead of flag CKF_USER_PIN_TO_BE_CHANGED.

For the old data format init_token_data() initialized user_pin_sha to all ASCII '0's and thus init_tokenInfo() will always detect that the user pin is not initialized and thus always set the CKF_USER_PIN_TO_BE_CHANGED flag. The one and only caller of init_tokenInfo() is init_token_data().

Since there is no way that the user pin might be initialized when init_tokenInfo() is called, because init_token_data() initialized user_pin_sha to all ASCII '0's for the old token format, there is no need for init_tokenInfo() to check the user_pin_sha field at all. Without that check (which would have needed to be adapted for the new token data format), it will always set CKF_USER_PIN_TO_BE_CHANGED regardless of the token data format.
