### PR TITLE
COMMON: Fix implicit rejection with RSA keys with empty CKA_PRIVATE_EXPONENT

### DIFF
--- a/usr/lib/common/mech_openssl.c
+++ b/usr/lib/common/mech_openssl.c
@@ -5161,7 +5161,8 @@ CK_RV openssl_specific_rsa_derive_kdk(STDLL_TokData_t *tokdata, OBJECT *key_obj,
 
     rc = template_attribute_get_non_empty(key_obj->template,
                                           CKA_PRIVATE_EXPONENT, &priv_exp_attr);
-    if (rc != CKR_OK && rc != CKR_TEMPLATE_INCOMPLETE) {
+    if (rc != CKR_OK && rc != CKR_TEMPLATE_INCOMPLETE &&
+        rc != CKR_ATTRIBUTE_VALUE_INVALID) {
         TRACE_ERROR("Failed to get CKA_PRIVATE_EXPONENT\n");
         goto out;
     }


### PR DESCRIPTION
An RSA key object that has no CKA_PRIVATE_EXPONENT may either don't have that attribute at all, or may have an empty CKA_PRIVATE_EXPONENT attribute. Both situations should be handed the same, and the private exponent of the key needs to be calculated from the other key components.

Note that RSA key objects generated with a current soft or ICA token will always have a valid CKA_PRIVATE_EXPONENT attribute, since this is provided during key generation.