### PR TITLE
CCA: All numeric fields in CCA key tokens and verb-data are big endian

### DIFF
--- a/testcases/misc_tests/cca_export_import_test.c
+++ b/testcases/misc_tests/cca_export_import_test.c
@@ -11,11 +11,13 @@
  * by Harald Freudenberger <freude@de.ibm.com>
  */
 
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <memory.h>
 #include <stdint.h>
+#include <endian.h>
 
 #include "pkcs11types.h"
 #include "ec_curves.h"
@@ -217,7 +219,7 @@ static CK_RV import_cca_gen_sec_key(CK_SESSION_HANDLE session,
     // calculate expected payloadbitsize based on keybitsize
     calc_pl = (((keybitsize + 32) + 63) & (~63)) + 320;
     // pull payloadbitsize from the cca hmac token
-    pl = *((uint16_t *)(ccatoken + 38));
+    pl = be16toh(*((uint16_t *)(ccatoken + 38)));
     if (calc_pl != pl) {
         testcase_error("mismatch keybitsize %u - expected pl bitsize %u / cca pl bitsize %u",
                        keybitsize, calc_pl, pl);

--- a/usr/sbin/pkcscca/pkcscca.c
+++ b/usr/sbin/pkcscca/pkcscca.c
@@ -196,7 +196,7 @@ int adjust_secret_key_attributes(OBJECT *obj, CK_ULONG key_type)
     ibm_opaque_attr = NULL;
 
     /* Provide dummy CKA_VAUE attribute in (clear) key size */
-    key_size = aes_token->bitsize / 8;
+    key_size = be16toh(aes_token->bitsize) / 8;
     zero = (CK_BYTE *)calloc(key_size, 1);
     if (zero == NULL) {
         fprintf(stderr, "Failed to allocate zero value\n");


### PR DESCRIPTION
On the s390x platform this does not make a difference, since s390x is big endian itself. However, on little endian platforms care must be taken to convert such fields to the correct endianness.