### PR TITLE
TESTCASES: abfunc test did leave one EC key over

### DIFF
--- a/testcases/crypto/abfunc.c
+++ b/testcases/crypto/abfunc.c
@@ -20,7 +20,7 @@
 #include "mech_to_str.h"
 #include "ec_curves.h"
 
-#define NUMKEYS 15
+#define NUMKEYS 16
 
 struct keys {
     union keysunion {


### PR DESCRIPTION
When running the abfunc test, one EC private key was left over, because the test creates 16 keys, but NUMKEYS was 15.