### PR TITLE
TESTCASES: run AES pkey=1 tests only on EP11 token

### DIFF
--- a/testcases/crypto/aes_func.c
+++ b/testcases/crypto/aes_func.c
@@ -2799,9 +2799,11 @@ int main(int argc, char **argv)
     pkey = CK_FALSE;
     rv = aes_funcs();
 
-    pkey = CK_TRUE;
-    rv += aes_funcs();
-    rv += aes_funcs_pkey();
+    if (is_ep11_token(SLOT_ID)) {
+        pkey = CK_TRUE;
+        rv += aes_funcs();
+        rv += aes_funcs_pkey();
+    }
 
     testcase_print_result();
 


### PR DESCRIPTION
Running them on other tokens, that do not support pkey=1 will just produce lots of skip messages, but has no real use.

The same is already done in the EC testcases.