### PR TITLE
hsm_mk_change: Try to open existing lock file before creating it

### DIFF
--- a/usr/lib/hsm_mk_change/hsm_mk_change.c
+++ b/usr/lib/hsm_mk_change/hsm_mk_change.c
@@ -48,6 +48,9 @@ CK_RV hsm_mk_change_lock_create(void)
     struct group *grp;
     mode_t mode = (S_IRUSR | S_IRGRP);
 
+    if (hsm_mk_change_lock_fd == -1)
+        hsm_mk_change_lock_fd = open(OCK_HSM_MK_CHANGE_LOCK_FILE, O_RDONLY);
+
     if (hsm_mk_change_lock_fd == -1) {
         hsm_mk_change_lock_fd = open(OCK_HSM_MK_CHANGE_LOCK_FILE,
                                      O_CREAT | O_RDONLY, mode);


### PR DESCRIPTION
If the OCK_HSM_MK_CHANGE_LOCK_FILE has already been created by another user, just open it. Only if it is not existent, try to create it and set the permissions.

While open(... , O_CREAT | O_RDONLY) also works for an already existing file, setting the permissions may fail if the file is owned by another user. However, when the file already exists, we can assume that the permissions are set correctly already.