### PR TITLE
testcases: pkcsconf_tests.sh: fix interpreter

### DIFF
--- a/testcases/misc_tests/pkcsconf_test.sh
+++ b/testcases/misc_tests/pkcsconf_test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # COPYRIGHT (c) International Business Machines Corp. 2022
 #


### PR DESCRIPTION
The script uses functions/commands, which are only available in bash. Change the interpreter line accordingly.

Signed-off-by: Holger Dengler <dengler@linux.ibm.com>