### PR TITLE
ICA: Fix private exponent calculation

### DIFF
--- a/usr/lib/ica_s390_stdll/ica_specific.c
+++ b/usr/lib/ica_s390_stdll/ica_specific.c
@@ -1864,7 +1864,7 @@ static CK_RV rsa_calc_private_exponent(ica_rsa_key_mod_expo_t *publKey,
      */
     d = BN_bin2bn(publKey->modulus, publKey->key_length, NULL);
     e = BN_bin2bn(publKey->exponent, publKey->key_length, NULL);
-    p = BN_bin2bn(privKey->p, privKey->key_length / 2, NULL);
+    p = BN_bin2bn(privKey->p + 8, privKey->key_length / 2, NULL);
     q = BN_bin2bn(privKey->q, privKey->key_length / 2, NULL);
     if (d == NULL || e == NULL || p == NULL || q == NULL) {
         TRACE_DEVEL("BN_bin2bn failed\n");


### PR DESCRIPTION
The 'p' component in the libica CRT private key is padded with 8 bytes. 
Correct the conversion of the 'p' component into an OpenSSL BIGNUM by skipping the first 8 bytes of padding.

Unfortunately this is no where documented, one needs to 'know' that there is an 8 bytes padding for 'p', 'dp', and 'qInverse'.

This fixes an error during private exponent calculation at RSA key generation when BN_mod_inverse() returns an error, reporting that no inverse exists, because the 'p' component is wrong.

Fixes: b9ae1f6efbef ("ICA: Calculate private exponent when generating RSA keys")

@jschmidb Maybe you could add information about this 8 bytes padding to the libica header file and/or manual? 