### PR TITLE
COMMON: Don't clear context_len before calling context_free_func

### DIFF
--- a/usr/lib/common/decr_mgr.c
+++ b/usr/lib/common/decr_mgr.c
@@ -643,7 +643,6 @@ CK_RV decr_mgr_cleanup(STDLL_TokData_t *tokdata, SESSION *sess,
     ctx->multi = FALSE;
     ctx->active = FALSE;
     ctx->init_pending = FALSE;
-    ctx->context_len = 0;
     ctx->pkey_active = FALSE;
     ctx->state_unsaveable = FALSE;
     ctx->count_statistics = FALSE;
@@ -673,6 +672,7 @@ CK_RV decr_mgr_cleanup(STDLL_TokData_t *tokdata, SESSION *sess,
             free(ctx->context);
         ctx->context = NULL;
     }
+    ctx->context_len = 0;
     ctx->context_free_func = NULL;
 
     return CKR_OK;

--- a/usr/lib/common/dig_mgr.c
+++ b/usr/lib/common/dig_mgr.c
@@ -150,7 +150,6 @@ CK_RV digest_mgr_cleanup(STDLL_TokData_t *tokdata, SESSION *sess,
     ctx->multi_init = FALSE;
     ctx->multi = FALSE;
     ctx->active = FALSE;
-    ctx->context_len = 0;
     ctx->state_unsaveable = FALSE;
     ctx->count_statistics = FALSE;
 
@@ -167,6 +166,7 @@ CK_RV digest_mgr_cleanup(STDLL_TokData_t *tokdata, SESSION *sess,
             free(ctx->context);
         ctx->context = NULL;
     }
+    ctx->context_len = 0;
     ctx->context_free_func = NULL;
 
     return CKR_OK;

--- a/usr/lib/common/encr_mgr.c
+++ b/usr/lib/common/encr_mgr.c
@@ -645,7 +645,6 @@ CK_RV encr_mgr_cleanup(STDLL_TokData_t *tokdata, SESSION *sess,
     ctx->multi = FALSE;
     ctx->active = FALSE;
     ctx->init_pending = FALSE;
-    ctx->context_len = 0;
     ctx->pkey_active = FALSE;
     ctx->state_unsaveable = FALSE;
     ctx->count_statistics = FALSE;
@@ -675,6 +674,7 @@ CK_RV encr_mgr_cleanup(STDLL_TokData_t *tokdata, SESSION *sess,
             free(ctx->context);
         ctx->context = NULL;
     }
+    ctx->context_len = 0;
     ctx->context_free_func = NULL;
 
     return CKR_OK;

--- a/usr/lib/common/sign_mgr.c
+++ b/usr/lib/common/sign_mgr.c
@@ -838,7 +838,6 @@ CK_RV sign_mgr_cleanup(STDLL_TokData_t *tokdata, SESSION *sess,
     ctx->active = FALSE;
     ctx->init_pending = FALSE;
     ctx->recover = FALSE;
-    ctx->context_len = 0;
     ctx->pkey_active = FALSE;
     ctx->state_unsaveable = FALSE;
     ctx->count_statistics = FALSE;
@@ -856,6 +855,7 @@ CK_RV sign_mgr_cleanup(STDLL_TokData_t *tokdata, SESSION *sess,
             free(ctx->context);
         ctx->context = NULL;
     }
+    ctx->context_len = 0;
     ctx->context_free_func = NULL;
 
     return CKR_OK;

--- a/usr/lib/common/verify_mgr.c
+++ b/usr/lib/common/verify_mgr.c
@@ -838,7 +838,6 @@ CK_RV verify_mgr_cleanup(STDLL_TokData_t *tokdata, SESSION *sess,
     ctx->active = FALSE;
     ctx->init_pending = FALSE;
     ctx->recover = FALSE;
-    ctx->context_len = 0;
     ctx->pkey_active = FALSE;
     ctx->state_unsaveable = FALSE;
     ctx->count_statistics = FALSE;
@@ -856,6 +855,7 @@ CK_RV verify_mgr_cleanup(STDLL_TokData_t *tokdata, SESSION *sess,
             free(ctx->context);
         ctx->context = NULL;
     }
+    ctx->context_len = 0;
     ctx->context_free_func = NULL;
 
     return CKR_OK;


### PR DESCRIPTION
The context_len field of an encrypt/decrypt, sign/verify, or digest context should not be set to zero before the context_free_func callback is called. This callback gets the context_len as argument, so setting it to zero before calling the callback may cause problems inside the callback.

Currently, none of the callbacks used makes use of the context length, so this does not actually cause any problems. However, future callbacks might rely on the context length being passed correctly.