### PR TITLE
Opencryptoki common code XTS support

### DIFF
--- a/usr/include/pkcs11types.h
+++ b/usr/include/pkcs11types.h
@@ -431,6 +431,8 @@ typedef CK_ULONG CK_KEY_TYPE;
 #define CKK_CDMF            0x0000001E
 /* CKK_AES is new for v2.11 */
 #define CKK_AES             0x0000001F
+/* CKK_AES_XTS is new for v3.0 */
+#define CKK_AES_XTS         0x00000035
 
 #define CKK_VENDOR_DEFINED  0x80000000
 
@@ -902,6 +904,9 @@ typedef CK_ULONG CK_MECHANISM_TYPE;
 #define CKM_JUNIPER_SHUFFLE            0x00001064
 #define CKM_JUNIPER_WRAP               0x00001065
 #define CKM_FASTHASH                   0x00001070
+/* The following are new for v3.0 */
+#define CKM_AES_XTS                    0x00001071
+#define CKM_AES_XTS_KEY_GEN            0x00001072
 /* The following are new for v2.11 */
 #define CKM_AES_KEY_GEN                0x00001080
 #define CKM_AES_ECB                    0x00001081

--- a/usr/lib/api/mechtable.inc
+++ b/usr/lib/api/mechtable.inc
@@ -40,6 +40,8 @@ const struct mechrow mechtable_rows[] =
      { "CKM_AES_ECB",                 CKM_AES_ECB,                  16, MC_INFORMATION_UNAVAILABLE, MCF_ENCRYPTDECRYPT | MCF_WRAPUNWRAP },
      { "CKM_AES_GCM",                 CKM_AES_GCM,                  16, MC_INFORMATION_UNAVAILABLE, MCF_ENCRYPTDECRYPT | MCF_WRAPUNWRAP | MCF_NEEDSPARAM },
      { "CKM_AES_KEY_GEN",             CKM_AES_KEY_GEN,               0, MC_INFORMATION_UNAVAILABLE, MCF_KEYGEN },
+     { "CKM_AES_XTS_KEY_GEN",         CKM_AES_XTS_KEY_GEN,           0, MC_INFORMATION_UNAVAILABLE, MCF_KEYGEN },
+     { "CKM_AES_XTS",                 CKM_AES_XTS,                  16, MC_INFORMATION_UNAVAILABLE, MCF_ENCRYPTDECRYPT },
      { "CKM_AES_MAC",                 CKM_AES_MAC,                  16,                          8, MCF_SIGNVERIFY },
      { "CKM_AES_MAC_GENERAL",         CKM_AES_MAC_GENERAL,          16,                         16, MCF_SIGNVERIFY | MCF_NEEDSPARAM | MCF_MAC_GENERAL },
      { "CKM_AES_OFB",                 CKM_AES_OFB,                  16, MC_INFORMATION_UNAVAILABLE, MCF_ENCRYPTDECRYPT | MCF_WRAPUNWRAP | MCF_NEEDSPARAM },

