### PR TITLE
TESTCASES: Enable AES and EC tests for combined extract

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -233,7 +233,7 @@ PKCS11_VHSM_PIN ?= 1234567890
 
 ci-prepare:
 	killall -HUP pkcsslotd || true
-	${srcdir}/testcases/ciconfig.sh "$(sysconfdir)/opencryptoki" "$(sysconfdir)/opencryptoki" "$(sysconfdir)/opencryptoki"
+	${srcdir}/testcases/ciconfig.sh "$(sysconfdir)/opencryptoki" "$(sysconfdir)/opencryptoki" "$(sysconfdir)/opencryptoki" "${srcdir}/testcases/test_combined_extract.slots"
 	@sbindir@/pkcsslotd
 	@sbindir@/pkcsstats --reset-all
 	for slot in `awk '/slot (.*)/ { print $$2; }' $(sysconfdir)/opencryptoki/opencryptoki.conf`; do @sbindir@/pkcsconf -c $$slot -t | grep "Flags:" | grep -q TOKEN_INITIALIZED || PKCS11_USER_PIN=$(PKCS11_USER_PIN) PKCS11_SO_PIN=$(PKCS11_SO_PIN) PKCSLIB=@libdir@/opencryptoki/libopencryptoki.so ${srcdir}/testcases/init_token.sh $$slot; done
@@ -246,10 +246,10 @@ installcheck-local: all
 	if test ! -z ${PKCS11_TEST_USER}; then				\
 		chmod 777 ${srcdir}/testcases &&			\
 		cd ${srcdir}/testcases &&                               \
-		su ${PKCS11_TEST_USER} -s /bin/bash -c "PKCS11_SO_PIN=$(PKCS11_SO_PIN) PKCS11_USER_PIN=$(PKCS11_USER_PIN) PKCSLIB=@libdir@/opencryptoki/libopencryptoki.so sh ./ock_tests.sh || true"; \
+		su ${PKCS11_TEST_USER} -s /bin/bash -c "PKCS11_SO_PIN=$(PKCS11_SO_PIN) PKCS11_USER_PIN=$(PKCS11_USER_PIN) PKCSLIB=@libdir@/opencryptoki/libopencryptoki.so /bin/bash ./ock_tests.sh || true"; \
 	else								\
 		cd ${srcdir}/testcases && 				\
-		PKCS11_SO_PIN=$(PKCS11_SO_PIN) PKCS11_USER_PIN=$(PKCS11_USER_PIN) PKCSLIB=@libdir@/opencryptoki/libopencryptoki.so sh ./ock_tests.sh || true; \
+		PKCS11_SO_PIN=$(PKCS11_SO_PIN) PKCS11_USER_PIN=$(PKCS11_USER_PIN) PKCSLIB=@libdir@/opencryptoki/libopencryptoki.so /bin/bash ./ock_tests.sh || true; \
 	fi
 	killall -HUP pkcsslotd
 
@@ -264,6 +264,7 @@ ci-installcheck: ci-prepare installcheck
 	&& ./misc_tests/pkcsconf_test.sh | tee log-pkcsconf.txt
 	@sbindir@/pkcsstats --all
 	killall -HUP pkcsslotd
+	rm ${srcdir}/testcases/test_combined_extract.slots -f
 	@echo "done"
 
 ci-cleanup:
@@ -272,6 +273,7 @@ ci-cleanup:
 #	@sbindir@/pkcsslotd
 #	cd ${srcdir}/testcases && PKCS11_USER_PIN=$(PKCS11_USER_PIN) PKCSLIB=@libdir@/opencryptoki/libopencryptoki.so ./cleanup_vhsm.exp 42
 #	killall -HUP pkcsslotd
+	rm ${srcdir}/testcases/test_combined_extract.slots -f
 
 ci-uninstall: uninstall
 	rm -f $(sysconfdir)/opencryptoki/ep11tok*.conf

