### PR TITLE
Covertiy fixes

### DIFF
--- a/usr/include/local_types.h
+++ b/usr/include/local_types.h
@@ -73,6 +73,6 @@ unsigned long bt_node_add(struct btree *t, void *value);
 void *bt_node_free(struct btree *t, unsigned long node_num,
                    int call_delete_func);
 void bt_destroy(struct btree *t);
-void bt_init(struct btree *t, void (*delete_func)(void *));
+CK_RV bt_init(struct btree *t, void (*delete_func)(void *));
 
 #endif

--- a/usr/lib/api/api_interface.c
+++ b/usr/lib/api/api_interface.c
@@ -3085,7 +3085,11 @@ CK_RV C_Initialize(CK_VOID_PTR pVoid)
     //if ( Shared Memory Mapped not Successful )
     //                Free allocated Memory
     //                Return CKR_HOST_MEMORY
-    bt_init(&Anchor->sess_btree, free);
+    if (bt_init(&Anchor->sess_btree, free) != CKR_OK) {
+        TRACE_ERROR("Btree init Failed.\n");
+        rc = CKR_FUNCTION_FAILED;
+        goto error;
+    }
 
 #if OPENSSL_VERSION_PREREQ(3, 0)
     /*

--- a/usr/lib/common/btree.c
+++ b/usr/lib/common/btree.c
@@ -456,11 +456,13 @@ void bt_destroy(struct btree *t)
  * Initialize a btree with a delete callback function that is used to delete
  * values during bt_node_free() and bt_destroy().
  */
-void bt_init(struct btree *t, void (*delete_func)(void *))
+CK_RV bt_init(struct btree *t, void (*delete_func)(void *))
 {
     t->free_list = NULL;
     t->top = NULL;
     t->size = 0;
     t->free_nodes = 0;
     t->delete_func = delete_func;
+
+    return CKR_OK;
 }

--- a/usr/lib/ep11_stdll/new_host.c
+++ b/usr/lib/ep11_stdll/new_host.c
@@ -79,11 +79,16 @@ CK_RV ST_Initialize(API_Slot_t *sltp, CK_SLOT_ID SlotNumber,
     /* set trace info */
     set_trace(t);
 
-    bt_init(&sltp->TokData->sess_btree, free);
-    bt_init(&sltp->TokData->object_map_btree, free);
-    bt_init(&sltp->TokData->sess_obj_btree, call_object_free);
-    bt_init(&sltp->TokData->priv_token_obj_btree, call_object_free);
-    bt_init(&sltp->TokData->publ_token_obj_btree, call_object_free);
+    rc = bt_init(&sltp->TokData->sess_btree, free);
+    rc |= bt_init(&sltp->TokData->object_map_btree, free);
+    rc |= bt_init(&sltp->TokData->sess_obj_btree, call_object_free);
+    rc |= bt_init(&sltp->TokData->priv_token_obj_btree, call_object_free);
+    rc |= bt_init(&sltp->TokData->publ_token_obj_btree, call_object_free);
+    if (rc != CKR_OK) {
+        TRACE_ERROR("Btree init failed\n");
+        rc = CKR_FUNCTION_FAILED;
+        goto done;
+    }
 
     if (strlen(sinfp->tokname)) {
         if (ock_snprintf(abs_tokdir_name, PATH_MAX, "%s/%s",
@@ -194,6 +199,11 @@ done:
         } else {
             CloseXProcLock(sltp->TokData);
             final_data_store(sltp->TokData);
+            bt_destroy(&sltp->TokData->sess_btree);
+            bt_destroy(&sltp->TokData->object_map_btree);
+            bt_destroy(&sltp->TokData->sess_obj_btree);
+            bt_destroy(&sltp->TokData->priv_token_obj_btree);
+            bt_destroy(&sltp->TokData->publ_token_obj_btree);
         }
     }
 

--- a/usr/lib/icsf_stdll/new_host.c
+++ b/usr/lib/icsf_stdll/new_host.c
@@ -77,11 +77,16 @@ CK_RV ST_Initialize(API_Slot_t *sltp, CK_SLOT_ID SlotNumber,
     /* set trace info */
     set_trace(t);
 
-    bt_init(&sltp->TokData->sess_btree, free);
-    bt_init(&sltp->TokData->object_map_btree, free);
-    bt_init(&sltp->TokData->sess_obj_btree, call_object_free);
-    bt_init(&sltp->TokData->priv_token_obj_btree, call_object_free);
-    bt_init(&sltp->TokData->publ_token_obj_btree, call_object_free);
+    rc = bt_init(&sltp->TokData->sess_btree, free);
+    rc |= bt_init(&sltp->TokData->object_map_btree, free);
+    rc |= bt_init(&sltp->TokData->sess_obj_btree, call_object_free);
+    rc |= bt_init(&sltp->TokData->priv_token_obj_btree, call_object_free);
+    rc |= bt_init(&sltp->TokData->publ_token_obj_btree, call_object_free);
+    if (rc != CKR_OK) {
+        TRACE_ERROR("Btree init failed\n");
+        rc = CKR_FUNCTION_FAILED;
+        goto done;
+    }
 
     if (strlen(sinfp->tokname)) {
         if (ock_snprintf(abs_tokdir_name, PATH_MAX, "%s/%s",
@@ -192,6 +197,11 @@ done:
         } else {
             CloseXProcLock(sltp->TokData);
             final_data_store(sltp->TokData);
+            bt_destroy(&sltp->TokData->sess_btree);
+            bt_destroy(&sltp->TokData->object_map_btree);
+            bt_destroy(&sltp->TokData->sess_obj_btree);
+            bt_destroy(&sltp->TokData->priv_token_obj_btree);
+            bt_destroy(&sltp->TokData->publ_token_obj_btree);
         }
     }
 


### PR DESCRIPTION
Check errors for all RW-lock or mutex initialization calls, and perform proper error handling and cleanup if it fails.
