### PR TITLE
Fixes for out of tree build

### DIFF
--- a/usr/lib/config/config.mk
+++ b/usr/lib/config/config.mk
@@ -8,10 +8,10 @@ usr/lib/config/cfglex.$(OBJEXT): usr/lib/config/cfgparse.h
 usr/lib/config/cfgparse.$(OBJEXT): usr/lib/config/cfglex.h
 
 usr/lib/config/cfgparse.c: usr/lib/config/cfgparse.y
-	$(AM_V_YACC)$(am__skipyacc) $(SHELL) $(YLWRAP) $< cfgparse.tab.c usr/lib/config/cfgparse.c cfgparse.tab.h usr/lib/config/cfgparse.h cfgparse.output usr/lib/config/cfgparse.output -- $(YACCCOMPILE)
+	$(AM_V_YACC)$(MKDIR_P) usr/lib/config && $(am__skipyacc) $(SHELL) $(YLWRAP) $< cfgparse.tab.c usr/lib/config/cfgparse.c cfgparse.tab.h usr/lib/config/cfgparse.h cfgparse.output usr/lib/config/cfgparse.output -- $(YACCCOMPILE)
 
 usr/lib/config/cfglex.c: usr/lib/config/cfglex.l
-	$(AM_V_LEX)$(am__skiplex) $(SHELL) $(YLWRAP) $< lex.config.c usr/lib/config/cfglex.c cfglex.h usr/lib/config/cfglex.h -- $(LEXCOMPILE)
+	$(AM_V_LEX)$(MKDIR_P) usr/lib/config && $(am__skiplex) $(SHELL) $(YLWRAP) $< lex.config.c usr/lib/config/cfglex.c cfglex.h usr/lib/config/cfglex.h -- $(LEXCOMPILE)
 
 CLEANFILES += usr/lib/config/cfglex.c usr/lib/config/cfglex.h	\
 usr/lib/config/cfgparse.c usr/lib/config/cfgparse.h		\

--- a/usr/sbin/pkcsicsf/pkcsicsf.mk
+++ b/usr/sbin/pkcsicsf/pkcsicsf.mk
@@ -6,8 +6,8 @@ usr_sbin_pkcsicsf_pkcsicsf_CFLAGS =					\
 	-D_THREAD_SAFE -DDEV -DAPI -DSTDLL_NAME=\"icsf\"		\
 	-I${srcdir}/usr/include -I${srcdir}/usr/lib/icsf_stdll		\
 	-I${srcdir}/usr/lib/common -I${srcdir}/usr/sbin/pkcsicsf	\
-	-I${srcdir}/usr/lib/config					\
-	-I${top_builddir}/usr/lib/config
+	-I${srcdir}/usr/lib/config -I${top_builddir}/usr/lib/config	\
+	-I${top_builddir}/usr/lib/api -I${srcdir}/usr/lib/api
 
 
 usr_sbin_pkcsicsf_pkcsicsf_SOURCES =					\


### PR DESCRIPTION
Fixes https://github.com/opencryptoki/opencryptoki/issues/636 from @mhartmay and another bug with the parser generation in out of tree builds.