--- a/testcases/ciconfig.sh
+++ b/testcases/ciconfig.sh
@@ -3,6 +3,7 @@
 OCKCONFDIR="$1"
 EPCONFDIR="$2"
 CCACONFDIR="$3"
+COMBINED_EXTRACT_FILE="$4"
 
 LATESTCEXP="CEX8P"
 
@@ -68,7 +69,7 @@ PKEY_MODE = ENABLED
 EOF
 }
 
-if test $(($(date +%j)%2)) == 1; then
+if test $(($(date +%-j)%2)) == 1; then
     USENEWFORMAT=/bin/true
     echo "Using FIPS compliant token store"
 else
@@ -132,3 +133,11 @@ addslot 44 libpkcs11_ep11.so ep4 ep11tok44.conf
 if genlatestep11cfg 45 "PKEY_MODE ENABLE4NONEXTR"; then
     addslot 45 libpkcs11_ep11.so ep5 ep11tok45.conf
 fi
+
+# 6: latest (CEX8 only)
+# PKEY_MODE ENABLE4ALL
+if genlatestep11cfg 46 "PKEY_MODE ENABLE4ALL"; then
+    addslot 46 libpkcs11_ep11.so ep6 ep11tok46.conf
+    echo "46" > $COMBINED_EXTRACT_FILE
+fi
+

--- a/testcases/common/common.c
+++ b/testcases/common/common.c
@@ -35,6 +35,7 @@ CK_BBOOL securekey;
  * pkey option.
  */
 CK_BBOOL pkey = CK_FALSE;
+CK_BBOOL combined_extract = CK_FALSE;
 
 CK_ULONG t_total = 0;           // total test assertions
 CK_ULONG t_ran = 0;             // number of assertions ran
@@ -185,6 +186,9 @@ CK_RV create_AESKey(CK_SESSION_HANDLE session, CK_BBOOL extractable,
     };
     CK_ULONG keyTemplate_len = sizeof(keyTemplate) / sizeof(CK_ATTRIBUTE);
 
