### PR TITLE
TESTCASE: Correct test run counting for digest test

### DIFF
--- a/testcases/crypto/digest_func.c
+++ b/testcases/crypto/digest_func.c
@@ -1715,10 +1715,12 @@ CK_RV do_SHA_derive_key(void)
                     continue;
                 }
 
+                testcase_new_assertion();
                 testcase_fail("Derive key with %s keytype=0x%lx, value_len=%lu: rc: %s",
                               mech_to_str(derive_mechs[i].mechanism),
                               key_type, key_len, p11_get_ckr(rc));
             } else {
+                testcase_new_assertion();
                 testcase_pass("Derive key with %s keytype=0x%lx, value_len=%lu",
                               mech_to_str(derive_mechs[i].mechanism),
                               key_type, key_len);

--- a/testcases/crypto/dilithium_func.c
+++ b/testcases/crypto/dilithium_func.c
@@ -338,7 +338,6 @@ CK_RV run_GenerateDilithiumKeyPairSignVerify(void)
                        dilithium_attr_public, num_dilithium_attrs,
                        dilithium_attr_private, num_dilithium_attrs,
                        &publ_key, &priv_key);
-        testcase_new_assertion();
         if (rc != CKR_OK) {
             if (rc == CKR_KEY_SIZE_RANGE) {
                 testcase_skip("C_GenerateKeyPair with %s (%s) not supported",
@@ -346,12 +345,14 @@ CK_RV run_GenerateDilithiumKeyPairSignVerify(void)
                      i < num_variants ? "KEYFORM" : "MODE");
                 goto next;
             } else {
+                testcase_new_assertion();
                 testcase_fail("C_GenerateKeyPair with %s (%s) and valid input failed, rc=%s",
                      variants[i % num_variants].name,
                      i < num_variants ? "KEYFORM" : "MODE", p11_get_ckr(rc));
                 goto testcase_cleanup;
             }
         }
+        testcase_new_assertion();
         testcase_pass("*Generate Dilithium key pair with %s (%s) passed.",
                       variants[i % num_variants].name,
                       i < num_variants ? "KEYFORM" : "MODE");
@@ -444,7 +445,6 @@ CK_RV run_ImportDilithiumKeyPairSignVerify(void)
                             dilithium_tv[i].t0, dilithium_tv[i].t0_len,
                             dilithium_tv[i].t1, dilithium_tv[i].t1_len,
                             &priv_key);
-        testcase_new_assertion();
         if (rc != CKR_OK) {
             if (rc == CKR_KEY_SIZE_RANGE) {
                 testcase_skip("C_CreateObject with %s not supported",
@@ -454,10 +454,12 @@ CK_RV run_ImportDilithiumKeyPairSignVerify(void)
                 testcase_skip("Dilithium key import is not allowed by policy");
                 continue;
             }
+            testcase_new_assertion();
             testcase_fail("C_CreateObject (Dilithium Private Key) failed at i=%lu, "
                           "rc=%s", i, p11_get_ckr(rc));
             goto testcase_cleanup;
         }
+        testcase_new_assertion();
         testcase_pass("*Import Dilithium private key (%s) index=%lu passed.",
                       dilithium_tv[i].name, i);
 
@@ -468,7 +470,6 @@ CK_RV run_ImportDilithiumKeyPairSignVerify(void)
                                 dilithium_tv[i].rho, dilithium_tv[i].rho_len,
                                 dilithium_tv[i].t1, dilithium_tv[i].t1_len,
                                 &publ_key);
-        testcase_new_assertion();
         if (rc != CKR_OK) {
             if (rc == CKR_KEY_SIZE_RANGE) {
                 testcase_skip("C_CreateObject with %s not supported",
@@ -478,10 +479,12 @@ CK_RV run_ImportDilithiumKeyPairSignVerify(void)
                 testcase_skip("Dilithium key import is not allowed by policy");
                 goto testcase_cleanup;
             }
+            testcase_new_assertion();
             testcase_fail("C_CreateObject (Dilithium Public Key) failed at i=%lu, "
                           "rc=%s", i, p11_get_ckr(rc));
             goto testcase_cleanup;
         }
+        testcase_new_assertion();
         testcase_pass("*Import Dilithium public key (%s) index=%lu passed.",
                       dilithium_tv[i].name, i);
 
@@ -665,7 +668,6 @@ CK_RV run_TransferDilithiumKeyPairSignVerify(void)
                             dilithium_tv[i].t0, dilithium_tv[i].t0_len,
                             dilithium_tv[i].t1, dilithium_tv[i].t1_len,
                             &priv_key);
