### PR TITLE
EP11: Handle RSA clear key import for key with p < q

### DIFF
--- a/usr/lib/common/h_extern.h
+++ b/usr/lib/common/h_extern.h
@@ -2562,6 +2562,7 @@ CK_RV rsa_priv_wrap_get_data(TEMPLATE *tmpl, CK_BBOOL length_only,
 CK_RV rsa_priv_unwrap(TEMPLATE *tmpl, CK_BYTE *data, CK_ULONG data_len);
 CK_RV rsa_priv_unwrap_get_data(TEMPLATE *tmpl,
                               CK_BYTE *data, CK_ULONG total_length);
+CK_RV rsa_priv_check_and_swap_pq(TEMPLATE *tmpl);
 
 // dsa routines
 //

--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -4379,6 +4379,12 @@ static CK_RV import_RSA_key(STDLL_TokData_t *tokdata, SESSION *sess,
 
         /* imported private RSA key goes here */
 
+        rc = rsa_priv_check_and_swap_pq(rsa_key_obj->template);
+        if (rc != CKR_OK) {
+            TRACE_DEVEL("%s RSA check and swap failed\n", __func__);
+            goto import_RSA_key_end;
+        }
+
         /* extract the secret data to be wrapped
          * since this is AES_CBC_PAD, padding is done in mechanism.
          */


### PR DESCRIPTION
Older EP11 card generations don't seem to like RSA CRT keys with p < q. Check for such keys during clear key import, and swap its CRT components and recalculate qInv (CKA_COEFFICIENT).