### PR TITLE
common: Fix compile error/warning when compiled with GCC 14

### DIFF
--- a/testcases/crypto/dilithium_func.c
+++ b/testcases/crypto/dilithium_func.c
@@ -104,7 +104,7 @@ CK_RV run_SignVerifyDilithium(CK_SESSION_HANDLE session,
         }
     }
 
-    data = calloc(sizeof(CK_BYTE), inputlen);
+    data = calloc(inputlen, sizeof(CK_BYTE));
     if (data == NULL) {
         testcase_error("Can't allocate memory for %lu bytes",
                        sizeof(CK_BYTE) * inputlen);
@@ -128,7 +128,7 @@ CK_RV run_SignVerifyDilithium(CK_SESSION_HANDLE session,
         testcase_error("C_Sign rc=%s", p11_get_ckr(rc));
         goto testcase_cleanup;
     }
-    signature = calloc(sizeof(CK_BYTE), signaturelen);
+    signature = calloc(signaturelen, sizeof(CK_BYTE));
     if (signature == NULL) {
         testcase_error("Can't allocate memory for %lu bytes",
                        sizeof(CK_BYTE) * signaturelen);
@@ -213,7 +213,7 @@ CK_RV run_SignVerifyDilithiumKAT(CK_SESSION_HANDLE session,
     }
 
     /* Allocate buffer for signature */
-    signature = calloc(sizeof(CK_BYTE), siglen);
+    signature = calloc(siglen, sizeof(CK_BYTE));
     if (signature == NULL) {
         testcase_error("Can't allocate memory for %lu bytes",
                        sizeof(CK_BYTE) *siglen);
@@ -543,7 +543,7 @@ CK_RV wrapKey(CK_SESSION_HANDLE session, CK_MECHANISM *wrap_mech,
         goto done;
 
     /* Allocate memory for wrapped_key */
-    tmp_key = calloc(sizeof(CK_BYTE), tmp_len);
+    tmp_key = calloc(tmp_len, sizeof(CK_BYTE));
     if (!tmp_key) {
         rc = CKR_HOST_MEMORY;
         goto done;

--- a/testcases/crypto/ec_func.c
+++ b/testcases/crypto/ec_func.c
@@ -1493,7 +1493,7 @@ CK_RV run_GenerateSignVerifyECC(CK_SESSION_HANDLE session,
     }
 
     if (inputlen > 0) {
-        data = calloc(sizeof(CK_BYTE), inputlen);
+        data = calloc(inputlen, sizeof(CK_BYTE));
         if (data == NULL) {
             testcase_error("Can't allocate memory for %lu bytes",
                            sizeof(CK_BYTE) * inputlen);
@@ -1544,7 +1544,7 @@ CK_RV run_GenerateSignVerifyECC(CK_SESSION_HANDLE session,
         }
     }
 
-    signature = calloc(sizeof(CK_BYTE), signaturelen);
+    signature = calloc(signaturelen, sizeof(CK_BYTE));
     if (signature == NULL) {
         testcase_error("Can't allocate memory for %lu bytes",
                        sizeof(CK_BYTE) * signaturelen);
@@ -2209,7 +2209,7 @@ CK_RV run_TransferECCKeyPairSignVerify(void)
             goto testcase_cleanup;
         }
         // allocate memory for wrapped_key
-        wrapped_key = calloc(sizeof(CK_BYTE), wrapped_keylen);
+        wrapped_key = calloc(wrapped_keylen, sizeof(CK_BYTE));
         if (wrapped_key == NULL) {
             testcase_error("Can't allocate memory for %lu bytes.",
                            sizeof(CK_BYTE) * wrapped_keylen);
@@ -2467,7 +2467,7 @@ CK_RV run_ImportSignVerify_Pkey(void)
                 goto testcase_cleanup;
             }
 
-            sig = calloc(sizeof(CK_BYTE), sig_len);
+            sig = calloc(sig_len, sizeof(CK_BYTE));
             if (sig == NULL) {
                 testcase_error("Can't allocate memory for %lu bytes", sig_len);
                 rc = CKR_HOST_MEMORY;

--- a/testcases/crypto/kyber_func.c
+++ b/testcases/crypto/kyber_func.c
@@ -336,7 +336,7 @@ CK_RV run_EnDecapsulateKyber(CK_SESSION_HANDLE session,
     }
 
     cipher_len = kyber_params.ulCipherLen;
-    cipher = calloc(sizeof(CK_BYTE), cipher_len);
+    cipher = calloc(cipher_len, sizeof(CK_BYTE));
     if (cipher == NULL) {
         testcase_error("Can't allocate memory for %lu bytes",
                        sizeof(CK_BYTE) * cipher_len);
@@ -451,7 +451,7 @@ CK_RV run_EncrypDecryptKyber(CK_SESSION_HANDLE session,
         }
     }
 
-    data = calloc(sizeof(CK_BYTE), datalen);
+    data = calloc(datalen, sizeof(CK_BYTE));
     if (data == NULL) {
         testcase_error("Can't allocate memory for %lu bytes",
                        sizeof(CK_BYTE) * datalen);
@@ -476,7 +476,7 @@ CK_RV run_EncrypDecryptKyber(CK_SESSION_HANDLE session,
         goto testcase_cleanup;
     }
 
-    encrypted = calloc(sizeof(CK_BYTE), encrypted_len);
+    encrypted = calloc(encrypted_len, sizeof(CK_BYTE));
     if (encrypted == NULL) {
         testcase_error("Can't allocate memory for %lu bytes",
                        sizeof(CK_BYTE) * encrypted_len);
@@ -504,7 +504,7 @@ CK_RV run_EncrypDecryptKyber(CK_SESSION_HANDLE session,
         goto testcase_cleanup;
     }
 
-    decrypted = calloc(sizeof(CK_BYTE), decrypted_len);
+    decrypted = calloc(decrypted_len, sizeof(CK_BYTE));
     if (decrypted == NULL) {
         testcase_error("Can't allocate memory for %lu bytes",
                        sizeof(CK_BYTE) * decrypted_len);
@@ -845,7 +845,7 @@ CK_RV wrapKey(CK_SESSION_HANDLE session, CK_MECHANISM *wrap_mech,
         goto done;
 
     /* Allocate memory for wrapped_key */
-    tmp_key = calloc(sizeof(CK_BYTE), tmp_len);
+    tmp_key = calloc(tmp_len, sizeof(CK_BYTE));
     if (!tmp_key) {
         rc = CKR_HOST_MEMORY;
         goto done;

--- a/testcases/crypto/rsa_func.c
+++ b/testcases/crypto/rsa_func.c
@@ -1463,7 +1463,7 @@ CK_RV do_WrapUnwrapRSA(struct GENERATED_TEST_SUITE_INFO * tsuite)
         testcase_new_assertion();       /* assertion #1 */
 
         // allocate memory for wrapped_key
-        wrapped_key = calloc(sizeof(CK_BYTE), wrapped_keylen);
+        wrapped_key = calloc(wrapped_keylen, sizeof(CK_BYTE));
         if (wrapped_key == NULL) {
             testcase_error("Can't allocate memory for %lu bytes.",
                            sizeof(CK_BYTE) * wrapped_keylen);

--- a/testcases/pkcs11/get_interface.c
+++ b/testcases/pkcs11/get_interface.c
@@ -34,7 +34,7 @@ static int get_interface_test(void)
         goto ret;
     }
 
-    flags = ~0ULL;
+    flags = ~0UL;
     rv = funcs3->C_GetInterface((CK_UTF8CHAR *)"PKCS 11",
                                 NULL, &interface, flags);
     if (rv != CKR_FUNCTION_FAILED) {

--- a/tools/tableidxgen.c
+++ b/tools/tableidxgen.c
@@ -512,7 +512,7 @@ static void dumpnumericfun(FILE *fp)
     fputs("    if (o3 < 0) return -1;\n", fp);
     fputs("    midx = numerictable[o3 + idx4];\n", fp);
     fputs("    midx = -(midx + 1);\n", fp);
-    fprintf(fp, "    if (0 <= midx && midx < %lu && mechtable_rows[midx].numeric == mech)\n",
+    fprintf(fp, "    if (0 <= midx && midx < %zu && mechtable_rows[midx].numeric == mech)\n",
             ARRAY_SIZE(mechtable_rows));
     fputs("        return midx;\n", fp);
     fputs("    return -1;\n", fp);
@@ -531,7 +531,7 @@ static void dumpstringfun(FILE *fp)
 {
     size_t i;
 
-    fprintf(fp, "static const size_t commonprefixlength = %lu;\n\n",
+    fprintf(fp, "static const size_t commonprefixlength = %zu;\n\n",
             commonprefixlength);
     fputs("int mechtable_idx_from_string(const char *mech)\n", fp);
     fputs("{\n", fp);
@@ -613,7 +613,7 @@ static void generateheader(char *hname)
     generatelicense(fp);
     fputs("#ifndef OCK_MECHTABLE_GEN_H\n", fp);
     fputs("#define OCK_MECHTABLE_GEN_H\n\n", fp);
-    fprintf(fp, "#define MECHTABLE_NUM_ELEMS %lu\n\n", ARRAY_SIZE(mechtable_rows));
+    fprintf(fp, "#define MECHTABLE_NUM_ELEMS %zu\n\n", ARRAY_SIZE(mechtable_rows));
     fputs("#endif\n\n", fp);
     closefile(fp);
 }

--- a/usr/lib/api/socket_client.c
+++ b/usr/lib/api/socket_client.c
@@ -373,7 +373,7 @@ static void *event_thread(void *arg)
 
         num = read_all(anchor->socketfd, (char *)&event, sizeof(event));
         if (num != sizeof(event)) {
-            TRACE_ERROR("Error receiving the event, rc: %ld\n", num);
+            TRACE_ERROR("Error receiving the event, rc: %zd\n", num);
             break;
         }
 
@@ -399,8 +399,8 @@ static void *event_thread(void *arg)
             }
 
             num = read_all(anchor->socketfd, payload, event.payload_len);
-            if (num != event.payload_len) {
-                TRACE_ERROR("Error receiving the event payload, rc: %ld\n", num);
+            if (num != (ssize_t)event.payload_len) {
+                TRACE_ERROR("Error receiving the event payload, rc: %zd\n", num);
                 if (payload != NULL)
                     free(payload);
                 break;
@@ -428,7 +428,7 @@ static void *event_thread(void *arg)
         if (event.flags & EVENT_FLAGS_REPLY_REQ) {
             num = send_all(anchor->socketfd, (char *)&reply, sizeof(reply));
             if (num != sizeof(reply)) {
-                TRACE_ERROR("Error sending the event reply, rc: %ld\n", num);
+                TRACE_ERROR("Error sending the event reply, rc: %zd\n", num);
                 if (payload != NULL)
                     free(payload);
                 break;

--- a/usr/lib/common/mech_openssl.c
+++ b/usr/lib/common/mech_openssl.c
@@ -2362,7 +2362,8 @@ CK_RV openssl_specific_ec_generate_keypair(STDLL_TokData_t *tokdata,
     int len;
 #endif
     CK_BYTE *ecpoint = NULL, *enc_ecpoint = NULL, *d = NULL;
-    CK_ULONG ecpoint_len, enc_ecpoint_len, d_len;
+    CK_ULONG enc_ecpoint_len, d_len;
+    size_t ecpoint_len;
     EVP_PKEY_CTX *ctx = NULL;
     EVP_PKEY *ec_pkey = NULL;
     int nid;

--- a/usr/lib/hsm_mk_change/hsm_mk_change.c
+++ b/usr/lib/hsm_mk_change/hsm_mk_change.c
@@ -738,7 +738,7 @@ CK_RV hsm_mk_change_op_load(const char *id, struct hsm_mk_change_op *op)
         goto out;
 
     if (info_read + slots_read != len) {
-        TRACE_ERROR("Not all data read for file %s: len: %lu read: %lu\n",
+        TRACE_ERROR("Not all data read for file %s: len: %zu read: %zu\n",
                     op->id, len, info_read + slots_read);
         rc = CKR_FUNCTION_FAILED;
         goto out;
@@ -868,7 +868,7 @@ CK_RV hsm_mk_change_token_mkvps_load(const char *id, CK_SLOT_ID slot_id,
         goto out;
 
     if (read != len) {
-        TRACE_ERROR("Not all datta read for file %s-%lu: len: %lu read: %lu\n",
+        TRACE_ERROR("Not all data read for file %s-%lu: len: %zu read: %zu\n",
                     id, slot_id, len, read);
         rc = CKR_FUNCTION_FAILED;
         hsm_mk_change_mkvps_clean(*mkvps, *num_mkvps);

--- a/usr/lib/icsf_stdll/icsf.c
+++ b/usr/lib/icsf_stdll/icsf.c
@@ -551,12 +551,12 @@ static int icsf_call(LDAP * ld, int *reason, char *handle, size_t handle_len,
 
     /* Check sizes */
     if (handle_len != ICSF_HANDLE_LEN) {
-        TRACE_ERROR("Invalid handle length: %lu\n", handle_len);
+        TRACE_ERROR("Invalid handle length: %zu\n", handle_len);
         return -1;
     }
 
     if ((rule_array_len % ICSF_RULE_ITEM_LEN)) {
-        TRACE_ERROR("Invalid rule array length: %lu\n", rule_array_len);
+        TRACE_ERROR("Invalid rule array length: %zu\n", rule_array_len);
         return -1;
     }
     rule_array_count = rule_array_len / ICSF_RULE_ITEM_LEN;
@@ -1738,9 +1738,9 @@ static const char *get_cipher_mode(CK_MECHANISM_PTR mech)
 /*
  * Get the block size of supported algorithms/mechanism.
  */
-CK_RV icsf_block_size(CK_MECHANISM_TYPE mech_type, CK_ULONG_PTR p_block_size)
+CK_RV icsf_block_size(CK_MECHANISM_TYPE mech_type, size_t *p_block_size)
 {
-    CK_ULONG block_size;
+    size_t block_size;
 
     switch (mech_type) {
     case CKM_DES_CBC:
@@ -1831,7 +1831,7 @@ static CK_RV icsf_encrypt_initial_vector(CK_MECHANISM_PTR mech, char *iv,
             memcpy(iv, mech->pParameter, expected_iv_len);
     }
     if (iv_len)
-        *iv_len = expected_iv_len;
+        *iv_len = (size_t)expected_iv_len;
 
     return 0;
 }

--- a/usr/lib/icsf_stdll/icsf.h
+++ b/usr/lib/icsf_stdll/icsf.h
@@ -178,7 +178,7 @@ int icsf_generate_key_pair(LDAP * ld, int *reason, const char *token_name,
                            struct icsf_object_record *pub_key_object,
                            struct icsf_object_record *priv_key_object);
 
-CK_RV icsf_block_size(CK_MECHANISM_TYPE mech_type, CK_ULONG_PTR p_block_size);
+CK_RV icsf_block_size(CK_MECHANISM_TYPE mech_type, size_t *p_block_size);
 
 int icsf_get_attribute(LDAP * ld, int *reason,
                        struct icsf_object_record *object, CK_ATTRIBUTE * attrs,

--- a/usr/lib/icsf_stdll/icsf_specific.c
+++ b/usr/lib/icsf_stdll/icsf_specific.c
@@ -2537,7 +2537,7 @@ CK_RV icsftok_encrypt(STDLL_TokData_t * tokdata,
     struct session_state *session_state;
     struct icsf_object_mapping *mapping = NULL;
     char chain_data[ICSF_CHAINING_DATA_LEN] = { 0, };
-    size_t chain_data_len = sizeof(chain_data);
+    size_t chain_data_len = sizeof(chain_data), output_data_len;
     int reason = 0;
     int symmetric = 0;
 
@@ -2574,21 +2574,23 @@ CK_RV icsftok_encrypt(STDLL_TokData_t * tokdata,
     }
 
     /* Encrypt data using remote token. */
+    output_data_len = *p_output_data_len;
     if (symmetric) {
         rc = icsf_secret_key_encrypt(session_state->ld, &reason,
                                      &mapping->icsf_object,
                                      &encr_ctx->mech,
                                      ICSF_CHAINING_ONLY, (char *)input_data,
                                      input_data_len, (char *)output_data,
-                                     p_output_data_len, chain_data,
+                                     &output_data_len, chain_data,
                                      &chain_data_len);
     } else {
         rc = icsf_public_key_verify(session_state->ld, &reason, TRUE,
                                     &mapping->icsf_object,
                                     &encr_ctx->mech, (char *)input_data,
                                     input_data_len, (char *)output_data,
-                                    p_output_data_len);
+                                    &output_data_len);
     }
+    *p_output_data_len = output_data_len;
     if (rc) {
         if (reason == ICSF_REASON_OUTPUT_PARAMETER_TOO_SHORT) {
             if (is_length_only) {
@@ -2636,7 +2638,7 @@ CK_RV icsftok_encrypt_update(STDLL_TokData_t * tokdata,
     struct session_state *session_state;
     struct icsf_object_mapping *mapping = NULL;
     char chain_data[ICSF_CHAINING_DATA_LEN] = { 0, };
-    size_t chain_data_len = sizeof(chain_data);
+    size_t chain_data_len = sizeof(chain_data), output_part_len;
     CK_ULONG total, remaining;
     char *buffer = NULL;
     int chaining;
@@ -2725,12 +2727,14 @@ CK_RV icsftok_encrypt_update(STDLL_TokData_t * tokdata,
                input_part_len - remaining);
 
     /* Encrypt data using remote token. */
+    output_part_len = *p_output_part_len;
     rc = icsf_secret_key_encrypt(session_state->ld, &reason,
                                  &mapping->icsf_object,
                                  &encr_ctx->mech, chaining,
                                  buffer, total - remaining,
-                                 (char *)output_part, p_output_part_len,
+                                 (char *)output_part, &output_part_len,
                                  chain_data, &chain_data_len);
+    *p_output_part_len = output_part_len;
     if (rc) {
         if (reason == ICSF_REASON_OUTPUT_PARAMETER_TOO_SHORT) {
             if (is_length_only) {
@@ -2821,7 +2825,7 @@ CK_RV icsftok_encrypt_final(STDLL_TokData_t * tokdata,
     struct session_state *session_state;
     struct icsf_object_mapping *mapping = NULL;
     char chain_data[ICSF_CHAINING_DATA_LEN] = { 0, };
-    size_t chain_data_len = sizeof(chain_data);
+    size_t chain_data_len = sizeof(chain_data), output_part_len;
     int chaining;
     int reason = 0;
     int symmetric = 0;
@@ -2887,13 +2891,15 @@ CK_RV icsftok_encrypt_final(STDLL_TokData_t * tokdata,
      *
      * All the data in multi-part context should be sent.
      */
+    output_part_len = *p_output_part_len;
     rc = icsf_secret_key_encrypt(session_state->ld, &reason,
                                  &mapping->icsf_object,
                                  &encr_ctx->mech, chaining,
                                  multi_part_ctx->data,
                                  multi_part_ctx->used_data_len,
-                                 (char *)output_part, p_output_part_len,
+                                 (char *)output_part, &output_part_len,
                                  chain_data, &chain_data_len);
+    *p_output_part_len = output_part_len;
     if (rc) {
         if (reason == ICSF_REASON_OUTPUT_PARAMETER_TOO_SHORT) {
             if (is_length_only) {
@@ -3057,7 +3063,7 @@ CK_RV icsftok_decrypt(STDLL_TokData_t * tokdata,
     struct session_state *session_state;
     struct icsf_object_mapping *mapping = NULL;
     char chain_data[ICSF_CHAINING_DATA_LEN] = { 0, };
-    size_t chain_data_len = sizeof(chain_data);
+    size_t chain_data_len = sizeof(chain_data), output_data_len;
     int reason = 0;
     int symmetric = 0;
 
@@ -3094,21 +3100,23 @@ CK_RV icsftok_decrypt(STDLL_TokData_t * tokdata,
     }
 
     /* Decrypt data using remote token. */
+    output_data_len = *p_output_data_len;
     if (symmetric) {
         rc = icsf_secret_key_decrypt(session_state->ld, &reason,
                                      &mapping->icsf_object,
                                      &decr_ctx->mech,
                                      ICSF_CHAINING_ONLY, (char *)input_data,
                                      input_data_len, (char *)output_data,
-                                     p_output_data_len, chain_data,
+                                     &output_data_len, chain_data,
                                      &chain_data_len);
     } else {
         rc = icsf_private_key_sign(session_state->ld, &reason, TRUE,
                                    &mapping->icsf_object,
                                    &decr_ctx->mech, (char *)input_data,
                                    input_data_len, (char *)output_data,
-                                   p_output_data_len);
+                                   &output_data_len);
     }
+    *p_output_data_len = output_data_len;
     if (rc) {
         if (reason == ICSF_REASON_OUTPUT_PARAMETER_TOO_SHORT) {
             if (is_length_only) {
@@ -3156,7 +3164,7 @@ CK_RV icsftok_decrypt_update(STDLL_TokData_t * tokdata,
     struct session_state *session_state;
     struct icsf_object_mapping *mapping = NULL;
     char chain_data[ICSF_CHAINING_DATA_LEN] = { 0, };
-    size_t chain_data_len = sizeof(chain_data);
+    size_t chain_data_len = sizeof(chain_data), output_part_len;
     CK_ULONG total, remaining;
     char *buffer = NULL;
     int chaining;
@@ -3262,12 +3270,14 @@ CK_RV icsftok_decrypt_update(STDLL_TokData_t * tokdata,
                input_part_len - remaining);
 
     /* Decrypt data using remote token. */
+    output_part_len = *p_output_part_len;
     rc = icsf_secret_key_decrypt(session_state->ld, &reason,
                                  &mapping->icsf_object,
                                  &decr_ctx->mech, chaining,
                                  buffer, total - remaining,
-                                 (char *)output_part, p_output_part_len,
+                                 (char *)output_part, &output_part_len,
                                  chain_data, &chain_data_len);
+    *p_output_part_len = output_part_len;
     if (rc) {
         if (reason == ICSF_REASON_OUTPUT_PARAMETER_TOO_SHORT) {
             if (is_length_only) {
@@ -3357,7 +3367,7 @@ CK_RV icsftok_decrypt_final(STDLL_TokData_t * tokdata,
     struct session_state *session_state;
     struct icsf_object_mapping *mapping = NULL;
     char chain_data[ICSF_CHAINING_DATA_LEN] = { 0, };
-    size_t chain_data_len = sizeof(chain_data);
+    size_t chain_data_len = sizeof(chain_data), output_part_len;
     int chaining;
     int reason = 0;
     int symmetric = 0;
@@ -3423,13 +3433,15 @@ CK_RV icsftok_decrypt_final(STDLL_TokData_t * tokdata,
      *
      * All the data in multi-part context should be sent.
      */
+    output_part_len = *p_output_part_len;
     rc = icsf_secret_key_decrypt(session_state->ld, &reason,
                                  &mapping->icsf_object,
                                  &decr_ctx->mech, chaining,
                                  multi_part_ctx->data,
                                  multi_part_ctx->used_data_len,
-                                 (char *)output_part, p_output_part_len,
+                                 (char *)output_part, &output_part_len,
                                  chain_data, &chain_data_len);
+    *p_output_part_len = output_part_len;
     if (rc) {
         if (reason == ICSF_REASON_OUTPUT_PARAMETER_TOO_SHORT) {
             if (is_length_only) {
@@ -4117,7 +4129,7 @@ CK_RV icsftok_sign(STDLL_TokData_t * tokdata,
     SIGN_VERIFY_CONTEXT *ctx = &session->sign_ctx;
     struct icsf_object_mapping *mapping = NULL;
     char chain_data[ICSF_CHAINING_DATA_LEN] = { 0, };
-    size_t chain_data_len = sizeof(chain_data);
+    size_t chain_data_len = sizeof(chain_data), slen;
     CK_RV rc = CKR_OK;
     int hlen, reason;
     CK_BBOOL length_only = (signature == NULL);
@@ -4170,11 +4182,13 @@ CK_RV icsftok_sign(STDLL_TokData_t * tokdata,
             goto done;
         }
 
+        slen = *sig_len;
         rc = icsf_hmac_sign(session_state->ld, &reason,
                             &mapping->icsf_object, &ctx->mech, "ONLY",
                             (char *)in_data, in_data_len,
-                            (char *)signature, sig_len,
+                            (char *)signature, &slen,
                             chain_data, &chain_data_len);
+        *sig_len = slen;
         if (rc != 0)
             rc = icsf_to_ock_err(rc, reason);
         break;
@@ -4182,10 +4196,12 @@ CK_RV icsftok_sign(STDLL_TokData_t * tokdata,
     case CKM_RSA_PKCS:
     case CKM_DSA:
     case CKM_ECDSA:
+        slen = *sig_len;
         rc = icsf_private_key_sign(session_state->ld, &reason, FALSE,
                                    &mapping->icsf_object, &ctx->mech,
                                    (char *)in_data, in_data_len,
-                                   (char *)signature, sig_len);
+                                   (char *)signature, &slen);
+        *sig_len = slen;
         if (rc != 0) {
             if (reason == ICSF_REASON_OUTPUT_PARAMETER_TOO_SHORT &&
                 length_only) {
@@ -4417,7 +4433,7 @@ CK_RV icsftok_sign_final(STDLL_TokData_t * tokdata,
     struct icsf_object_mapping *mapping = NULL;
     struct icsf_multi_part_context *multi_part_ctx = NULL;
     char chain_data[ICSF_CHAINING_DATA_LEN] = { 0, };
-    size_t chain_data_len = sizeof(chain_data);
+    size_t chain_data_len = sizeof(chain_data), slen;
     char *buffer = NULL;
     CK_RV rc = CKR_OK;
     int hlen, reason;
@@ -4474,11 +4490,13 @@ CK_RV icsftok_sign_final(STDLL_TokData_t * tokdata,
             return CKR_OK;
         }
 
+        slen = *sig_len;
         rc = icsf_hmac_sign(session_state->ld, &reason,
                             &mapping->icsf_object, &ctx->mech,
                             multi_part_ctx->initiated ? "LAST" : "ONLY", "",
-                            0, (char *)signature, sig_len,
+                            0, (char *)signature, &slen,
                             chain_data, &chain_data_len);
+        *sig_len = slen;
         if (rc != 0)
             rc = icsf_to_ock_err(rc, reason);
         break;
@@ -4741,7 +4759,7 @@ CK_RV icsftok_verify(STDLL_TokData_t * tokdata,
     SIGN_VERIFY_CONTEXT *ctx = &session->verify_ctx;
     struct icsf_object_mapping *mapping = NULL;
     char chain_data[ICSF_CHAINING_DATA_LEN] = { 0, };
-    size_t chain_data_len = sizeof(chain_data);
+    size_t chain_data_len = sizeof(chain_data), slen;
     CK_RV rc = CKR_OK;
     int reason;
 
@@ -4794,10 +4812,12 @@ CK_RV icsftok_verify(STDLL_TokData_t * tokdata,
     case CKM_RSA_PKCS:
     case CKM_DSA:
     case CKM_ECDSA:
+        slen = sig_len;
         rc = icsf_public_key_verify(session_state->ld, &reason, FALSE,
                                     &mapping->icsf_object, &ctx->mech,
                                     (char *)in_data, in_data_len,
-                                    (char *)signature, &sig_len);
+                                    (char *)signature, &slen);
+        sig_len = slen;
         if (rc != 0)
             rc = icsf_to_ock_err(rc, reason);
         break;

--- a/usr/sbin/p11sak/p11sak.c
+++ b/usr/sbin/p11sak/p11sak.c
@@ -243,11 +243,11 @@ static CK_RV p11sak_export_ec_pkey(const struct p11sak_objtype *keytype,
                                    CK_OBJECT_HANDLE key, const char *label);
 static CK_RV p11sak_export_dilithium_kyber_pem_data(
                                         const struct p11sak_objtype *keytype,
-                                        unsigned char **data, size_t *data_len,
+                                        CK_BYTE **data, CK_ULONG *data_len,
                                         bool private, CK_OBJECT_HANDLE key,
                                         const char *label);
 static CK_RV p11sak_export_x509(const struct p11sak_objtype *certtype,
-                                unsigned char **data, size_t *data_len,
+                                CK_BYTE **data, CK_ULONG *data_len,
                                 CK_OBJECT_HANDLE cert, const char *label);
 static CK_RV p11sak_extract_x509_pk(const struct p11sak_objtype *certtype,
                                     CK_ATTRIBUTE **attrs, CK_ULONG *num_attrs,
@@ -8653,7 +8653,7 @@ done:
 }
 
 static CK_RV p11sak_export_x509(const struct p11sak_objtype *certtype,
-                                unsigned char **data, size_t *data_len,
+                                CK_BYTE **data, CK_ULONG *data_len,
                                 CK_OBJECT_HANDLE cert,
                                 const char *label)
 {
@@ -9122,7 +9122,7 @@ done:
 
 static CK_RV p11sak_export_dilithium_kyber_pem_data(
                                         const struct p11sak_objtype *keytype,
-                                        unsigned char **data, size_t *data_len,
+                                        CK_BYTE **data, CK_ULONG *data_len,
                                         bool private, CK_OBJECT_HANDLE key,
                                         const char *label)
 {

--- a/usr/sbin/p11sak/p11sak.h
+++ b/usr/sbin/p11sak/p11sak.h
@@ -174,7 +174,7 @@ struct p11sak_objtype {
                               EVP_PKEY **pkey, bool private,
                               CK_OBJECT_HANDLE key, const char *label);
     CK_RV (*export_asym_pem_data)(const struct p11sak_objtype *keytype,
-                                  unsigned char **data, size_t *data_len,
+                                  CK_BYTE **data, CK_ULONG *data_len,
                                   bool private, CK_OBJECT_HANDLE key,
                                   const char *label);
     const char *pem_name_private;
@@ -185,7 +185,7 @@ struct p11sak_objtype {
                               X509 *x509, CK_ATTRIBUTE **attrs,
                               CK_ULONG *num_attrs);
     CK_RV (*export_x509_data)(const struct p11sak_objtype *certtype,
-                              unsigned char **data, size_t *data_len,
+                              CK_BYTE **data, CK_ULONG *data_len,
                               CK_OBJECT_HANDLE cert, const char *label);
     CK_RV (*extract_x509_pubkey)(const struct p11sak_objtype *certtype,
                                  CK_ATTRIBUTE **attrs, CK_ULONG *num_attrs,

--- a/usr/sbin/pkcshsm_mk_change/pkcshsm_mk_change.c
+++ b/usr/sbin/pkcshsm_mk_change/pkcshsm_mk_change.c
@@ -187,7 +187,7 @@ static int parse_mkvp(char *mkvp_str, size_t min_size, unsigned char *mkvp,
         mkvp_str += 2;
 
     if (strlen(mkvp_str) < min_size * 2) {
-        warnx("option %s must specify at least %lu bytes", option, min_size);
+        warnx("option %s must specify at least %zu bytes", option, min_size);
         return EINVAL;
     }
 
@@ -200,7 +200,7 @@ static int parse_mkvp(char *mkvp_str, size_t min_size, unsigned char *mkvp,
     }
 
     if (strlen(mkvp_str) > min_size * 2)
-        warnx("option %s specifies more than %lu bytes, remaining bytes are ignored",
+        warnx("option %s specifies more than %zu bytes, remaining bytes are ignored",
               option, min_size);
 
     *set = true;

--- a/usr/sbin/pkcstok_migrate/pkcstok_migrate.c
+++ b/usr/sbin/pkcstok_migrate/pkcstok_migrate.c
@@ -587,7 +587,7 @@ static CK_RV read_object(const char *data_store, const char *name,
     /* Read 32-bit size field */
     read_size = fread(&size, sizeof(CK_ULONG_32), 1, fp);
     if (read_size != 1) {
-        TRACE_ERROR("Cannot read %ld bytes from %s, read_size = %ld. "
+        TRACE_ERROR("Cannot read %zu bytes from %s, read_size = %zu. "
                     "Object probably empty or corrupted.\n",
                     sizeof(CK_ULONG_32), name, read_size);
         ret = CKR_FUNCTION_FAILED;
@@ -735,7 +735,7 @@ static CK_RV load_masterkey_312(const char *data_store, const char *mkfile,
     /* Read wrapped key from file */
     rc = fread(inbuf, sizeof(inbuf), 1, fp);
     if (rc != 1) {
-        TRACE_ERROR("Cannot read %ld bytes from %s.\n", sizeof(inbuf), fname);
+        TRACE_ERROR("Cannot read %zu bytes from %s.\n", sizeof(inbuf), fname);
         ret = CKR_FUNCTION_FAILED;
         goto done;
     }
@@ -2678,7 +2678,7 @@ int main(int argc, char **argv)
 
     /* Limit datastore path length because of appended suffixes */
     if (strlen(data_store) > PKCSTOK_MIGRATE_MAX_PATH_LEN) {
-        warnx("Datastore path (%ld characters) is too long (max = %d).\n",
+        warnx("Datastore path (%zu characters) is too long (max = %u).\n",
               strlen(data_store), PKCSTOK_MIGRATE_MAX_PATH_LEN);
         ret = CKR_FUNCTION_FAILED;
         goto done;
@@ -2692,7 +2692,7 @@ int main(int argc, char **argv)
 
     /* Limit path to config file because of appended suffixes */
     if (strlen(conf_dir) > PKCSTOK_MIGRATE_MAX_PATH_LEN) {
-        warnx("Path to config file (%ld characters) is too long (max = %d).\n",
+        warnx("Path to config file (%zd characters) is too long (max = %u).\n",
               strlen(conf_dir), PKCSTOK_MIGRATE_MAX_PATH_LEN);
         ret = CKR_FUNCTION_FAILED;
         goto done;


### PR DESCRIPTION
usr/lib/common/mech_openssl.c:2425:51:
   error: passing argument 5 of 'EVP_PKEY_get_octet_string_param' from
          incompatible pointer type

Change ecpoint_len to type size_t instead of CK_ULONG to match the expected type used by EVP_PKEY_get_octet_string_param(). Also, for the further use of that variable it is OK to use size_t.