### PR TITLE
Fix compile error "error: initializer element is not constant"

### DIFF
--- a/testcases/crypto/dilithium_func.c
+++ b/testcases/crypto/dilithium_func.c
@@ -44,15 +44,10 @@ const _signVerifyParam signVerifyInput[] = {
 };
 
 const CK_BYTE dilithium_r2_65[] = OCK_DILITHIUM_R2_65;
-const CK_ULONG dilithium_r2_65_len = sizeof(dilithium_r2_65);
 const CK_BYTE dilithium_r2_87[] = OCK_DILITHIUM_R2_87;
-const CK_ULONG dilithium_r2_87_len = sizeof(dilithium_r2_87);
 const CK_BYTE dilithium_r3_44[] = OCK_DILITHIUM_R3_44;
-const CK_ULONG dilithium_r3_44_len = sizeof(dilithium_r3_44);
 const CK_BYTE dilithium_r3_65[] = OCK_DILITHIUM_R3_65;
-const CK_ULONG dilithium_r3_65_len = sizeof(dilithium_r3_65);
 const CK_BYTE dilithium_r3_87[] = OCK_DILITHIUM_R3_87;
-const CK_ULONG dilithium_r3_87_len = sizeof(dilithium_r3_87);
 
 typedef struct variant_info {
     const char *name;
@@ -64,15 +59,15 @@ typedef struct variant_info {
 const _variant_info variants[] = {
     { "DEFAULT (DILITHIUM_R2_65)", 0, NULL, 0 },
     { "DILITHIUM_R2_65", CK_IBM_DILITHIUM_KEYFORM_ROUND2_65,
-      dilithium_r2_65, dilithium_r2_65_len },
+      dilithium_r2_65, sizeof(dilithium_r2_65) },
     { "DILITHIUM_R2_87", CK_IBM_DILITHIUM_KEYFORM_ROUND2_87,
-      dilithium_r2_87, dilithium_r2_87_len },
+      dilithium_r2_87, sizeof(dilithium_r2_87) },
     { "DILITHIUM_R3_44", CK_IBM_DILITHIUM_KEYFORM_ROUND3_44,
-      dilithium_r3_44, dilithium_r3_44_len },
+      dilithium_r3_44, sizeof(dilithium_r3_44) },
     { "DILITHIUM_R3_65", CK_IBM_DILITHIUM_KEYFORM_ROUND3_65,
-      dilithium_r3_65, dilithium_r3_65_len },
+      dilithium_r3_65, sizeof(dilithium_r3_65) },
     { "DILITHIUM_R3_87", CK_IBM_DILITHIUM_KEYFORM_ROUND3_87,
-      dilithium_r3_87, dilithium_r3_87_len },
+      dilithium_r3_87, sizeof(dilithium_r3_87) },
 };
 
 const CK_ULONG num_variants = sizeof(variants) / sizeof(_variant_info);

--- a/testcases/crypto/kyber_func.c
+++ b/testcases/crypto/kyber_func.c
@@ -30,9 +30,7 @@
  */
 
 const CK_BYTE kyber_r2_768[] = OCK_KYBER_R2_768;
-const CK_ULONG kyber_r2_768_len = sizeof(kyber_r2_768);
 const CK_BYTE kyber_r2_1024[] = OCK_KYBER_R2_1024;
-const CK_ULONG kyber_r2_1024_len = sizeof(kyber_r2_1024);
 
 const CK_BYTE prime256v1[] = OCK_PRIME256V1;
 
@@ -46,9 +44,9 @@ typedef struct variant_info {
 const _variant_info variants[] = {
     { "DEFAULT (KYBER_R2_1024)", 0, NULL, 0 },
     { "KYBER_R2_768", CK_IBM_KYBER_KEYFORM_ROUND2_768,
-      kyber_r2_768, kyber_r2_768_len },
+      kyber_r2_768, sizeof(kyber_r2_768) },
     { "KYBER_R2_1024", CK_IBM_KYBER_KEYFORM_ROUND2_1024,
-      kyber_r2_1024, kyber_r2_1024_len },
+      kyber_r2_1024, sizeof(kyber_r2_1024) },
 };
 
 const CK_ULONG num_variants = sizeof(variants) / sizeof(_variant_info);

--- a/usr/lib/common/pqc_defs.h
+++ b/usr/lib/common/pqc_defs.h
@@ -16,20 +16,13 @@
 #include "pqc_oids.h"
 
 extern const CK_BYTE dilithium_r2_65[];
-extern const CK_ULONG dilithium_r2_65_len;
 extern const CK_BYTE dilithium_r2_87[];
-extern const CK_ULONG dilithium_r2_87_len;
 extern const CK_BYTE dilithium_r3_44[];
-extern const CK_ULONG dilithium_r3_44_len;
 extern const CK_BYTE dilithium_r3_56[];
-extern const CK_ULONG dilithium_r3_56_len;
 extern const CK_BYTE dilithium_r3_87[];
