### PR TITLE
EP11 pkey option: misc fixes and enhancements 

### DIFF
--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -1369,11 +1369,6 @@ CK_RV token_specific_set_attrs_for_new_object(STDLL_TokData_t *tokdata,
                 add_pkey_extractable = CK_TRUE;
             break;
         }
-        if (add_pkey_extractable) {
-            ret = ep11tok_pkey_add_protkey_attr_to_tmpl(tmpl);
-            if (ret != CKR_OK)
-                goto done;
-        }
         break;
     case PKEY_MODE_ENABLE4EXTR:
         /* If the application did not specify CKA_IBM_PROTKEY_EXTRACTABLE in
@@ -1396,11 +1391,6 @@ CK_RV token_specific_set_attrs_for_new_object(STDLL_TokData_t *tokdata,
                 add_pkey_extractable = CK_TRUE;
             break;
         }
-        if (add_pkey_extractable) {
-            ret = ep11tok_pkey_add_protkey_attr_to_tmpl(tmpl);
-            if (ret != CKR_OK)
-                goto done;
-        }
         break;
     case PKEY_MODE_ENABLE4ALL:
         /* If the application did not specify CKA_IBM_PROTKEY_EXTRACTABLE in
@@ -1421,17 +1411,18 @@ CK_RV token_specific_set_attrs_for_new_object(STDLL_TokData_t *tokdata,
             add_pkey_extractable = CK_TRUE;
             break;
         }
-        if (add_pkey_extractable) {
-            ret = ep11tok_pkey_add_protkey_attr_to_tmpl(tmpl);
-            if (ret != CKR_OK)
-                goto done;
-        }
         break;
     default:
         TRACE_ERROR("PKEY_MODE %i unsupported.\n", ep11_data->pkey_mode);
         ret = CKR_FUNCTION_FAILED;
         goto done;
         break;
+    }
+
+    if (add_pkey_extractable) {
+        ret = ep11tok_pkey_add_protkey_attr_to_tmpl(tmpl);
+        if (ret != CKR_OK)
+            goto done;
     }
 #endif /* NO_PKEY */
 

