### PR TITLE
More Coverty fixes (for EP11 and ICA tokens)

### DIFF
--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -12735,6 +12735,8 @@ static ep11_target_info_t *get_target_info(STDLL_TokData_t *tokdata)
     target_info = *((void * volatile *)&ep11_data->target_info);
     if (target_info == NULL) {
         TRACE_ERROR("%s: target_info is NULL\n", __func__);
+        if (pthread_rwlock_unlock(&ep11_data->target_rwlock) != 0)
+            TRACE_DEVEL("Target Unlock failed.\n");
         return NULL;
     }
 

--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -9784,7 +9784,7 @@ static CK_RV ep11_config_add_apqn(ep11_private_data_t *ep11_data,
 
     if (ep11_data->target_list.length >= MAX_APQN) {
         OCK_SYSLOG(LOG_ERR,"%s: Error: Too many APQNs in config "
-                   "file '%s' (max %d)\n", __func__, fname);
+                   "file '%s' (max %d)\n", __func__, fname, (int) MAX_APQN);
         TRACE_ERROR("Too many APQNs in config file '%s' (max %d)\n",
                     fname, (int) MAX_APQN);
         return CKR_BUFFER_TOO_SMALL;

--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -3575,7 +3575,6 @@ static CK_RV import_IBM_Dilithium_key(STDLL_TokData_t *tokdata, SESSION *sess,
     unsigned char *ep11_pin_blob = NULL;
     CK_ULONG ep11_pin_blob_len = 0;
     ep11_session_t *ep11_session = (ep11_session_t *) sess->private_data;
-    CK_BYTE *pubkey = NULL;
 
     memcpy(iv, "1234567812345678", AES_BLOCK_SIZE);
 
@@ -3734,9 +3733,6 @@ static CK_RV import_IBM_Dilithium_key(STDLL_TokData_t *tokdata, SESSION *sess,
     }
 
 done:
-
-    if (pubkey)
-        free(pubkey);
     if (data) {
         OPENSSL_cleanse(data, data_len);
         free(data);
@@ -5488,7 +5484,6 @@ static CK_RV dh_generate_keypair(STDLL_TokData_t *tokdata,
     CK_ATTRIBUTE *opaque_attr = NULL;
     CK_ATTRIBUTE *value_attr = NULL;
     CK_ATTRIBUTE *attr = NULL;
-    CK_ATTRIBUTE *pPublicKeyTemplate_new = NULL;
     CK_ATTRIBUTE_PTR dh_pPublicKeyTemplate = NULL;
     CK_ULONG dh_ulPublicKeyAttributeCount = 0;
     CK_ATTRIBUTE_PTR dh_pPrivateKeyTemplate = NULL;
@@ -5748,7 +5743,6 @@ static CK_RV dh_generate_keypair(STDLL_TokData_t *tokdata,
     }
 
 dh_generate_keypair_end:
-    free(pPublicKeyTemplate_new);
     if (dh_pgs.pg != NULL)
         free(dh_pgs.pg);
     if (dh_pPublicKeyTemplate)
@@ -5780,7 +5774,6 @@ static CK_RV dsa_generate_keypair(STDLL_TokData_t *tokdata,
     CK_ATTRIBUTE *opaque_attr = NULL;
     CK_ATTRIBUTE *value_attr = NULL;
     CK_ATTRIBUTE *attr = NULL;
-    CK_ATTRIBUTE *pPublicKeyTemplate_new = NULL;
     CK_BYTE *key;
     CK_BYTE *data, *oid, *parm;
     CK_ULONG data_len, field_len, bit_str_len, oid_len, parm_len;
@@ -6049,7 +6042,6 @@ static CK_RV dsa_generate_keypair(STDLL_TokData_t *tokdata,
     }
 
 dsa_generate_keypair_end:
-    free(pPublicKeyTemplate_new);
     if (dsa_pqgs.pqg != NULL)
         free(dsa_pqgs.pqg);
     if (dsa_pPublicKeyTemplate)
@@ -6082,10 +6074,6 @@ static CK_RV rsa_ec_generate_keypair(STDLL_TokData_t *tokdata,
     CK_BYTE *data, *oid, *parm;
     CK_ULONG data_len, oid_len, parm_len;
     CK_ULONG field_len;
-    CK_ATTRIBUTE_PTR new_pPublicKeyTemplate = NULL;
-    CK_ULONG new_ulPublicKeyAttributeCount = 0;
-    CK_ATTRIBUTE_PTR new_pPrivateKeyTemplate = NULL;
-    CK_ULONG new_ulPrivateKeyAttributeCount = 0;
     CK_ULONG ktype;
     unsigned char *ep11_pin_blob = NULL;
     CK_ULONG ep11_pin_blob_len = 0;
@@ -6401,12 +6389,6 @@ static CK_RV rsa_ec_generate_keypair(STDLL_TokData_t *tokdata,
     }
 
 error:
-    if (new_pPrivateKeyTemplate)
-        free_attribute_array(new_pPrivateKeyTemplate,
-                             new_ulPrivateKeyAttributeCount);
-    if (new_pPublicKeyTemplate)
-        free_attribute_array(new_pPublicKeyTemplate,
-                             new_ulPublicKeyAttributeCount);
     if (new_publ_attrs)
         free_attribute_array(new_publ_attrs, new_publ_attrs_len);
     if (new_priv_attrs)
@@ -6434,10 +6416,6 @@ static CK_RV ibm_dilithium_generate_keypair(STDLL_TokData_t *tokdata,
     CK_BYTE *data, *oid, *parm;
     CK_ULONG data_len, oid_len, parm_len;
     CK_ULONG field_len;
-    CK_ATTRIBUTE_PTR new_pPublicKeyTemplate = NULL;
-    CK_ULONG new_ulPublicKeyAttributeCount = 0;
-    CK_ATTRIBUTE_PTR new_pPrivateKeyTemplate = NULL;
-    CK_ULONG new_ulPrivateKeyAttributeCount = 0;
     CK_ULONG ktype = CKK_IBM_PQC_DILITHIUM;
     unsigned char *ep11_pin_blob = NULL;
     CK_ULONG ep11_pin_blob_len = 0;
@@ -6681,12 +6659,6 @@ static CK_RV ibm_dilithium_generate_keypair(STDLL_TokData_t *tokdata,
     }
 
 error:
-    if (new_pPrivateKeyTemplate)
-        free_attribute_array(new_pPrivateKeyTemplate,
-                             new_ulPrivateKeyAttributeCount);
-    if (new_pPublicKeyTemplate)
-        free_attribute_array(new_pPublicKeyTemplate,
-                             new_ulPublicKeyAttributeCount);
     if (new_publ_attrs)
         free_attribute_array(new_publ_attrs, new_publ_attrs_len);
     if (new_priv_attrs)

--- a/usr/lib/ica_s390_stdll/ica_specific.c
+++ b/usr/lib/ica_s390_stdll/ica_specific.c
@@ -3093,8 +3093,8 @@ CK_RV token_specific_aes_gcm_update(STDLL_TokData_t *tokdata, SESSION *sess,
             context->len = remain;
         } else {                /* case 2 - partial data */
             memcpy(buffer, context->data, AES_BLOCK_SIZE);
-            memcpy(context->data, context->data + AES_BLOCK_SIZE,
-                   context->len - AES_BLOCK_SIZE);
+            memmove(context->data, context->data + AES_BLOCK_SIZE,
+                    context->len - AES_BLOCK_SIZE);
             memcpy(context->data + context->len - AES_BLOCK_SIZE,
                    in_data, in_data_len);
             context->len = context->len - AES_BLOCK_SIZE + in_data_len;


### PR DESCRIPTION
With some temporary code tweaking (comment asm statements out, replace libica calls with dummy functions, etc), I was able to build the EP11 and ICA tokens on x86 as well, and thus let Coverty find problems there as well.