### PR TITLE
configure: Don't add libcap to LIBS globally

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -72,8 +72,10 @@ fi
 
 AC_CHECK_LIB([itm], [_ITM_commitTransaction], [itm=yes], [itm=no])
 
-AC_CHECK_LIB([cap], [cap_get_proc], [],
+LIBCAP_LIBS=
+AC_CHECK_LIB([cap], [cap_get_proc], [LIBCAP_LIBS="-lcap"],
 		[AC_MSG_ERROR(['libcap' library is missing on your system. Please install 'libcap-devel'.])])
+AC_SUBST([LIBCAP_LIBS])
 
 OPENLDAP_LIBS=
 AC_CHECK_HEADERS([lber.h ldap.h],


### PR DESCRIPTION
Library libcap is only needed by pkcsslotd, bot not by all the other executables.

AC_CHECK_LIB without a 'action-if-found' specified will add the library to the global LIBS, and thus all executables will link against it. Avoid this by specifying a 'action-if-found' action and build a LIBCAP_LIBS variable (which however is unused).