--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -535,13 +535,18 @@ static CK_RV ep11tok_pkey_wrap_handler(uint_32 adapter, uint_32 domain,
     CK_ULONG bloblen;
     CK_BBOOL blobretry = FALSE;
     login_logout_data_t lldata;
+    const CK_VERSION ver40 = { .major = 4, .minor = 0 };
+    uint64_t flags = 0;
 
     if (data->wrap_was_successful)
         goto done;
 
     ep11_data = data->tokdata->private_data;
 
-    ret = get_ep11_target_for_apqn(adapter, domain, &target, XCP_MFL_PROBE);
+    if (compare_ck_version(&ep11_data->ep11_lib_version, &ver40) > 0)
+        flags |= XCP_MFL_PROBE;
+
+    ret = get_ep11_target_for_apqn(adapter, domain, &target, flags);
     if (ret != CKR_OK)
         goto done;
 

--- a/usr/lib/ep11_stdll/ep11_specific.h
+++ b/usr/lib/ep11_stdll/ep11_specific.h
@@ -241,6 +241,8 @@ typedef struct {
 #define PKEY_MODE_DISABLED          0
 #define PKEY_MODE_DEFAULT           1
 #define PKEY_MODE_ENABLE4NONEXTR    2
+#define PKEY_MODE_ENABLE4EXTR       3
+#define PKEY_MODE_ENABLE4ALL        4
 
 #define PQC_BYTE_NO(idx)            (((idx) - 1) / 8)
 #define PQC_BIT_IN_BYTE(idx)        (((idx - 1)) % 8)
@@ -278,6 +280,7 @@ typedef struct {
     int fips_session_mode;
     int optimize_single_ops;
     int pkey_mode;
+    volatile int pkey_combined_extract_supported;
     volatile int pkey_wrap_supported;
     int pkey_wrap_support_checked;
     char pkey_mk_vp[PKEY_MK_VP_LENGTH];

--- a/usr/lib/ep11_stdll/ep11_stdll.mk
+++ b/usr/lib/ep11_stdll/ep11_stdll.mk
@@ -41,7 +41,7 @@ opencryptoki_stdll_libpkcs11_ep11_la_SOURCES = usr/lib/common/asn1.c	\
 	usr/lib/common/trace.c usr/lib/common/mech_list.c		\
 	usr/lib/common/shared_memory.c usr/lib/common/attributes.c	\
 	usr/lib/common/sw_crypt.c usr/lib/common/profile_obj.c		\
-	usr/lib/common/dlist.c usr/lib/common/pkey_utils.c		\
+	usr/lib/common/dlist.c						\
 	usr/lib/ep11_stdll/new_host.c usr/lib/common/mech_openssl.c	\
 	usr/lib/ep11_stdll/ep11_specific.c 				\
 	usr/lib/ep11_stdll/ep11_session.c				\
@@ -53,3 +53,8 @@ opencryptoki_stdll_libpkcs11_ep11_la_SOURCES = usr/lib/common/asn1.c	\
 	usr/lib/common/pqc_supported.c					\
 	usr/lib/hsm_mk_change/hsm_mk_change.c				\
 	usr/lib/common/btree.c usr/lib/common/sess_mgr.c
+
+if !NO_PKEY
+opencryptoki_stdll_libpkcs11_ep11_la_SOURCES +=				\
+	usr/lib/common/pkey_utils.c
+endif

--- a/usr/lib/ep11_stdll/ep11tok.conf
+++ b/usr/lib/ep11_stdll/ep11tok.conf
@@ -104,7 +104,7 @@
 # disabled and additional hardware and firmware prerequisites are met. AES-XTS
 # is not supported via the EP11 coprocessor itself.
 #
-#      PKEY_MODE DISABLED | DEFAULT | ENABLE4NONEXTR
+#    PKEY_MODE DISABLED | DEFAULT | ENABLE4NONEXTR | ENABLE4EXTR | ENABLE4ALL
 #
 #        DISABLED       : Protected key support disabled. All key operations
 #                         are performed via EP11 coprocessor, even if a
@@ -118,6 +118,22 @@
 #        ENABLE4NONEXTR : If the application specified CKA_EXTRACTABLE=false,
 #                         but not CKA_IBM_PROTKEY_EXTRACTABLE, new keys get 
 #                         CKA_IBM_PROTKEY_EXTRACTABLE=true internally.
+#
+#    Control point 75 (XCP_CPB_ALLOW_COMBINED_EXTRACT) must be enabled for all
+#    APQNs accessible by the token for the following parameters. 
+#
+#        ENABLE4EXTR    : If the application did not specify
+#                         CKA_IBM_PROTKEY_EXTRACTABLE in its template, new keys
+#                         of any type with CKA_EXTRACTABLE=true get
+#                         CKA_IBM_PROTKEY_EXTRACTABLE=true and a protected key
+#                         is automatically created at first use of the key.
+#
+#        ENABLE4ALL     : If the application did not specify 
+#                         CKA_IBM_PROTKEY_EXTRACTABLE in its template, new keys
+#                         of any type, regardless of the CKA_EXTRACTABLE
+#                         attribute, get CKA_IBM_PROTKEY_EXTRACTABLE=true and
+#                         a protected key is automatically created at first
+#                         use of the key.
 #
 # --------------------------------------------------------------------------
 # 

--- a/usr/lib/ep11_stdll/tok_struct.h
+++ b/usr/lib/ep11_stdll/tok_struct.h
@@ -115,8 +115,13 @@ token_spec_t token_specific = {
     // AES
     NULL,                       // aes_key_gen,
     NULL,                       // aes_xts_key_gen
+#ifndef NO_PKEY
     &token_specific_aes_ecb,
     &token_specific_aes_cbc,
+#else
+    NULL,                       // aes_ecb
+    NULL,                       // aes_cbc
+#endif
     NULL,                       // aes_ctr
     NULL,                       // aes_gcm_init
     NULL,                       // aes_gcm
@@ -125,8 +130,13 @@ token_spec_t token_specific = {
     NULL,                       // aes_ofb
     NULL,                       // aes_cfb
     NULL,                       // aes_mac
+#ifndef NO_PKEY
     &token_specific_aes_cmac,
     &token_specific_aes_xts,    // aes_xts
+#else
+    NULL,                       // aes_cmac
+    NULL,                       // aes_xts
+#endif
     // DSA
     NULL,                       // dsa_generate_keypair,
     NULL,                       // dsa_sign


### PR DESCRIPTION
This pull request adds the following fixes and enhancements:

- Add two new parameter values ENABLE4EXTR and ENABLE4ALL to the ep11token PKEY_MODE config option. Older ep11 card firmware enforces the restriction that keys can not have CKA_EXTRACTABLE=true and CKA_IBM_PROTKEY_EXTRACTABLE=true at the same time. With newer card firmware this restriction is removed and a new control point is introduced to allow checking for this feature.
- On 32-bit s390 platforms, the pkey related assembler code parts won't compile. Therefore, add NO_PKEY compile switches where necessary. The NO_PKEY compile switch is already handled in configure.ac.
- The XCP_MFL_PROBE flag is no longer needed for host libs > 4.0, so add a check for this and don't specify the flag for newer libraries.


