### PR TITLE
EP11: Fix set attribute values function for Data or Certificate objects.

### DIFF
--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -13397,12 +13397,6 @@ CK_RV token_specific_set_attribute_values(STDLL_TokData_t *tokdata,
         return rc;
     }
 
-    rc = template_attribute_get_ulong(obj->template, CKA_KEY_TYPE, &ktype);
-    if (rc != CKR_OK) {
-        TRACE_ERROR("%s CKA_KEY_TYPE is missing\n", __func__);
-        return rc;
-    }
-
     switch (class) {
     case CKO_SECRET_KEY:
     case CKO_PRIVATE_KEY:
@@ -13411,6 +13405,12 @@ CK_RV token_specific_set_attribute_values(STDLL_TokData_t *tokdata,
     default:
         /* Not a key, nothing to do */
         return CKR_OK;
+    }
+
+    rc = template_attribute_get_ulong(obj->template, CKA_KEY_TYPE, &ktype);
+    if (rc != CKR_OK) {
+        TRACE_ERROR("%s CKA_KEY_TYPE is missing\n", __func__);
+        return rc;
     }
 
     rc = obj_opaque_2_blob(tokdata, obj, &keyblob, &keyblobsize);


### PR DESCRIPTION
Data or Certificate objects do not have a key type(CKA_KEY_TYPE). So, Key type should be fetched after the switch case to handle this.

Signed-off-by: Vishnudatha Kanjur <kanjur@ibm.com>