### PR TITLE
EP11/CCA: Fixes and change regarding CKA_SENSITIVE and CKA_EXTRACTABLE defaults

### DIFF
--- a/usr/lib/cca_stdll/cca_specific.c
+++ b/usr/lib/cca_stdll/cca_specific.c
@@ -1937,11 +1937,19 @@ CK_RV cca_load_config_file(STDLL_TokData_t *tokdata, char *conf_name)
             continue;
         }
 
+        if (confignode_hastype(c, CT_BARECONST)) {
+            /* single keyword tokens */
+            if (strcasecmp(c->key, "FORCE_SENSITIVE") == 0) {
+                cca_private->cka_sensitive_default_true = TRUE;
+                continue;
+            }
+        }
+
         if (confignode_hastype(c, CT_BAREVAL)) {
             /* New style (key = value) tokens */
             strval = confignode_getstr(c);
 
-            if (strcmp(c->key, "PKEY_MODE") == 0) {
+            if (strcasecmp(c->key, "PKEY_MODE") == 0) {
                 rc = cca_config_set_pkey_mode(cca_private, fname, strval);
                 if (rc != CKR_OK)
                     break;
@@ -2735,17 +2743,23 @@ done:
 }
 
 /*
- * This function is called whenever a new object is created. It currently sets
+ * This function is called whenever a new object is created. It sets
  * attribute CKA_IBM_PROTKEY_EXTRACTABLE according to the PKEY_MODE token
- * option, but may also be used for other token options and attrs in future.
+ * option.
+ * If the FORCE_SENSITIVE token option is enabled, it sets attribute
+ * CKA_SENSITIVE to TRUE for secret keys (CKO_SECRET_KEY) if it is not
+ * specified in the template. For private keys (CKO_PRIVATE_KEY) it always
+ * sets CKA_SENSITIVE to TRUE if it is not specified in the template,
+ * regardless of the FORCE_SENSITIVE option.
  */
 CK_RV token_specific_set_attrs_for_new_object(STDLL_TokData_t *tokdata,
                                               CK_OBJECT_CLASS class,
                                               CK_ULONG mode, TEMPLATE *tmpl)
 {
     struct cca_private_data *cca_data = tokdata->private_data;
-    CK_ATTRIBUTE *pkey_attr = NULL, *ecp_attr = NULL;
+    CK_ATTRIBUTE *pkey_attr = NULL, *ecp_attr = NULL, *sensitive_attr = NULL;
     CK_BBOOL add_pkey_extractable = CK_FALSE;
+    CK_BBOOL sensitive;
     CK_BBOOL btrue = CK_TRUE;
     CK_RV ret;
 
@@ -2754,6 +2768,27 @@ CK_RV token_specific_set_attrs_for_new_object(STDLL_TokData_t *tokdata,
     if (class != CKO_SECRET_KEY && class != CKO_PRIVATE_KEY &&
         class != CKO_PUBLIC_KEY)
         return CKR_OK;
+
+    if (class == CKO_PRIVATE_KEY ||
+        (class == CKO_SECRET_KEY && cca_data->cka_sensitive_default_true)) {
+        /* private key, or secret key and FORCE_SENSITIVE is enabled */
+        ret = template_attribute_get_bool(tmpl, CKA_SENSITIVE, &sensitive);
+        if (ret == CKR_TEMPLATE_INCOMPLETE) {
+            /* Not in template, supply default (TRUE) */
+            ret = build_attribute(CKA_SENSITIVE, &btrue, sizeof(CK_BBOOL),
+                                  &sensitive_attr);
+            if (ret != CKR_OK) {
+                TRACE_ERROR("build_attribute failed with ret=0x%lx\n", ret);
+                goto done;
+            }
+            ret = template_update_attribute(tmpl, sensitive_attr);
+            if (ret != CKR_OK) {
+                TRACE_ERROR("update_attribute failed with ret=0x%lx\n", ret);
+                free(sensitive_attr);
+                goto done;
+            }
+        }
+    }
 
     switch (cca_data->pkey_mode) {
     case PKEY_MODE_DISABLED:

--- a/usr/lib/cca_stdll/cca_stdll.h
+++ b/usr/lib/cca_stdll/cca_stdll.h
@@ -263,6 +263,7 @@ struct cca_private_data {
     char pkey_mk_vp[PKEY_MK_VP_LENGTH];
     int pkeyfd;
     int msa_level;
+    CK_BBOOL cka_sensitive_default_true;
 };
 
 #define CCA_CFG_EXPECTED_MKVPS  "EXPECTED_MKVPS"

--- a/usr/lib/cca_stdll/ccatok.conf
+++ b/usr/lib/cca_stdll/ccatok.conf
@@ -55,3 +55,10 @@ version cca-0
 #                         = true and a protected key is automatically created
 #                         at first use of the key.
 #
+# --------------------------------------------------------------------------
+#
+# To force that the default for CKA_SENSITIVE is CK_TRUE for
+# secret keys specify the following option:
+#
+#      FORCE_SENSITIVE
+#

--- a/usr/lib/common/h_extern.h
+++ b/usr/lib/common/h_extern.h
@@ -1974,6 +1974,9 @@ CK_RV digest_mgr_digest_final(STDLL_TokData_t *tokdata,
 
 // key manager routines
 //
+CK_RV key_mgr_apply_always_sensitive_never_extractable_attrs(
+                                    STDLL_TokData_t *tokdata, OBJECT *key_obj);
+
 CK_RV key_mgr_generate_key(STDLL_TokData_t *tokdata,
                            SESSION *sess,
                            CK_MECHANISM *mech,

--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -4661,6 +4661,15 @@ retry_xts:
     }
     attr = NULL;
 
+    /* Set CKA_ALWAYS_SENSITIVE and CKA_NEVER_EXTRACTABLE */
+    rc = key_mgr_apply_always_sensitive_never_extractable_attrs(tokdata,
+                                                                key_obj);
+    if (rc != CKR_OK) {
+        TRACE_ERROR("%s key_mgr_apply_always_sensitive_never_extractable_attrs "
+                    "failed  with rc=0x%lx\n", __func__, rc);
+        goto error;
+    }
+
     /* key should be fully constructed.
      * Assign an object handle and store key.
      * Enforce policy.
@@ -8246,6 +8255,15 @@ CK_RV ep11tok_generate_key_pair(STDLL_TokData_t * tokdata, SESSION * sess,
     n_attr = NULL;
     free(spki);
     spki = NULL;
+
+    /* Set CKA_ALWAYS_SENSITIVE and CKA_NEVER_EXTRACTABLE */
+    rc = key_mgr_apply_always_sensitive_never_extractable_attrs(tokdata,
+                                                            private_key_obj);
+    if (rc != CKR_OK) {
+        TRACE_ERROR("%s key_mgr_apply_always_sensitive_never_extractable_attrs "
+                    "failed with rc=0x%lx\n", __func__, rc);
+        goto error;
+    }
 
     /* Keys should be fully constructed,
      * assign object handles and store keys.


### PR DESCRIPTION
**EP11:** 
When a secret key (CKO_SECRET_KEY) or a private key (CKO_PRIVATE_KEY) is generated with CKA_SENSITIVE=TRUE and/or CKA_EXTRACTABLE=FALSE then set CKA_ALWAYS_SENSITIVE to TRUE and/or CKA_NEVER_EXTRACTABLE to TRUE accordingly.

This is the same as done by common code in key_mgr_generate_key() and key_mgr_generate_key_pair(). Factor-out this code and make a separate function out of it that can be called from the EP11 token.

**EP11+CCA:** 
The PKCS#11 standard defines that the default value for CKA_SENSITIVE is FALSE for secret keys (CKO_SECRET_KEY), and for private keys (CKO_PRIVATE_KEY) the default is token dependent.

If the FORCE_SENSITIVE token option is enabled, set attribute CKA_SENSITIVE to TRUE for secret keys (CKO_SECRET_KEY) if it is not specified in the template. This is against the PKCS#11 standard, but it is done only when the FORCE_SENSITIVE option is enabled.

For private keys (CKO_PRIVATE_KEY) always set CKA_SENSITIVE to TRUE if it is not specified in the template, regardless of the FORCE_SENSITIVE option. This is according to the PKCS#11 standard, since for private keys the default is defined as being token dependent, and thus the EP11 or CCA token can define its own default value (i.e. TRUE).