-        testcase_new_assertion();
         if (rc != CKR_OK) {
             if (rc == CKR_KEY_SIZE_RANGE) {
                 testcase_skip("C_CreateObject with %s not supported",
@@ -675,11 +677,13 @@ CK_RV run_TransferDilithiumKeyPairSignVerify(void)
                 testcase_skip("Dilithium key import is not allowed by policy");
                 continue;
             }
+            testcase_new_assertion();
             testcase_fail
                 ("C_CreateObject (Dilithium Private Key) failed at i=%lu, rc=%s", i,
                  p11_get_ckr(rc));
             goto testcase_cleanup;
         }
+        testcase_new_assertion();
         testcase_pass("*Import Dilithium private key (%s) index=%lu passed.",
                       dilithium_tv[i].name, i);
 
@@ -690,7 +694,6 @@ CK_RV run_TransferDilithiumKeyPairSignVerify(void)
                                 dilithium_tv[i].rho, dilithium_tv[i].rho_len,
                                 dilithium_tv[i].t1, dilithium_tv[i].t1_len,
                                 &publ_key);
-        testcase_new_assertion();
         if (rc != CKR_OK) {
             if (rc == CKR_KEY_SIZE_RANGE) {
                 testcase_skip("C_CreateObject with %s not supported",
@@ -700,11 +703,13 @@ CK_RV run_TransferDilithiumKeyPairSignVerify(void)
                 testcase_skip("Dilithium key import is not allowed by policy");
                 goto testcase_cleanup;
             }
+            testcase_new_assertion();
             testcase_fail
                 ("C_CreateObject (Dilithium Public Key) failed at i=%lu, rc=%s", i,
                  p11_get_ckr(rc));
             goto testcase_cleanup;
         }
+        testcase_new_assertion();
         testcase_pass("*Import Dilithium public key (%s) index=%lu passed.",
                       dilithium_tv[i].name, i);
 

--- a/testcases/crypto/kyber_func.c
+++ b/testcases/crypto/kyber_func.c
@@ -618,7 +618,6 @@ CK_RV run_GenerateKyberKeyPairEnDecryptKEM(void)
                        kyber_attr_public, num_kyber_attrs,
                        kyber_attr_private, num_kyber_attrs,
                        &publ_key, &priv_key);
-        testcase_new_assertion();
         if (rc != CKR_OK) {
             if (rc == CKR_KEY_SIZE_RANGE) {
                 testcase_skip("C_GenerateKeyPair with %s (%s) not supported",
@@ -626,12 +625,14 @@ CK_RV run_GenerateKyberKeyPairEnDecryptKEM(void)
                      i < num_variants ? "KEYFORM" : "MODE");
                 goto next;
             } else {
+                testcase_new_assertion();
                 testcase_fail("C_GenerateKeyPair with %s (%s) failed, rc=%s",
                      variants[i % num_variants].name,
                      i < num_variants ? "KEYFORM" : "MODE", p11_get_ckr(rc));
                 goto testcase_cleanup;
             }
         }
+        testcase_new_assertion();
         testcase_pass("*Generate Kyber key pair with %s (%s) passed.",
                       variants[i % num_variants].name,
                       i < num_variants ? "KEYFORM" : "MODE");
@@ -738,7 +739,6 @@ CK_RV run_ImportKyberKeyPairKEM(void)
                             kyber_tv[i].sk, kyber_tv[i].sk_len,
                             kyber_tv[i].pk, kyber_tv[i].pk_len,
                             &priv_key);
