### PR TITLE
configure: Fix install location of tmpfiles.d config file

### DIFF
--- a/misc/misc.mk
+++ b/misc/misc.mk
@@ -31,7 +31,7 @@ if ENABLE_SYSTEMD
 servicedir = $(unitdir)
 service_DATA = misc/pkcsslotd.service
 
-tmpfilesdir = $(DESTDIR)/usr/lib/tmpfiles.d
+tmpfilesdir = /usr/lib/tmpfiles.d
 tmpfiles_DATA = misc/opencryptoki.conf
 
 CLEANFILES += misc/pkcsslotd.service misc/opencryptoki.conf


### PR DESCRIPTION
Don't prefix with destination directory, as this would produce an invalid directory. This would for example cause rpmbuild to fail.
Autoconf prefixes it with the destination directory automatically.