-extern const CK_ULONG dilithium_r3_87_len;
 
 extern const CK_BYTE kyber_r2_768[];
-extern const CK_ULONG kyber_r2_768_len;
 extern const CK_BYTE kyber_r2_1024[];
-extern const CK_ULONG kyber_r2_1024_len;
 
 struct pqc_oid {
     const CK_BYTE *oid;

--- a/usr/lib/common/pqc_supported.c
+++ b/usr/lib/common/pqc_supported.c
@@ -13,30 +13,25 @@
 #include "pqc_defs.h"
 
 const CK_BYTE dilithium_r2_65[] = OCK_DILITHIUM_R2_65;
-const CK_ULONG dilithium_r2_65_len = sizeof(dilithium_r2_65);
 const CK_BYTE dilithium_r2_87[] = OCK_DILITHIUM_R2_87;
-const CK_ULONG dilithium_r2_87_len = sizeof(dilithium_r2_87);
 const CK_BYTE dilithium_r3_44[] = OCK_DILITHIUM_R3_44;
-const CK_ULONG dilithium_r3_44_len = sizeof(dilithium_r3_44);
 const CK_BYTE dilithium_r3_65[] = OCK_DILITHIUM_R3_65;
-const CK_ULONG dilithium_r3_65_len = sizeof(dilithium_r3_65);
 const CK_BYTE dilithium_r3_87[] = OCK_DILITHIUM_R3_87;
-const CK_ULONG dilithium_r3_87_len = sizeof(dilithium_r3_87);
 
 const struct pqc_oid dilithium_oids[] = {
-    { .oid = dilithium_r2_65, .oid_len = dilithium_r2_65_len,
+    { .oid = dilithium_r2_65, .oid_len = sizeof(dilithium_r2_65),
       .keyform = CK_IBM_DILITHIUM_KEYFORM_ROUND2_65,
       .policy_size = 256, .policy_siglen = 3366 },
-    { .oid = dilithium_r2_87, .oid_len = dilithium_r2_87_len,
+    { .oid = dilithium_r2_87, .oid_len = sizeof(dilithium_r2_87),
       .keyform = CK_IBM_DILITHIUM_KEYFORM_ROUND2_87,
       .policy_size = 256, .policy_siglen = 4668 },
-    { .oid = dilithium_r3_44, .oid_len = dilithium_r3_44_len,
+    { .oid = dilithium_r3_44, .oid_len = sizeof(dilithium_r3_44),
       .keyform = CK_IBM_DILITHIUM_KEYFORM_ROUND3_44,
       .policy_size = 256, .policy_siglen = 2420 },
-    { .oid = dilithium_r3_65, .oid_len = dilithium_r3_65_len,
+    { .oid = dilithium_r3_65, .oid_len = sizeof(dilithium_r3_65),
       .keyform = CK_IBM_DILITHIUM_KEYFORM_ROUND3_65,
       .policy_size = 256, .policy_siglen = 3293 },
-    { .oid = dilithium_r3_87, .oid_len = dilithium_r3_87_len,
+    { .oid = dilithium_r3_87, .oid_len = sizeof(dilithium_r3_87),
       .keyform = CK_IBM_DILITHIUM_KEYFORM_ROUND3_87,
       .policy_size = 256, .policy_siglen = 4595 },
     { .oid = NULL, .oid_len = 0, .keyform = 0,
@@ -44,15 +39,13 @@ const struct pqc_oid dilithium_oids[] = {
 };
 
 const CK_BYTE kyber_r2_768[] = OCK_KYBER_R2_768;
-const CK_ULONG kyber_r2_768_len = sizeof(kyber_r2_768);
 const CK_BYTE kyber_r2_1024[] = OCK_KYBER_R2_1024;
-const CK_ULONG kyber_r2_1024_len = sizeof(kyber_r2_1024);
 
 const struct pqc_oid kyber_oids[] = {
-    { .oid = kyber_r2_768, .oid_len = kyber_r2_768_len,
+    { .oid = kyber_r2_768, .oid_len = sizeof(kyber_r2_768),
        .keyform = CK_IBM_KYBER_KEYFORM_ROUND2_768,
        .policy_size = 256, .policy_siglen = 0 },
-    { .oid = kyber_r2_1024, .oid_len = kyber_r2_1024_len,
+    { .oid = kyber_r2_1024, .oid_len = sizeof(kyber_r2_1024),
       .keyform = CK_IBM_KYBER_KEYFORM_ROUND2_1024,
       .policy_size = 256, .policy_siglen = 0 },
     { .oid = NULL, .oid_len = 0, .keyform = 0,


### PR DESCRIPTION
Some compiler versions report error "error: initializer element is not constant" for the PQC initializers.

Use sizeof() directly in the initializer, instead of declaring a global variable holding the size. Such a global variable is not always considered as a constant, although it is declared as const.