### PR TITLE
opencryptoki (master branch) cannot be build on s390x

### DIFF
--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -9977,7 +9977,7 @@ CK_RV ep11tok_decrypt_final(STDLL_TokData_t * tokdata, SESSION * session,
     rc = constant_time_select(constant_time_eq(rc, CKR_OK),
                               ep11_error_to_pkcs11_error(rc, session),
                               rc);
-    if (!is_rsa_mechanism(ctx->mech.mechanism)) {
+    if (!is_rsa_mechanism((&session->decr_ctx)->mech.mechanism)) {
         if (rc != CKR_OK) {
             TRACE_ERROR("%s rc=0x%lx\n", __func__, rc);
         } else {


### PR DESCRIPTION
opencryptoki (master branch) cannot be build on s390x, it aborts with the following error:

usr/lib/ep11_stdll/ep11_specific.c: In function 'ep11tok_decrypt_single': usr/lib/ep11_stdll/ep11_specific.c:9750:27: error: 'ctx' undeclared (first use in this function)
 9750 |     if (!is_rsa_mechanism(ctx->mech.mechanism)) {
      |                           ^~~
usr/lib/ep11_stdll/ep11_specific.c:9750:27: note: each undeclared identifier is reported only once for each function it appears in
make[1]: *** [Makefile:7719: usr/lib/ep11_stdll/opencryptoki_stdll_libpkcs11_ep11_la-ep11_specific.lo] Error 1

The proposed patch resolves this issue.