### PR TITLE
EP11: Fix memory leak introduced with recent commit

### DIFF
--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -5451,6 +5451,8 @@ error:
         free(chk_attr);
     if (spki_attr != NULL)
         free(spki_attr);
+    if (spki != NULL)
+        free(spki);
     if (new_attrs)
         free_attribute_array(new_attrs, new_attrs_len);
     if (new_attrs1)


### PR DESCRIPTION
Function publ_key_get_spki() allocates the SPKI buffer, so it must be freed afterwards.