### PR TITLE
p11sak fixes

### DIFF
--- a/usr/sbin/p11sak/p11sak.c
+++ b/usr/sbin/p11sak/p11sak.c
@@ -1712,6 +1712,7 @@ static CK_RV process_number_argument(const struct p11sak_arg *arg, char *val)
 {
     char *endptr;
 
+    errno = 0;
     *arg->value.number = strtoul(val, &endptr, 0);
 
     if ((errno == ERANGE && *arg->value.number == ULONG_MAX) ||


### PR DESCRIPTION
A command like 'p11sak list-key all --slot N ...' fails with

  p11sak: Attribute CKA_KEY_TYPE is not available in key object
  p11sak: Failed to iterate over key objects for key type All: 0xD0: CKR_TEMPLATE_INCOMPLETE
  p11sak: Failed to perform the 'list-key' command: CKR_TEMPLATE_INCOMPLETE

when the object repository contains other, non-key objects, e.g. certificates.

When 'all' is used as key type, then no filter for CKA_KEY_TYPE is used with C_FindObjects(), and thus other non-key objects also match the filter. When a specific key type is specified, then only such objects match that have the desired CKA_KEY_TYPE attribute value.

Fix this by checking the object class in get_key_infos() and skip the object, if it is not a key object.