### PR TITLE
Testcases fixes

### DIFF
--- a/testcases/crypto/rsa_func.c
+++ b/testcases/crypto/rsa_func.c
@@ -103,7 +103,7 @@ CK_RV do_EncryptDecryptRSA(struct GENERATED_TEST_SUITE_INFO *tsuite)
 
         if (!keysize_supported(slot_id, tsuite->mech.mechanism,
                                tsuite->tv[i].modbits)) {
-            testcase_skip("Token in slot %ld cannot be used with modbits.='%ld'",
+            testcase_skip("Token in slot %ld cannot be used with modbits='%ld'",
                           SLOT_ID, tsuite->tv[i].modbits);
             free(s);
             continue;
@@ -388,7 +388,7 @@ CK_RV do_EncryptDecryptImportRSA(struct PUBLISHED_TEST_SUITE_INFO *tsuite)
 
         if (!keysize_supported(slot_id, tsuite->mech.mechanism,
                                tsuite->tv[i].mod_len * 8)) {
-            testcase_skip("Token in slot %ld cannot be used with modbits.='%ld'",
+            testcase_skip("Token in slot %ld cannot be used with modbits='%ld'",
                           SLOT_ID, tsuite->tv[i].mod_len * 8);
             free(s);
             continue;
@@ -718,7 +718,7 @@ CK_RV do_SignVerifyRSA(struct GENERATED_TEST_SUITE_INFO * tsuite,
 
         if (!keysize_supported(slot_id, tsuite->mech.mechanism,
                                tsuite->tv[i].modbits)) {
-            testcase_skip("Token in slot %ld cannot be used with modbits.='%ld'",
+            testcase_skip("Token in slot %ld cannot be used with modbits='%ld'",
                           SLOT_ID, tsuite->tv[i].modbits);
             free(s);
             continue;
@@ -981,7 +981,7 @@ CK_RV do_SignVerify_RSAPSS(struct GENERATED_TEST_SUITE_INFO * tsuite)
 
         if (!keysize_supported(slot_id, tsuite->mech.mechanism,
                                tsuite->tv[i].modbits)) {
-            testcase_skip("Token in slot %ld cannot be used with modbits.='%ld'",
+            testcase_skip("Token in slot %ld cannot be used with modbits='%ld'",
                           SLOT_ID, tsuite->tv[i].modbits);
             free(s);
             continue;
@@ -1212,7 +1212,7 @@ CK_RV do_WrapUnwrapRSA(struct GENERATED_TEST_SUITE_INFO * tsuite)
 
         if (!keysize_supported(slot_id, tsuite->mech.mechanism,
                                tsuite->tv[i].modbits)) {
-            testcase_skip("Token in slot %ld cannot be used with modbits.='%ld'",
+            testcase_skip("Token in slot %ld cannot be used with modbits='%ld'",
                           SLOT_ID, tsuite->tv[i].modbits);
             continue;
         }

--- a/testcases/crypto/rsa_func.c
+++ b/testcases/crypto/rsa_func.c
@@ -1623,6 +1623,13 @@ CK_RV do_SignRSA(struct PUBLISHED_TEST_SUITE_INFO * tsuite)
 
         rc = CKR_OK;            // set return value
 
+        if (!keysize_supported(slot_id, tsuite->mech.mechanism,
+                               tsuite->tv[i].mod_len * 8)) {
+            testcase_skip("Token in slot %ld cannot be used with modbits='%ld'",
+                          SLOT_ID, tsuite->tv[i].mod_len * 8);
+            continue;
+        }
+
         // special case for ica
         // prime1, prime2, exp1, exp2, coef
         // must be size mod_len/2 or smaller
@@ -1823,6 +1830,13 @@ CK_RV do_VerifyRSA(struct PUBLISHED_TEST_SUITE_INFO * tsuite)
         testcase_begin("%s Verify with test vector %d.", tsuite->name, i);
 
         rc = CKR_OK;            // set return value
+
+        if (!keysize_supported(slot_id, tsuite->mech.mechanism,
+                               tsuite->tv[i].mod_len * 8)) {
+            testcase_skip("Token in slot %ld cannot be used with modbits='%ld'",
+                          SLOT_ID, tsuite->tv[i].mod_len * 8);
+            continue;
+        }
 
         // special case for EP11
         // modulus length must be multiple of 128 byte

--- a/testcases/crypto/rsaupdate_func.c
+++ b/testcases/crypto/rsaupdate_func.c
@@ -645,6 +645,14 @@ CK_RV do_VerifyUpdateRSA(struct PUBLISHED_TEST_SUITE_INFO * tsuite)
 
         testcase_begin("%s Verify with test vector %d.", tsuite->name, i);
 
+        if (!keysize_supported(slot_id, tsuite->mech.mechanism,
+                               tsuite->tv[i].mod_len * 8)) {
+            testcase_skip("Token in slot %ld cannot be used with modbits='%ld'",
+                          SLOT_ID, tsuite->tv[i].mod_len * 8);
+            free(s);
+            continue;
+        }
+
         // special case for EP11
         // modulus length must be multiple of 128 byte
         // skip test if modulus length has unsuported size
@@ -841,6 +849,14 @@ CK_RV do_SignUpdateRSA(struct PUBLISHED_TEST_SUITE_INFO * tsuite)
             goto testcase_cleanup;
         }
         testcase_begin("%s Sign with test vector %d.", tsuite->name, i);
+
+        if (!keysize_supported(slot_id, tsuite->mech.mechanism,
+                               tsuite->tv[i].mod_len * 8)) {
+            testcase_skip("Token in slot %ld cannot be used with modbits='%ld'",
+                          SLOT_ID, tsuite->tv[i].mod_len * 8);
+            free(s);
+            continue;
+        }
 
         // special case for ica
         // prime1, prime2, exp1, exp2, coef

--- a/testcases/crypto/rsaupdate_func.c
+++ b/testcases/crypto/rsaupdate_func.c
@@ -96,7 +96,7 @@ CK_RV do_SignVerifyUpdateRSA(struct GENERATED_TEST_SUITE_INFO *tsuite)
 
         if (!keysize_supported(slot_id, tsuite->mech.mechanism,
                                tsuite->tv[i].modbits)) {
-            testcase_skip("Token in slot %ld cannot be used with modbits.='%ld'",
+            testcase_skip("Token in slot %ld cannot be used with modbits='%ld'",
                           SLOT_ID, tsuite->tv[i].modbits);
             free(s);
             continue;
@@ -377,7 +377,7 @@ CK_RV do_SignVerifyUpdate_RSAPSS(struct GENERATED_TEST_SUITE_INFO * tsuite)
 
         if (!keysize_supported(slot_id, tsuite->mech.mechanism,
                                tsuite->tv[i].modbits)) {
-            testcase_skip("Token in slot %ld cannot be used with modbits.='%ld'",
+            testcase_skip("Token in slot %ld cannot be used with modbits='%ld'",
                           SLOT_ID, tsuite->tv[i].modbits);
             free(s);
             continue;

--- a/testcases/misc_tests/reencrypt.c
+++ b/testcases/misc_tests/reencrypt.c
@@ -361,7 +361,7 @@ CK_RV do_reencrypt(struct mech_info *mech1, struct mech_info *mech2)
 
         if (!keysize_supported(slot_id, mech2->key_gen_mech.mechanism,
                                mech2->rsa_modbits)) {
-            testcase_skip("Token in slot %ld cannot be used with modbits.='%ld'",
+            testcase_skip("Token in slot %ld cannot be used with modbits='%ld'",
                           slot_id, mech2->rsa_modbits);
             goto testcase_cleanup;
         }
@@ -610,7 +610,7 @@ CK_RV do_encrypt_reencrypt(struct mech_info *mech1)
                                mech1->key_gen_mech.mechanism,
                                mech1->rsa_modbits)) {
             testsuite_skip(NUM_REENCRYPT_TESTS, "Token in slot %ld cannot be "
-                          "used with modbits.='%ld'", slot_id,
+                          "used with modbits='%ld'", slot_id,
                           mech1->rsa_modbits);
             goto testcase_cleanup;
         }

--- a/testcases/misc_tests/tok2tok_transport.c
+++ b/testcases/misc_tests/tok2tok_transport.c
@@ -581,13 +581,13 @@ CK_RV do_wrap_key_test(struct wrapped_mech_info *tsuite,
 
         if (!keysize_supported(slot_id1, tsuite->wrapped_key_gen_mech.mechanism,
                                tsuite->rsa_modbits)) {
-            testcase_skip("Token in slot %lu cannot be used with modbits.='%ld'",
+            testcase_skip("Token in slot %lu cannot be used with modbits='%ld'",
                           slot_id1, tsuite->rsa_modbits);
             goto testcase_cleanup;
         }
         if (!keysize_supported(slot_id2, tsuite->wrapped_key_gen_mech.mechanism,
                                tsuite->rsa_modbits)) {
-            testcase_skip("Token in slot %lu cannot be used with modbits.='%ld'",
+            testcase_skip("Token in slot %lu cannot be used with modbits='%ld'",
                           slot_id2, tsuite->rsa_modbits);
             goto testcase_cleanup;
         }
@@ -980,14 +980,14 @@ CK_RV do_wrapping_test(struct wrapping_mech_info *tsuite)
         if (!keysize_supported(slot_id1,
                                tsuite->wrapping_key_gen_mech.mechanism,
                                tsuite->rsa_modbits)) {
-            testcase_skip("Token in slot %ld cannot be used with modbits.='%ld'",
+            testcase_skip("Token in slot %ld cannot be used with modbits='%ld'",
                           slot_id1, tsuite->rsa_modbits);
             goto testcase_cleanup;
         }
         if (!keysize_supported(slot_id2,
                                tsuite->wrapping_key_gen_mech.mechanism,
                                tsuite->rsa_modbits)) {
-            testcase_skip("Token in slot %ld cannot be used with modbits.='%ld'",
+            testcase_skip("Token in slot %ld cannot be used with modbits='%ld'",
                           slot_id2, tsuite->rsa_modbits);
             goto testcase_cleanup;
         }


### PR DESCRIPTION
Skip tests with RSA key sizes not supported by the token.