### PR TITLE
COMMON: Create HSM_MK_CHANGE directory in RPM and at pkcsslotd startup

### DIFF
--- a/rpm/opencryptoki.spec
+++ b/rpm/opencryptoki.spec
@@ -262,6 +262,7 @@ exit 0
 %{_libdir}/opencryptoki/methods
 %{_libdir}/pkcs11/methods
 %dir %attr(770,root,pkcs11) %{_sharedstatedir}/%{name}
+%dir %attr(770,root,pkcs11) %{_sharedstatedir}/%{name}/HSM_MK_CHANGE/
 %dir %attr(770,root,pkcs11) %{_localstatedir}/lock/%{name}
 %dir %attr(770,root,pkcs11) %{_localstatedir}/lock/%{name}/*
 

--- a/usr/sbin/pkcsslotd/slotmgr.c
+++ b/usr/sbin/pkcsslotd/slotmgr.c
@@ -125,6 +125,8 @@ void run_sanity_checks(void)
         //drwxrwx---
         {LOCKDIR_PATH, S_IRWXU | S_IRWXG},
         {OCK_LOGDIR, S_IRWXU | S_IRWXG},
+        {CONFIG_PATH, S_IRWXU | S_IRWXG},
+        {CONFIG_PATH "/HSM_MK_CHANGE", S_IRWXU | S_IRWXG},
         {NULL, 0},
     };
 


### PR DESCRIPTION
Create the /var/lib/opencryptoki/HSM_MK_CHANGE/ directory during RPM install and check for it also during pkcsslotd startup.