### PR TITLE
Fixes for protecting buffers containing sensitive data

### DIFF
--- a/usr/lib/common/mech_ec.c
+++ b/usr/lib/common/mech_ec.c
@@ -1329,8 +1329,12 @@ CK_RV ec_point_from_priv_key(CK_BYTE *parms, CK_ULONG parms_len,
     if (nid == -1)
         return CKR_CURVE_NOT_SUPPORTED;
 
-    bn_d = BN_bin2bn(d, d_len, NULL);
+    bn_d = BN_secure_new();
     if (bn_d == NULL) {
+        rc = CKR_FUNCTION_FAILED;
+        goto done;
+    }
+    if (BN_bin2bn(d, d_len, bn_d) == NULL) {
         rc = CKR_FUNCTION_FAILED;
         goto done;
     }

--- a/usr/lib/common/template.c
+++ b/usr/lib/common/template.c
@@ -103,6 +103,8 @@ CK_RV template_add_attributes(TEMPLATE *tmpl, CK_ATTRIBUTE *pTemplate,
                                 attr->ulValueLen / sizeof(CK_ATTRIBUTE),
                                 (CK_ATTRIBUTE_PTR)attr->pValue);
                 if (rc !=CKR_OK) {
+                    if (attr->pValue != NULL)
+                        OPENSSL_cleanse(attr->pValue, attr->ulValueLen);
                     free(attr);
                     TRACE_DEVEL("dup_attribute_array_no_alloc failed.\n");
                     return rc;
@@ -116,6 +118,8 @@ CK_RV template_add_attributes(TEMPLATE *tmpl, CK_ATTRIBUTE *pTemplate,
 
         rc = template_update_attribute(tmpl, attr);
         if (rc != CKR_OK) {
+            if (attr->pValue != NULL)
+                OPENSSL_cleanse(attr->pValue, attr->ulValueLen);
             free(attr);
             TRACE_DEVEL("template_update_attribute failed.\n");
             return rc;
@@ -588,6 +592,8 @@ CK_RV template_copy(TEMPLATE *dest, TEMPLATE *src)
                                     attr->ulValueLen / sizeof(CK_ATTRIBUTE),
                                     (CK_ATTRIBUTE_PTR)new_attr->pValue);
             if (rc != CKR_OK) {
+                if (new_attr->pValue != NULL)
+                    OPENSSL_cleanse(new_attr->pValue, new_attr->ulValueLen);
                 free(new_attr);
                 TRACE_ERROR("dup_attribute_array_no_alloc failed\n");
                 return rc;
@@ -596,11 +602,15 @@ CK_RV template_copy(TEMPLATE *dest, TEMPLATE *src)
 
         if (attr->type == CKA_UNIQUE_ID) {
             if (attr->ulValueLen < 2 * UNIQUE_ID_LEN) {
+                if (new_attr->pValue != NULL)
+                    OPENSSL_cleanse(new_attr->pValue, new_attr->ulValueLen);
                 free(new_attr);
                 TRACE_ERROR("%s\n", ock_err(ERR_ATTRIBUTE_VALUE_INVALID));
                 return CKR_ATTRIBUTE_VALUE_INVALID;
             }
             if (get_unique_id_str(unique_id_str) != CKR_OK) {
+                if (new_attr->pValue != NULL)
+                    OPENSSL_cleanse(new_attr->pValue, new_attr->ulValueLen);
                 free(new_attr);
                 TRACE_ERROR("%s\n", ock_err(ERR_FUNCTION_FAILED));
                 return CKR_FUNCTION_FAILED;
@@ -616,6 +626,8 @@ CK_RV template_copy(TEMPLATE *dest, TEMPLATE *src)
                                 (CK_ATTRIBUTE_PTR)new_attr->pValue,
                                 new_attr->ulValueLen / sizeof(CK_ATTRIBUTE),
                                 FALSE);
+            if (new_attr->pValue != NULL)
+                OPENSSL_cleanse(new_attr->pValue, new_attr->ulValueLen);
             free(new_attr);
             TRACE_ERROR("%s\n", ock_err(ERR_HOST_MEMORY));
             return CKR_HOST_MEMORY;
@@ -1170,6 +1182,8 @@ CK_RV template_free(TEMPLATE *tmpl)
                                     attr->ulValueLen / sizeof(CK_ATTRIBUTE),
                                     FALSE);
             }
+            if (attr->pValue != NULL)
+                OPENSSL_cleanse(attr->pValue, attr->ulValueLen);
             free(attr);
         }
 
@@ -1601,6 +1615,8 @@ CK_RV template_remove_attribute(TEMPLATE *tmpl, CK_ATTRIBUTE_TYPE type)
                                      attr->ulValueLen / sizeof(CK_ATTRIBUTE),
                                      FALSE);
             }
+            if (attr->pValue != NULL)
+                OPENSSL_cleanse(attr->pValue, attr->ulValueLen);
             free(attr);
             tmpl->attribute_list =
                 dlist_remove_node(tmpl->attribute_list, node);

--- a/usr/lib/tpm_stdll/tpm_openssl.c
+++ b/usr/lib/tpm_stdll/tpm_openssl.c
@@ -274,14 +274,16 @@ int openssl_get_modulus_and_prime(EVP_PKEY *pkey, unsigned int *size_n,
     *size_n = len;
     BN_free(n_tmp);
 
-    if (!EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_RSA_FACTOR1, &p_tmp) ||
+    p_tmp = BN_secure_new();
+    if (p_tmp == NULL ||
+        !EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_RSA_FACTOR1, &p_tmp) ||
         (len = BN_bn2bin(p_tmp, p)) <= 0) {
         DEBUG_openssl_print_errors();
-        BN_free(p_tmp);
+        BN_clear_free(p_tmp);
         return -1;
     }
     *size_p = len;
-    BN_free(p_tmp);
+    BN_clear_free(p_tmp);
 #endif
 
     return 0;


### PR DESCRIPTION
For OpenSSL BIGNUMs containing sensitive private key material, use BN_secure_new() to allocate the BIGNUM on OpenSSLs secure heap.

Also clean any buffers that might contain sensitive data before freeing it.