### PR TITLE
CCA/EP11: add info about AES-XTS to token config files

### DIFF
--- a/usr/lib/cca_stdll/ccatok.conf
+++ b/usr/lib/cca_stdll/ccatok.conf
@@ -31,6 +31,10 @@ version cca-0
 # IBM specific boolean attribute CKA_IBM_PROTKEY_EXTRACTABLE must be true to
 # make a key eligible for protected key support. 
 #
+# AES-XTS related mechanisms are only available if the PKEY_MODE option is not
+# disabled and additional hardware and firmware prerequisites are met. AES-XTS
+# is not supported via the CCA coprocessor itself.
+#
 #    PKEY_MODE = DISABLED | DEFAULT | ENABLED
 #
 #        DISABLED       : Protected key support disabled. All keys are used 

--- a/usr/lib/ep11_stdll/ep11tok.conf
+++ b/usr/lib/ep11_stdll/ep11tok.conf
@@ -81,6 +81,10 @@
 # and CKA_EXTRACTABLE cannot both be true. The default value of
 # CKA_IBM_PROTKEY_EXTRACTABLE is false.
 #
+# AES-XTS related mechanisms are only available if the PKEY_MODE option is not
+# disabled and additional hardware and firmware prerequisites are met. AES-XTS
+# is not supported via the EP11 coprocessor itself.
+#
 #      PKEY_MODE DISABLED | DEFAULT | ENABLE4NONEXTR
 #
 #        DISABLED       : Protected key support disabled. All key operations


### PR DESCRIPTION
For both tokens, AES-XTS is only supported via protected keys. Other operation modes, like ECB and CBC, are just accelerated via the PKEY_MODE option.