### PR TITLE
More p11sak fixes

### DIFF
--- a/usr/sbin/p11sak/p11sak.c
+++ b/usr/sbin/p11sak/p11sak.c
@@ -4085,7 +4085,7 @@ static const struct p11sak_objtype *find_keytype(CK_KEY_TYPE ktype)
 {
     const struct p11sak_objtype **kt;
 
-    for (kt = p11sak_keytypes; (*kt)->name != NULL; kt++) {
+    for (kt = p11sak_keytypes; *kt != NULL; kt++) {
         if ((*kt)->type == ktype)
             return *kt;
     }
@@ -4097,7 +4097,7 @@ static const struct p11sak_objtype *find_keytype_by_pkey(int pkey_type)
 {
     const struct p11sak_objtype **kt;
 
-    for (kt = p11sak_keytypes; (*kt)->name != NULL; kt++) {
+    for (kt = p11sak_keytypes; *kt != NULL; kt++) {
         if ((*kt)->pkey_type == pkey_type)
             return *kt;
     }
@@ -4109,7 +4109,7 @@ static const struct p11sak_objtype *find_certtype(CK_KEY_TYPE ktype)
 {
     const struct p11sak_objtype **kt;
 
-    for (kt = p11sak_certtypes; (*kt)->name != NULL; kt++) {
+    for (kt = p11sak_certtypes; *kt != NULL; kt++) {
         if ((*kt)->type == ktype)
             return *kt;
     }
@@ -5326,7 +5326,7 @@ static const struct p11sak_attr *find_attribute(CK_ATTRIBUTE_TYPE type)
             return attr;
     }
 
-    for (keytype = p11sak_keytypes; (*keytype)->name != NULL; keytype++) {
+    for (keytype = p11sak_keytypes; *keytype != NULL; keytype++) {
         for (attr = (*keytype)->secret_attrs;
                                 attr != NULL && attr->name != NULL; attr++) {
             if (attr->type == type)
@@ -5346,7 +5346,7 @@ static const struct p11sak_attr *find_attribute(CK_ATTRIBUTE_TYPE type)
         }
     }
 
-    for (keytype = p11sak_certtypes; (*keytype)->name != NULL; keytype++) {
+    for (keytype = p11sak_certtypes; *keytype != NULL; keytype++) {
         for (attr = (*keytype)->cert_attrs;
                                 attr != NULL && attr->name != NULL; attr++) {
             if (attr->type == type)

--- a/usr/sbin/p11sak/p11sak.c
+++ b/usr/sbin/p11sak/p11sak.c
@@ -9140,7 +9140,8 @@ static CK_RV p11sak_cert_extract_pubkey(const struct p11sak_objtype *certtype,
 
     rc = certtype->extract_x509_pubkey(certtype, &attrs, &num_attrs, cert, label);
     if (rc != CKR_OK) {
-        warnx("Failed to extract public key from certificate object, rc=%lx.",rc);
+        warnx("Failed to extract public key from certificate object: 0x%lx: %s",
+              rc, p11_get_ckr(rc));
         goto done;
     }
 
@@ -9447,7 +9448,8 @@ static CK_RV handle_cert_export(CK_OBJECT_HANDLE cert, CK_OBJECT_CLASS class,
 
     rc = certtype->export_x509_data(certtype, &cert_data, &data_len, cert, label);
     if (rc != CKR_OK) {
-        warnx("Failed to export certificate object into X509 object, rc=%lx.",rc);
+        warnx("Failed to export certificate object into X509 object, 0x%lx: %s",
+              rc, p11_get_ckr(rc));
         data->num_failed++;
         rc = CKR_OK;
         goto done;


### PR DESCRIPTION
An RSA-PSS key can be generated via:
`openssl genpkey -algorithm rsa-pss -pkeyopt rsa_keygen_bits:2048  -out rsapss.pem`
Generating a certificate with this key resuts in a certificate that contains an RSA-PSS key.