### PR TITLE
TESTCASES: ec_tests: Support ECDH KATs for secure key tokens

### DIFF
--- a/testcases/crypto/crypto.mk
+++ b/testcases/crypto/crypto.mk
@@ -46,6 +46,7 @@ testcases_crypto_ssl3_tests_LDADD = testcases/common/libcommon.la
 testcases_crypto_ssl3_tests_SOURCES = testcases/crypto/ssl3_func.c
 
 testcases_crypto_ec_tests_CFLAGS = ${testcases_inc}
+testcases_crypto_ec_tests_LDFLAGS = -lcrypto
 testcases_crypto_ec_tests_LDADD = testcases/common/libcommon.la
 testcases_crypto_ec_tests_SOURCES = testcases/crypto/ec_func.c
 

--- a/usr/lib/common/h_extern.h
+++ b/usr/lib/common/h_extern.h
@@ -1834,6 +1834,15 @@ int ec_point_from_public_data(const CK_BYTE *data, CK_ULONG data_len,
                               CK_ULONG prime_len, CK_BBOOL allow_raw,
                               CK_BBOOL *allocated, CK_BYTE **ec_point,
                               CK_ULONG *ec_point_len);
+int ec_point_uncompressed_from_public_data(const CK_BYTE *data,
+                                           CK_ULONG data_len,
+                                           CK_ULONG prime_len,
+                                           CK_BYTE *curve_oid,
+                                           CK_ULONG curve_oid_len,
+                                           CK_BBOOL allow_raw,
+                                           CK_BBOOL *allocated,
+                                           CK_BYTE **ec_point,
+                                           CK_ULONG *ec_point_len);
 
 CK_RV attach_shm(STDLL_TokData_t *tokdata, CK_SLOT_ID slot_id);
 CK_RV detach_shm(STDLL_TokData_t *tokdata, CK_BBOOL ignore_ref_count);


### PR DESCRIPTION
For secure key tokens, the derived secret can not be compared with the expected key value for known answer tests (KATs), because the derived secret is a secure key that never reveals its key value in clear.

However, the test can calculate an HMAC of some know data using the derived key as well as with the expected key value from the KAT. If both keys are the same, then the calculated HMAC must also be the same.