### PR TITLE
EP11: Handle m_Get/m_SetAttributeValue and protected key derive with session bound blobs

### DIFF
--- a/usr/lib/common/h_extern.h
+++ b/usr/lib/common/h_extern.h
@@ -2235,7 +2235,7 @@ CK_RV object_create_skel(STDLL_TokData_t *tokdata,
                          CK_ULONG mode,
                          CK_ULONG class, CK_ULONG subclass, OBJECT **key);
 
-CK_RV object_copy(STDLL_TokData_t *tokdata,
+CK_RV object_copy(STDLL_TokData_t *tokdata, SESSION *sess,
                   CK_ATTRIBUTE *pTemplate,
                   CK_ULONG ulCount, OBJECT *old_obj, OBJECT **new_obj);
 
@@ -2254,7 +2254,7 @@ CK_RV object_restore_withSize(struct policy *policy, CK_BYTE *data,
                               OBJECT **obj, CK_BBOOL replace, int data_size,
                               const char *fname);
 
-CK_RV object_set_attribute_values(STDLL_TokData_t *tokdata,
+CK_RV object_set_attribute_values(STDLL_TokData_t *tokdata, SESSION *sess,
                                   OBJECT *obj,
                                   CK_ATTRIBUTE *pTemplate, CK_ULONG ulCount);
 

--- a/usr/lib/common/obj_mgr.c
+++ b/usr/lib/common/obj_mgr.c
@@ -324,7 +324,7 @@ CK_RV object_mgr_copy(STDLL_TokData_t *tokdata,
         goto done;
     }
 
-    rc = object_copy(tokdata, pTemplate, ulCount, old_obj, &new_obj);
+    rc = object_copy(tokdata, sess, pTemplate, ulCount, old_obj, &new_obj);
     if (rc != CKR_OK) {
         TRACE_DEVEL("Object Copy failed.\n");
         goto done;
@@ -1691,7 +1691,7 @@ CK_RV object_mgr_set_attribute_values(STDLL_TokData_t *tokdata,
     if (rc != CKR_OK)
         goto done;
 
-    rc = object_set_attribute_values(tokdata, obj, pTemplate, ulCount);
+    rc = object_set_attribute_values(tokdata, sess, obj, pTemplate, ulCount);
     if (rc != CKR_OK) {
         TRACE_DEVEL("object_set_attribute_values failed.\n");
         goto done;

--- a/usr/lib/common/object.c
+++ b/usr/lib/common/object.c
@@ -140,7 +140,7 @@ CK_RV object_create(STDLL_TokData_t * tokdata,
 //
 // The old_obj must hold the READ lock!
 //
-CK_RV object_copy(STDLL_TokData_t * tokdata,
+CK_RV object_copy(STDLL_TokData_t * tokdata, SESSION *sess,
                   CK_ATTRIBUTE * pTemplate,
                   CK_ULONG ulCount, OBJECT * old_obj, OBJECT ** new_obj)
 {
@@ -228,7 +228,7 @@ CK_RV object_copy(STDLL_TokData_t * tokdata,
      * changed.
      */
     if (token_specific.t_set_attribute_values != NULL) {
-        rc = token_specific.t_set_attribute_values(tokdata, o, new_tmpl);
+        rc = token_specific.t_set_attribute_values(tokdata, sess, o, new_tmpl);
         if (rc != CKR_OK) {
             TRACE_DEVEL("token_specific_set_attribute_values failed with %lu\n",
                         rc);
@@ -620,7 +620,7 @@ CK_RV object_get_attribute_values(OBJECT * obj,
 
 // object_set_attribute_values()
 //
-CK_RV object_set_attribute_values(STDLL_TokData_t * tokdata,
+CK_RV object_set_attribute_values(STDLL_TokData_t * tokdata, SESSION *sess,
                                   OBJECT * obj,
                                   CK_ATTRIBUTE * pTemplate, CK_ULONG ulCount)
 {
@@ -669,7 +669,8 @@ CK_RV object_set_attribute_values(STDLL_TokData_t * tokdata,
     }
 
     if (token_specific.t_set_attribute_values != NULL) {
-        rc = token_specific.t_set_attribute_values(tokdata, obj, new_tmpl);
+        rc = token_specific.t_set_attribute_values(tokdata, sess,
+                                                   obj, new_tmpl);
         if (rc != CKR_OK) {
             TRACE_DEVEL("token_specific_set_attribute_values failed with %lu\n",
                         rc);

--- a/usr/lib/common/tok_spec_struct.h
+++ b/usr/lib/common/tok_spec_struct.h
@@ -274,7 +274,8 @@ struct token_specific_struct {
                                 ENCR_DECR_CONTEXT *, CK_MECHANISM *, OBJECT *,
                                 CK_BYTE *, CK_ULONG , CK_BYTE *, CK_ULONG *);
 
-    CK_RV(*t_set_attribute_values) (STDLL_TokData_t *, OBJECT *, TEMPLATE *);
+    CK_RV(*t_set_attribute_values) (STDLL_TokData_t *, SESSION *,
+                                    OBJECT *, TEMPLATE *);
 
     CK_RV(*t_set_attrs_for_new_object) (STDLL_TokData_t *, CK_OBJECT_CLASS,
                                         CK_ULONG, TEMPLATE *);

--- a/usr/lib/common/tok_specific.h
+++ b/usr/lib/common/tok_specific.h
@@ -316,8 +316,8 @@ CK_RV token_specific_reencrypt_single(STDLL_TokData_t *, SESSION *,
                                       CK_MECHANISM *, OBJECT *, CK_BYTE *,
                                       CK_ULONG , CK_BYTE *, CK_ULONG *);
 
-CK_RV token_specific_set_attribute_values(STDLL_TokData_t *, OBJECT *,
-                                          TEMPLATE *);
+CK_RV token_specific_set_attribute_values(STDLL_TokData_t *, SESSION *,
+                                          OBJECT *, TEMPLATE *);
 
 CK_RV token_specific_set_attrs_for_new_object(STDLL_TokData_t *,
                                               CK_OBJECT_CLASS, CK_ULONG,


### PR DESCRIPTION
Like other EP11 host library functions that operate on key blobs, m_GetAttributeValue and m_SetAttributeValue as well as m_UnwrpKey with CKM_IBM_CPACF_WRAP may also return CKR_SESSION_CLOSED when the EP11 session that the key blob is bound to is not logged in into the adapter that is currently used for the request.

For that the session must be passed through to the functions.