### PR TITLE
TESTCASE: Correct test run counting for the events test case

### DIFF
--- a/testcases/misc_tests/events.c
+++ b/testcases/misc_tests/events.c
@@ -75,6 +75,8 @@ int main(int argc, char **argv)
     }
     testcase_pass("send_event (simple, one-shot)");
 
+    testcase_new_assertion();
+
     rc = send_event(-1, 0x12345, EVENT_FLAGS_NONE, sizeof(payload), payload,
                     NULL, NULL);
     if (rc != 0) {
@@ -83,6 +85,8 @@ int main(int argc, char **argv)
         goto out;
     }
     testcase_pass("send_event (payload, one-shot)");
+
+    testcase_new_assertion();
 
     init_event_destination(&dest, EVENT_TOK_TYPE_CCA, NULL, 0);
 
@@ -94,6 +98,8 @@ int main(int argc, char **argv)
     }
     testcase_pass("send_event (token-type, one-shot)");
 
+    testcase_new_assertion();
+
     init_event_destination(&dest, EVENT_TOK_TYPE_ALL, "cca", 0);
 
     rc = send_event(-1, 0x12345, EVENT_FLAGS_NONE, 0, NULL, &dest, NULL);
@@ -104,6 +110,8 @@ int main(int argc, char **argv)
     }
     testcase_pass("send_event (token-label, one-shot)");
 
+    testcase_new_assertion();
+
     init_event_destination(&dest, EVENT_TOK_TYPE_ALL, NULL, 12345);
 
     rc = send_event(-1, 0x12345, EVENT_FLAGS_NONE, 0, NULL, &dest, NULL);
@@ -113,6 +121,8 @@ int main(int argc, char **argv)
         goto out;
     }
     testcase_pass("send_event (pid, one-shot)");
+
+    testcase_new_assertion();
 
     memset(&reply, 0, sizeof(reply));
 
@@ -132,6 +142,7 @@ int main(int argc, char **argv)
     }
     testcase_pass("send_event (reply, one-shot)");
 
+    testcase_new_assertion();
 
     fd = init_event_client();
     if (fd < 0) {
@@ -140,12 +151,16 @@ int main(int argc, char **argv)
     }
     testcase_pass("init_event_client()");
 
+    testcase_new_assertion();
+
     rc = send_event(fd, 0x12345, EVENT_FLAGS_NONE, 0, NULL, NULL, NULL);
     if (rc != 0) {
         testcase_fail("send_event (simple) rc = %d (%s)", rc, strerror(-rc));
         goto out;
     }
     testcase_pass("send_event (simple)");
+
+    testcase_new_assertion();
 
     rc = send_event(fd, 0x12345, EVENT_FLAGS_NONE, sizeof(payload), payload,
                     NULL, NULL);
@@ -155,6 +170,8 @@ int main(int argc, char **argv)
         goto out;
     }
     testcase_pass("send_event (payload)");
+
+    testcase_new_assertion();
 
     memset(&reply, 0, sizeof(reply));
 


### PR DESCRIPTION
When running the events test the number of passed tests is 10, but the 'total' and 'ran' tests is 1.

  Total=1, Ran=1, Passed=10, Failed=0, Skipped=0, Errors=0

Fix this by adding a call to testcase_new_assertion() at the right places to ensure the ran counter is increased before a test is counted as being passed or failed.