+    if (combined_extract)
+        pkeyextractable = CK_TRUE;
+
     rc = funcs->C_CreateObject(session, keyTemplate, keyTemplate_len, h_key);
     if (rc != CKR_OK) {
         if (is_rejected_by_policy(rc, session))
@@ -208,6 +212,9 @@ CK_RV generate_AESKey(CK_SESSION_HANDLE session,
         {CKA_IBM_PROTKEY_EXTRACTABLE, &pkeyextractable, sizeof(CK_BBOOL)},
     };
     CK_ULONG key_gen_tmpl_len = sizeof(key_gen_tmpl) / sizeof(CK_ATTRIBUTE);
+
+    if (combined_extract)
+        pkeyextractable = CK_TRUE;
 
     CK_RV rc = funcs->C_GenerateKey(session, mechkey,
                                     key_gen_tmpl, key_gen_tmpl_len,
@@ -523,6 +530,9 @@ CK_RV generate_EC_KeyPair(CK_SESSION_HANDLE session,
     CK_ULONG num_publ_attrs = sizeof(publicKeyTemplate)/sizeof(CK_ATTRIBUTE);
     CK_ULONG num_priv_attrs = sizeof(privateKeyTemplate)/sizeof(CK_ATTRIBUTE);
 
+    if (combined_extract)
+        pkeyextractable = CK_TRUE;
+
     // generate keys
     rc = funcs->C_GenerateKeyPair(session,
                                   &mech,
@@ -572,6 +582,9 @@ CK_RV create_ECPrivateKey(CK_SESSION_HANDLE session,
         {CKA_EXTRACTABLE, &extractable, sizeof(CK_BBOOL)},
         {CKA_IBM_PROTKEY_EXTRACTABLE, &pkeyextractable, sizeof(CK_BBOOL)},
     };
+
+    if (combined_extract)
+        pkeyextractable = CK_TRUE;
 
     // create key
     rc = funcs->C_CreateObject(session, template,
@@ -1361,6 +1374,8 @@ int do_ParseArgs(int argc, char **argv)
             no_init = TRUE;
         } else if (strcmp(argv[i], "-nostop") == 0) {
             no_stop = TRUE;
+        } else if (strcmp(argv[i], "-combined-extract") == 0) {
+            combined_extract = TRUE;
         } else {
             printf("Invalid argument passed as option: %s\n", argv[i]);
             usage(argv[0]);

--- a/testcases/crypto/aes_func.c
+++ b/testcases/crypto/aes_func.c
@@ -2781,7 +2781,13 @@ int main(int argc, char **argv)
         return rc;
 
     printf("Using slot #%lu...\n\n", SLOT_ID);
-    printf("With option: nostop: %d\n", no_stop);
+    printf("With options: combined_extract: %d, nostop: %d\n",
+           combined_extract, no_stop);
+    if (combined_extract)
+        printf("\n--------------------------------------------------------\n"
+               "Caution: combined_extract does only work on systems with\n"
+               "control point 75 (XCP_CPB_ALLOW_COMBINED_EXTRACT)='on'.\n"
+               "--------------------------------------------------------\n\n");
 
     rc = do_GetFunctionList();
     if (!rc) {

--- a/testcases/crypto/ec_func.c
+++ b/testcases/crypto/ec_func.c
@@ -2890,7 +2890,13 @@ int main(int argc, char **argv)
         return rc;
 
     printf("Using slot #%lu...\n\n", SLOT_ID);
-    printf("With option: no_init: %d\n", no_init);
+    printf("With options: combined_extract: %d, nostop: %d\n",
+           combined_extract, no_stop);
+    if (combined_extract)
+        printf("\n--------------------------------------------------------\n"
+               "Caution: combined_extract does only work on systems with\n"
+               "control point 75 (XCP_CPB_ALLOW_COMBINED_EXTRACT)='on'.\n"
+               "--------------------------------------------------------\n\n");
 
     rc = do_GetFunctionList();
     if (!rc) {

--- a/testcases/ock_tests.sh.in
+++ b/testcases/ock_tests.sh.in
@@ -237,9 +237,15 @@ run_tests()
     fi
     echo "***** Will run the following tests for slot $1: $(ls -U $OCK_TESTS)"
     ALLRES=0
+    COMBINED_EXTRACT=""
+    for item in "$(cat test_combined_extract.slots 2>/dev/null)"; do
+        if [[ "$1" == "$item" ]]; then
+            COMBINED_EXTRACT="-combined-extract"
+        fi
+    done
     for j in $( ls -U $OCK_TESTS ); do
-        echo "** Now executing '$j'"
-        $j -slot $1 $NO_STOP 2>&1
+        echo "** Now executing '$j -slot $1 $NO_STOP $COMBINED_EXTRACT'"
+        $j -slot $1 $NO_STOP $COMBINED_EXTRACT 2>&1
         RES=$?
         if [ $RES -ne 0 ]; then
             ALLRES=$RES
@@ -282,13 +288,13 @@ main_script()
 
     # where to run
     if [ -z $SLOT ]; then
-	SLOT="`awk '/slot (.*)/ { print $2; }' $PKCONF`"
+        SLOT="`awk '/^slot (.*)/ { print $2; }' $PKCONF`"
         LOGFILE=1
     fi
 
     # Turn space separated list into array
     totrace=($OCK_TRACE_TOKENS)
-    
+
     rm -f error_file.*
 
     for i in $SLOT; do (


### PR DESCRIPTION
A new parameter -combined-extract is introduced for the testcases. If this parameter is specified, the CKA_IBM_PROTKEY_EXTRACTABLE attribute is always set to TRUE for new key objects. Note that testcases will fail if combined extract is not supported in the test environment! In addition to this, a new token setup is added to ciconfig.sh to enable combined extract tests in the CI.