### PR TITLE
EP11: Fix setting unknown CPs to ON

### DIFF
--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -11340,8 +11340,8 @@ static CK_RV control_point_handler(uint_32 adapter, uint_32 domain,
     if (data->first) {
         data->first_adapter = adapter;
         data->first_domain = domain;
-        /* Apply CP bits 0 to max_cp_index-1 only */
-        for (i = 0; i < max_cp_index; i++) {
+        /* Apply CP bits 0 to max_cp_index only */
+        for (i = 0; i <= max_cp_index; i++) {
             data->combined_cp[CP_BYTE_NO(i)] &=
                                     (cp[CP_BYTE_NO(i)] | ~CP_BIT_MASK(i));
         }
@@ -11362,8 +11362,8 @@ static CK_RV control_point_handler(uint_32 adapter, uint_32 domain,
                        data->first_domain);
         }
 
-        for (i = 0; i < max_cp_index; i++) {
-            /* Apply CP bits 0 to max_cp_index-1 only */
+        for (i = 0; i <= max_cp_index; i++) {
+            /* Apply CP bits 0 to max_cp_index only */
             data->combined_cp[CP_BYTE_NO(i)] &=
                                     (cp[CP_BYTE_NO(i)] | ~CP_BIT_MASK(i));
         }


### PR DESCRIPTION
The very last control point must also be applied from the queried bits to the combined bits. Otherwise the very last control point is always treated as being ON, although it might be OFF, and this can lead to mechanisms being used that are disabled by that control point.

Fixes https://github.com/opencryptoki/opencryptoki/commit/97248f73495695436f11fafd74c2ec41a5a6f796

This caused failures in the CI last night.