### PR TITLE
TPM: Fix issue caused by uninitialized variables

### DIFF
--- a/usr/lib/tpm_stdll/tpm_openssl.c
+++ b/usr/lib/tpm_stdll/tpm_openssl.c
@@ -240,10 +240,10 @@ int openssl_get_modulus_and_prime(EVP_PKEY *pkey, unsigned int *size_n,
                                   unsigned char *p)
 {
 #if !OPENSSL_VERSION_PREREQ(3, 0)
-    const BIGNUM *n_tmp, *p_tmp;
+    const BIGNUM *n_tmp = NULL, *p_tmp = NULL;
     RSA *rsa;
 #else
-    BIGNUM *n_tmp, *p_tmp;
+    BIGNUM *n_tmp = NULL, *p_tmp = NULL;
 #endif
     int len;
 


### PR DESCRIPTION
Set NULL to OpenSSL BIGNUM pointers as initial value. Otherwise it will crash in OpenSSL libary when invoking openssl_get_modulus_and_prime function.