### PR TITLE
Silence maybe-uninitialized warning

### DIFF
--- a/usr/lib/common/mech_aes.c
+++ b/usr/lib/common/mech_aes.c
@@ -4227,7 +4227,7 @@ CK_RV aes_xts_cipher(CK_BYTE *in_data, CK_ULONG in_data_len,
                      void *cb_data)
 {
     unsigned char partial[AES_BLOCK_SIZE];
-    unsigned char iv_prev[AES_INIT_VECTOR_SIZE];
+    unsigned char iv_prev[AES_INIT_VECTOR_SIZE] = { 0 };
     CK_ULONG len, rest;
     CK_RV rc;
 


### PR DESCRIPTION
Compiles may warn about a possibly uninitialized variable. This is a false positive, the variable is initialized in the code path where it is used. Zeroize the variable on the declaration to silence this warning.

```
usr/lib/common/mech_aes.c: In function 'aes_xts_cipher': usr/lib/common/mech_aes.c:4320:13: error: 'iv_prev' may be used uninitialized in this function [-Werror=maybe-uninitialized]
             memcpy(iv, iv_prev, AES_BLOCK_SIZE);
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```