-        testcase_new_assertion();
         if (rc != CKR_OK) {
             if (rc == CKR_KEY_SIZE_RANGE) {
                 testcase_skip("C_CreateObject with key form %lu not supported",
@@ -749,10 +749,12 @@ CK_RV run_ImportKyberKeyPairKEM(void)
                 testcase_skip("Kyber key import is not allowed by policy");
                 continue;
             }
+            testcase_new_assertion();
             testcase_fail("C_CreateObject (Kyber Private Key) failed at i=%lu, "
                           "rc=%s", i, p11_get_ckr(rc));
             goto next;
         }
+        testcase_new_assertion();
         testcase_pass("*Import Kyber private key (%s) index=%lu passed.",
                       kyber_tv[i].name, i);
 
@@ -762,7 +764,6 @@ CK_RV run_ImportKyberKeyPairKEM(void)
                                 kyber_tv[i].keyform,
                                 kyber_tv[i].pk, kyber_tv[i].pk_len,
                                 &publ_key);
-        testcase_new_assertion();
         if (rc != CKR_OK) {
             if (rc == CKR_KEY_SIZE_RANGE) {
                 testcase_skip("C_CreateObject with key form %lu not supported",
@@ -773,10 +774,12 @@ CK_RV run_ImportKyberKeyPairKEM(void)
                 testcase_skip("Kyber key import is not allowed by policy");
                 goto testcase_cleanup;
             }
+            testcase_new_assertion();
             testcase_fail("C_CreateObject (Kyber Public Key) failed at i=%lu, "
                           "rc=%s", i, p11_get_ckr(rc));
             goto next;
         }
+        testcase_new_assertion();
         testcase_pass("*Import Kyber public key (%s) index=%lu passed.",
                       kyber_tv[i].name, i);
 
@@ -963,7 +966,6 @@ CK_RV run_TransferKyberKeyPair(void)
                             kyber_tv[i].pk, kyber_tv[i].pk_len,
                             &priv_key);
 
-        testcase_new_assertion();
         if (rc != CKR_OK) {
             if (rc == CKR_KEY_SIZE_RANGE) {
                 testcase_skip("C_CreateObject with key form %lu not supported",
@@ -974,11 +976,13 @@ CK_RV run_TransferKyberKeyPair(void)
                 testcase_skip("Kyber key import is not allowed by policy");
                 continue;
             }
+            testcase_new_assertion();
             testcase_fail
                 ("C_CreateObject (Kyber Private Key) failed at i=%lu, rc=%s", i,
                  p11_get_ckr(rc));
             goto next;
         }
+        testcase_new_assertion();
         testcase_pass("*Import Kyber private key (%s) index=%lu passed.",
                       kyber_tv[i].name, i);
 
@@ -988,7 +992,6 @@ CK_RV run_TransferKyberKeyPair(void)
                                 kyber_tv[i].keyform,
                                 kyber_tv[i].pk, kyber_tv[i].pk_len,
                                 &publ_key);
-        testcase_new_assertion();
         if (rc != CKR_OK) {
             if (rc == CKR_KEY_SIZE_RANGE) {
                 testcase_skip("C_CreateObject with key form %lu not supported",
@@ -999,11 +1002,13 @@ CK_RV run_TransferKyberKeyPair(void)
                 testcase_skip("Kyber key import is not allowed by policy");
                 goto testcase_cleanup;
             }
+            testcase_new_assertion();
             testcase_fail
                 ("C_CreateObject (Kyber Public Key) failed at i=%lu, rc=%s", i,
                  p11_get_ckr(rc));
             goto next;
         }
+        testcase_new_assertion();
         testcase_pass("*Import Kyber public key (%s) index=%lu passed.",
                       kyber_tv[i].name, i);
 


### PR DESCRIPTION
When running the digest tests against the EP11 token, the number of passed tests is greater than the number of ran tests:

  `Total=849, Ran=365, Passed=389, Failed=0, Skipped=484, Errors=0`

Fix this by adding a call to testcase_new_assertion() at the right place to ensure the ran counter is increased before a test is counted as being passed or failed.

This is only seen with the EP11 token because only the EP11 token currently supports mechanisms CKM_SHAnnn_KEY_DERIVATION. The tests for those mechanisms are missing the testcase_new_assertion() to increase the ran counter.