### PR TITLE
EP11: Fix possible memory leak

### DIFF
--- a/usr/lib/common/pkey_utils.c
+++ b/usr/lib/common/pkey_utils.c
@@ -328,7 +328,7 @@ CK_BBOOL pkey_is_ec_public_key(TEMPLATE *tmpl)
  *       because it tries to obtain a write lock on the key object.
  */
 CK_RV pkey_update_and_save(STDLL_TokData_t *tokdata, OBJECT *key_obj,
-                           CK_ATTRIBUTE *pkey_attr)
+                           CK_ATTRIBUTE **pkey_attr)
 {
     CK_RV ret1, ret2;
 
@@ -349,11 +349,12 @@ CK_RV pkey_update_and_save(STDLL_TokData_t *tokdata, OBJECT *key_obj,
     }
 
     /* Update attribute */
-    ret1 = template_update_attribute(key_obj->template, pkey_attr);
+    ret1 = template_update_attribute(key_obj->template, *pkey_attr);
     if (ret1 != CKR_OK) {
         TRACE_ERROR("template_update_attribute failed with rc=0x%lx\n", ret1);
         goto done;
     }
+    *pkey_attr = NULL;
 
     /* Save to repository if it's a token object */
     if (object_is_token_object(key_obj)) {

--- a/usr/lib/common/pkey_utils.h
+++ b/usr/lib/common/pkey_utils.h
@@ -86,7 +86,7 @@ int get_msa_level(void);
 CK_BBOOL pkey_is_ec_public_key(TEMPLATE *tmpl);
 
 CK_RV pkey_update_and_save(STDLL_TokData_t *tokdata, OBJECT *key_obj,
-                           CK_ATTRIBUTE *attr);
+                           CK_ATTRIBUTE **attr);
 
 CK_BBOOL pkey_op_supported_by_cpacf(int msa_level, CK_MECHANISM_TYPE type,
                                     TEMPLATE *tmpl);

--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -1184,8 +1184,8 @@ static CK_RV ep11tok_pkey_update(STDLL_TokData_t *tokdata, SESSION *session,
     }
 
     /* Now update the key obj. If it's a token obj, it will be also updated
-     * in the repository. */
-    ret = pkey_update_and_save(tokdata, key_obj, pkey_attr);
+     * in the repository. pkey_attr is set to NULL if added to the object.*/
+    ret = pkey_update_and_save(tokdata, key_obj, &pkey_attr);
     if (ret != CKR_OK) {
         TRACE_ERROR("pkey_update_and_save failed with rc=0x%lx\n", ret);
         goto done;
@@ -1194,6 +1194,8 @@ static CK_RV ep11tok_pkey_update(STDLL_TokData_t *tokdata, SESSION *session,
     ret = CKR_OK;
 
 done:
+    if (pkey_attr != NULL)
+        free(pkey_attr);
 
     return ret;
 }


### PR DESCRIPTION
When pkey_attr has been allocated by ep11tok_pkey_skey2pkey(), but afterwards, the verification pattern check fails, or pkey_update_and_save() fails without adding the attribute to the object, then pkey_attr must be freed.