--- a/usr/lib/api/policy.c
+++ b/usr/lib/api/policy.c
@@ -255,6 +255,7 @@ static CK_RV policy_extract_key_data(get_attr_val_f getattr, void *d,
         *comptarget = COMPARE_SYMMETRIC;
         break;
     case CKK_AES:
+    case CKK_AES_XTS:
         *siglen = 128;
         /* Fallthrough */
     case CKK_GENERIC_SECRET:
@@ -889,7 +890,9 @@ static CK_RV policy_update_mech_info(policy_t p, CK_MECHANISM_TYPE mech,
         case CKM_AES_CTR:
         case CKM_AES_ECB:
         case CKM_AES_GCM:
+        case CKM_AES_XTS:
         case CKM_AES_KEY_GEN:
+        case CKM_AES_XTS_KEY_GEN:
         case CKM_AES_MAC:
         case CKM_AES_MAC_GENERAL:
         case CKM_AES_OFB:

--- a/usr/lib/cca_stdll/tok_struct.h
+++ b/usr/lib/cca_stdll/tok_struct.h
@@ -106,6 +106,7 @@ token_spec_t token_specific = {
 
     // AES
     &token_specific_aes_key_gen,
+    NULL,                       // aes_xts_key_gen
     &token_specific_aes_ecb,
     &token_specific_aes_cbc,
     NULL,                       // aes_ctr
@@ -117,6 +118,7 @@ token_spec_t token_specific = {
     NULL,                       // aes_cfb
     NULL,                       // aes_mac
     NULL,                       // aes_cmac
+	NULL,                       // aes_xts
     // DSA
     NULL,                       // dsa_generate_keypair
     NULL,                       // dsa_sign

--- a/usr/lib/common/encr_mgr.c
+++ b/usr/lib/common/encr_mgr.c
@@ -548,6 +548,39 @@ CK_RV encr_mgr_init(STDLL_TokData_t *tokdata,
         }
         memset(ctx->context, 0x0, sizeof(AES_CONTEXT));
         break;
+    case CKM_AES_XTS:
+            // XXX Copied in from DES3, should be verified - KEY
+        if (mech->ulParameterLen != AES_INIT_VECTOR_SIZE ||
+                    mech->pParameter == NULL) {
+                    TRACE_ERROR("%s\n", ock_err(ERR_MECHANISM_PARAM_INVALID));
+                    rc = CKR_MECHANISM_PARAM_INVALID;
+                    goto done;
+                }
+        // is the key type correct?
+        //
+        rc = template_attribute_get_ulong(key_obj->template, CKA_KEY_TYPE,
+                                              &keytype);
+        TRACE_ERROR("Key type %lx\n",keytype);
+        if (rc != CKR_OK) {
+            TRACE_ERROR("Could not find CKA_KEY_TYPE for the key.\n");
+            goto done;
+        }
+
+        if (keytype != CKK_AES_XTS) {
+            TRACE_ERROR("%s\n", ock_err(ERR_KEY_TYPE_INCONSISTENT));
+            rc = CKR_KEY_TYPE_INCONSISTENT;
+            goto done;
+        }
+
+        ctx->context_len = sizeof(AES_CONTEXT);
+        ctx->context = (CK_BYTE *) malloc(sizeof(AES_CONTEXT));
+        if (!ctx->context) {
+            TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
+            rc = CKR_HOST_MEMORY;
+            goto done;
+        }
+        memset(ctx->context, 0x0, sizeof(AES_CONTEXT));
+        break;
     default:
         TRACE_ERROR("%s\n", ock_err(ERR_MECHANISM_PARAM_INVALID));
         rc = CKR_MECHANISM_INVALID;
@@ -791,6 +824,10 @@ CK_RV encr_mgr_encrypt(STDLL_TokData_t *tokdata,
         return aes_cfb_encrypt(tokdata, sess, length_only, ctx,
                                in_data, in_data_len,
                                out_data, out_data_len, 0x10);
+    case CKM_AES_XTS:
+            return aes_xts_encrypt(tokdata, sess, length_only, ctx,
+                                   in_data, in_data_len,
+                                   out_data, out_data_len);
     default:
         TRACE_ERROR("%s\n", ock_err(ERR_MECHANISM_PARAM_INVALID));
         return CKR_MECHANISM_INVALID;
@@ -927,6 +964,10 @@ CK_RV encr_mgr_encrypt_update(STDLL_TokData_t *tokdata,
         return aes_cfb_encrypt_update(tokdata, sess, length_only, ctx,
                                       in_data, in_data_len,
                                       out_data, out_data_len, 0x10);
+    case CKM_AES_XTS:
+        return aes_xts_encrypt_update(tokdata, sess, length_only, ctx,
+                                      in_data, in_data_len,
+                                      out_data, out_data_len);
     default:
         return CKR_MECHANISM_INVALID;
     }
@@ -1036,6 +1077,9 @@ encr_mgr_encrypt_final(STDLL_TokData_t *tokdata,
     case CKM_AES_CFB128:
         return aes_cfb_encrypt_final(tokdata, sess, length_only,
                                      ctx, out_data, out_data_len, 0x10);
+    case CKM_AES_XTS:
+        return aes_xts_encrypt_final(tokdata, sess, length_only,
+                                     ctx, out_data, out_data_len);
     default:
         return CKR_MECHANISM_INVALID;
     }

--- a/usr/lib/common/h_extern.h
+++ b/usr/lib/common/h_extern.h
@@ -1337,6 +1337,16 @@ CK_RV aes_ctr_decrypt_update(STDLL_TokData_t *tokdata, SESSION *sess,
                              CK_BYTE *in_data, CK_ULONG in_data_len,
                              CK_BYTE *out_data, CK_ULONG *out_data_len);
 
+CK_RV aes_xts_encrypt_update(STDLL_TokData_t *tokdata, SESSION *sess,
+                             CK_BBOOL length_only, ENCR_DECR_CONTEXT *context,
+                             CK_BYTE *in_data, CK_ULONG in_data_len,
+                             CK_BYTE *out_data, CK_ULONG *out_data_len);
+
+CK_RV aes_xts_decrypt_update(STDLL_TokData_t *tokdata, SESSION *sess,
+                             CK_BBOOL length_only, ENCR_DECR_CONTEXT *context,
+                             CK_BYTE *in_data, CK_ULONG in_data_len,
+                             CK_BYTE *out_data, CK_ULONG *out_data_len);
+
 CK_RV aes_ecb_encrypt_final(STDLL_TokData_t *tokdata, SESSION *sess,
                             CK_BBOOL length_only, ENCR_DECR_CONTEXT *context,
                             CK_BYTE *out_data, CK_ULONG *out_data_len);
@@ -1368,6 +1378,14 @@ CK_RV aes_ctr_encrypt_final(STDLL_TokData_t *tokdata, SESSION *sess,
                             CK_BYTE *out_data, CK_ULONG *out_data_len);
 
 CK_RV aes_ctr_decrypt_final(STDLL_TokData_t *tokdata, SESSION *sess,
+                            CK_BBOOL length_only, ENCR_DECR_CONTEXT *context,
+                            CK_BYTE *out_data, CK_ULONG *out_data_len);
+
+CK_RV aes_xts_encrypt_final(STDLL_TokData_t *tokdata, SESSION *sess,
+                            CK_BBOOL length_only, ENCR_DECR_CONTEXT *context,
+                            CK_BYTE *out_data, CK_ULONG *out_data_len);
+
+CK_RV aes_xts_decrypt_final(STDLL_TokData_t *tokdata, SESSION *sess,
                             CK_BBOOL length_only, ENCR_DECR_CONTEXT *context,
                             CK_BYTE *out_data, CK_ULONG *out_data_len);
 
@@ -1427,6 +1445,7 @@ CK_RV aes_cmac_verify_final(STDLL_TokData_t *tokdata, SESSION *sess,
 // AES mechanisms
 //
 CK_RV ckm_aes_key_gen(STDLL_TokData_t *, TEMPLATE *tmpl);
+CK_RV ckm_aes_xts_key_gen(STDLL_TokData_t *, TEMPLATE *tmpl);
 
 CK_RV ckm_aes_ecb_encrypt(STDLL_TokData_t *, CK_BYTE *in_data,
                           CK_ULONG in_data_len, CK_BYTE *out_data,
@@ -1455,6 +1474,19 @@ CK_RV ckm_aes_ctr_decrypt(STDLL_TokData_t *, CK_BYTE *in_data,
                           CK_ULONG in_data_len, CK_BYTE *out_data,
                           CK_ULONG *out_data_len, CK_BYTE *counterblock,
                           CK_ULONG counter_width, OBJECT *key);
+CK_RV ckm_aes_xts_encrypt(STDLL_TokData_t *tokdata,
+                          CK_BYTE *in_data,
+                          CK_ULONG in_data_len,
+                          CK_BYTE *out_data,
+                          CK_ULONG *out_data_len,
+                          CK_BYTE *init_v, OBJECT *key);
+
+CK_RV ckm_aes_xts_decrypt(STDLL_TokData_t *tokdata,
+                          CK_BYTE *in_data,
+                          CK_ULONG in_data_len,
+                          CK_BYTE *out_data,
+                          CK_ULONG *out_data_len,
+                          CK_BYTE *init_v, OBJECT *key);
 
 CK_RV ckm_aes_wrap_format(STDLL_TokData_t *, CK_BBOOL length_only,
                           CK_BYTE **data, CK_ULONG *data_len);
@@ -1557,6 +1589,20 @@ CK_RV aes_cfb_decrypt_final(STDLL_TokData_t *tokdata, SESSION *sess,
                             CK_BBOOL length_only,
                             ENCR_DECR_CONTEXT *ctx, CK_BYTE *out_data,
                             CK_ULONG *out_data_len, CK_ULONG cfb_len);
+CK_RV aes_xts_encrypt(STDLL_TokData_t *tokdata,
+                      SESSION *sess,
+                      CK_BBOOL length_only,
+                      ENCR_DECR_CONTEXT *ctx,
+                      CK_BYTE *in_data,
+                      CK_ULONG in_data_len,
+                      CK_BYTE *out_data, CK_ULONG *out_data_len);
+CK_RV aes_xts_decrypt(STDLL_TokData_t *tokdata,
+                      SESSION *sess,
+                      CK_BBOOL length_only,
+                      ENCR_DECR_CONTEXT *ctx,
+                      CK_BYTE *in_data,
+                      CK_ULONG in_data_len,
+                      CK_BYTE *out_data, CK_ULONG *out_data_len);
 
 // SHA mechanisms
 //
@@ -2566,10 +2612,15 @@ CK_RV des3_wrap_get_data(TEMPLATE *tmpl, CK_BBOOL length_only, CK_BYTE **data,
 
 // AES routines
 CK_RV aes_check_required_attributes(TEMPLATE *tmpl, CK_ULONG mode);
+
+CK_RV aes_xts_set_default_attributes(TEMPLATE *tmpl, TEMPLATE *basetmpl, CK_ULONG mode);
+
 CK_RV aes_set_default_attributes(TEMPLATE *tmpl, TEMPLATE *basetmpl, CK_ULONG mode);
 CK_RV aes_unwrap(STDLL_TokData_t *tokdata, TEMPLATE *tmpl, CK_BYTE *data,
                  CK_ULONG data_len, CK_BBOOL fromend);
 CK_RV aes_validate_attribute(STDLL_TokData_t *tokdata, TEMPLATE *tmpl,
+                             CK_ATTRIBUTE *attr, CK_ULONG mode);
+CK_RV aes_xts_validate_attribute(STDLL_TokData_t *tokdata, TEMPLATE *tmpl,
                              CK_ATTRIBUTE *attr, CK_ULONG mode);
 CK_RV aes_wrap_get_data(TEMPLATE *tmpl, CK_BBOOL length_only, CK_BYTE **data,
                         CK_ULONG *data_len);

--- a/usr/lib/common/key_mgr.c
+++ b/usr/lib/common/key_mgr.c
@@ -136,6 +136,14 @@ CK_RV key_mgr_generate_key(STDLL_TokData_t *tokdata,
 
         subclass = CKK_AES;
         break;
+    case CKM_AES_XTS_KEY_GEN:
+            if (subclass != 0 && subclass != CKK_AES_XTS) {
+                TRACE_ERROR("%s\n", ock_err(ERR_TEMPLATE_INCONSISTENT));
+                return CKR_TEMPLATE_INCONSISTENT;
+            }
+
+            subclass = CKK_AES_XTS;
+            break;
     case CKM_GENERIC_SECRET_KEY_GEN:
         if (subclass != 0 && subclass != CKK_GENERIC_SECRET) {
             TRACE_ERROR("%s\n", ock_err(ERR_TEMPLATE_INCONSISTENT));
@@ -175,6 +183,9 @@ CK_RV key_mgr_generate_key(STDLL_TokData_t *tokdata,
         break;
     case CKM_AES_KEY_GEN:
         rc = ckm_aes_key_gen(tokdata, key_obj->template);
+        break;
+    case CKM_AES_XTS_KEY_GEN:
+        rc = ckm_aes_xts_key_gen(tokdata, key_obj->template);
         break;
     case CKM_GENERIC_SECRET_KEY_GEN:
         rc = ckm_generic_secret_key_gen(tokdata, key_obj->template);

--- a/usr/lib/common/obj_mgr.c
+++ b/usr/lib/common/obj_mgr.c
@@ -160,6 +160,7 @@ CK_RV object_mgr_add(STDLL_TokData_t *tokdata,
         switch (keytype) {
         case CKK_GENERIC_SECRET:
         case CKK_AES:
+        case CKK_AES_XTS:
             rc = template_attribute_get_non_empty(o->template, CKA_VALUE,
                                                   &value_attr);
             if (rc != CKR_OK) {

--- a/usr/lib/common/template.c
+++ b/usr/lib/common/template.c
@@ -198,6 +198,8 @@ CK_RV template_add_default_attributes(TEMPLATE *tmpl, TEMPLATE *basetmpl,
             return des3_set_default_attributes(tmpl, mode);
         case CKK_AES:
             return aes_set_default_attributes(tmpl, basetmpl, mode);
+        case CKK_AES_XTS:
+            return aes_xts_set_default_attributes(tmpl, basetmpl, mode);
         default:
             TRACE_ERROR("%s: %lx\n", ock_err(ERR_ATTRIBUTE_VALUE_INVALID),
                         subclass);
@@ -442,6 +444,7 @@ CK_RV template_check_required_attributes(TEMPLATE *tmpl, CK_ULONG class,
         case CKK_DES3:
             return des3_check_required_attributes(tmpl, mode);
         case CKK_AES:
+        case CKK_AES_XTS:
             return aes_check_required_attributes(tmpl, mode);
         default:
             TRACE_ERROR("%s: %lx\n", ock_err(ERR_ATTRIBUTE_VALUE_INVALID),
@@ -1674,6 +1677,8 @@ CK_RV template_validate_attribute(STDLL_TokData_t *tokdata, TEMPLATE *tmpl,
             return des3_validate_attribute(tokdata, tmpl, attr, mode);
         case CKK_AES:
             return aes_validate_attribute(tokdata, tmpl, attr, mode);
+        case CKK_AES_XTS:
+            return aes_xts_validate_attribute(tokdata, tmpl, attr, mode);
         default:
             TRACE_ERROR("%s\n", ock_err(ERR_ATTRIBUTE_VALUE_INVALID));
             return CKR_ATTRIBUTE_VALUE_INVALID; // unknown key type

--- a/usr/lib/common/tok_spec_struct.h
+++ b/usr/lib/common/tok_spec_struct.h
@@ -212,6 +212,9 @@ struct token_specific_struct {
     CK_RV(*t_aes_key_gen) (STDLL_TokData_t *, CK_BYTE **, CK_ULONG *, CK_ULONG,
                            CK_BBOOL *);
 
+    CK_RV(*t_aes_xts_key_gen) (STDLL_TokData_t *, CK_BYTE **, CK_ULONG *, CK_ULONG,
+                               CK_BBOOL *);
+
     CK_RV(*t_aes_ecb) (STDLL_TokData_t *tokdata, CK_BYTE *, CK_ULONG,
                        CK_BYTE *, CK_ULONG *, OBJECT *, CK_BYTE);
 
@@ -248,6 +251,9 @@ struct token_specific_struct {
 
     CK_RV(*t_aes_cmac) (STDLL_TokData_t *, CK_BYTE *, CK_ULONG, OBJECT *,
                         CK_BYTE *, CK_BBOOL, CK_BBOOL, CK_VOID_PTR *);
+
+    CK_RV(*t_aes_xts) (STDLL_TokData_t *tokdata, CK_BYTE *, CK_ULONG,
+                           CK_BYTE *, CK_ULONG *, OBJECT *, CK_BYTE *, CK_BYTE);
 
     // Token Specific DSA functions
     CK_RV(*t_dsa_generate_keypair) (STDLL_TokData_t *, TEMPLATE *, TEMPLATE *);

--- a/usr/lib/common/tok_specific.h
+++ b/usr/lib/common/tok_specific.h
@@ -235,6 +235,9 @@ CK_RV token_specific_generic_secret_key_gen(STDLL_TokData_t *,
 CK_RV token_specific_aes_key_gen(STDLL_TokData_t *,
                                  CK_BYTE **, CK_ULONG *, CK_ULONG, CK_BBOOL *);
 
+CK_RV token_specific_aes_xts_key_gen(STDLL_TokData_t *,
+        CK_BYTE **, CK_ULONG *, CK_ULONG, CK_BBOOL *);
+
 CK_RV token_specific_aes_ecb(STDLL_TokData_t *,
                              CK_BYTE *,
                              CK_ULONG,
@@ -285,6 +288,11 @@ CK_RV token_specific_aes_cmac(STDLL_TokData_t *,
                               CK_BYTE *, CK_ULONG, OBJECT *, CK_BYTE *,
                               CK_BBOOL, CK_BBOOL, CK_VOID_PTR *);
 
+CK_RV token_specific_aes_xts(STDLL_TokData_t *,
+                             CK_BYTE *,
+                             CK_ULONG,
+                             CK_BYTE *,
+                             CK_ULONG *, OBJECT *, CK_BYTE *, CK_BYTE);
 CK_RV token_specific_dsa_generate_keypair(STDLL_TokData_t *,
                                           TEMPLATE *, TEMPLATE *);
 CK_RV token_specific_dsa_sign(STDLL_TokData_t *, CK_BYTE *, CK_ULONG, CK_ULONG);

--- a/usr/lib/ep11_stdll/tok_struct.h
+++ b/usr/lib/ep11_stdll/tok_struct.h
@@ -114,6 +114,7 @@ token_spec_t token_specific = {
     NULL,                       // generic_secret_key_gen
     // AES
     NULL,                       // aes_key_gen,
+    NULL,                       // aes_xts_key_gen
     &token_specific_aes_ecb,
     &token_specific_aes_cbc,
     NULL,                       // aes_ctr
@@ -125,6 +126,7 @@ token_spec_t token_specific = {
     NULL,                       // aes_cfb
     NULL,                       // aes_mac
     &token_specific_aes_cmac,
+    NULL,                       // aes_xts
     // DSA
     NULL,                       // dsa_generate_keypair,
     NULL,                       // dsa_sign

--- a/usr/lib/ica_s390_stdll/tok_struct.h
+++ b/usr/lib/ica_s390_stdll/tok_struct.h
@@ -109,6 +109,7 @@ token_spec_t token_specific = {
     &token_specific_generic_secret_key_gen,
     // AES
     &token_specific_aes_key_gen,
+    NULL,                       // aes_xts_key_gen
     &token_specific_aes_ecb,
     &token_specific_aes_cbc,
     &token_specific_aes_ctr,
@@ -120,6 +121,7 @@ token_spec_t token_specific = {
     &token_specific_aes_cfb,
     &token_specific_aes_mac,
     &token_specific_aes_cmac,
+    NULL,                       // aes_xts
     // DSA
     NULL,                       // dsa_generate_keypair
     NULL,                       // dsa_sign

--- a/usr/lib/icsf_stdll/tok_struct.h
+++ b/usr/lib/icsf_stdll/tok_struct.h
@@ -106,6 +106,7 @@ token_spec_t token_specific = {
     NULL,                       // generic_secret_key_gen
     // AES
     NULL,                       // aes_key_gen
+	NULL,                       // aes_xts_key_gen
     NULL,                       // aes_ecb
     NULL,                       // aes_cbc
     NULL,                       // aes_ctr
@@ -117,6 +118,7 @@ token_spec_t token_specific = {
     NULL,                       // aes_cfb
     NULL,                       // aes_mac
     NULL,                       // aes_cmac
+	NULL,                       // aes_xts
     // DSA
     NULL,                       // dsa_generate_keypair
     NULL,                       // dsa_sign

--- a/usr/lib/soft_stdll/tok_struct.h
+++ b/usr/lib/soft_stdll/tok_struct.h
@@ -138,6 +138,7 @@ token_spec_t token_specific = {
     &token_specific_generic_secret_key_gen,
     // AES
     &token_specific_aes_key_gen,
+    NULL,                      // aes_xts_key_gen
     &token_specific_aes_ecb,
     &token_specific_aes_cbc,
     &token_specific_aes_ctr,
@@ -149,6 +150,7 @@ token_spec_t token_specific = {
     &token_specific_aes_cfb,
     &token_specific_aes_mac,
     &token_specific_aes_cmac,
+    NULL,                       // aes_xts
     // DSA
     NULL,                       // dsa_generate_keypair
     NULL,                       // dsa_sign

--- a/usr/lib/tpm_stdll/tok_struct.h
+++ b/usr/lib/tpm_stdll/tok_struct.h
@@ -97,6 +97,7 @@ struct token_specific_struct token_specific = {
     NULL,                       // generic_secret_key_gen
     // AES
     &token_specific_aes_key_gen,
+    NULL,                       // aes_xts_key_gen
     &token_specific_aes_ecb,
     &token_specific_aes_cbc,
     NULL,                       // aes_ctr
@@ -108,6 +109,7 @@ struct token_specific_struct token_specific = {
     NULL,                       // aes_cfb
     NULL,                       // aes_mac
     NULL,                       // aes_cmac
+	NULL,                       // aes_xts
     // DSA
     NULL,                       // dsa_generate_keypair
     NULL,                       // dsa_sign


### PR DESCRIPTION
This patch adds XTS support to the common
code layer of opencryptoki.
Support for the tokens and improvements on the
testcases will come later.

Signed-off-by: kanjur <kanjur@ibm.com>