### PR TITLE
EP11: Fix ep11tok_pkey_update to not fail if no reenc blob is available

### DIFF
--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -2016,13 +2016,10 @@ static CK_RV ep11tok_pkey_update(STDLL_TokData_t *tokdata, SESSION *session,
     }
 
     if (ep11_data->mk_change_active) {
-        if (template_attribute_get_non_empty(key_obj->template,
-                                             CKA_IBM_OPAQUE_REENC,
-                                             &skey_reenc_attr) != CKR_OK) {
-            TRACE_ERROR("This key has no reenc-blob: should not occur!\n");
-            ret = CKR_FUNCTION_FAILED;
-            goto done;
-        }
+        /* Try to get CKA_IBM_OPAQUE_REENC, ignore if it fails */
+        template_attribute_get_non_empty(key_obj->template,
+                                         CKA_IBM_OPAQUE_REENC,
+                                         &skey_reenc_attr);
     }
 
     /* Transform the secure key into a protected key */


### PR DESCRIPTION
Do not fail if a concurrent master key change is active but no re-enciphered key blob (attribute CKA_IBM_OPAQUE_REENC) is (not yet) available. This is a possible situation and is not an error case. Leave skey_reenc_attr = NULL in this case, and ep11tok_pkey_skey2pkey() and the ep11tok_pkey_wrap_handler() will take care abut this.