### PR TITLE
p11sak: Don't copy an empty CKA_ID with extract-pubkey

### DIFF
--- a/usr/sbin/p11sak/p11sak.c
+++ b/usr/sbin/p11sak/p11sak.c
@@ -9428,7 +9428,7 @@ static CK_RV p11sak_key_extract_pubkey(const struct p11sak_objtype *keytype,
     /* If no new ID is specified, try to use ID from certificate */
     if (opt_new_id == NULL) {
         rc = get_attribute(key, &id_attr);
-        if (rc == CKR_OK) {
+        if (rc == CKR_OK && id_attr.ulValueLen > 0) {
             rc = add_attribute(CKA_ID, id_attr.pValue, id_attr.ulValueLen,
                                &attrs, &num_attrs);
             if (rc != CKR_OK) {


### PR DESCRIPTION
Copying an empty (zero length) CKA_ID attribute does not make much sense, because the default CKA_ID value is empty anyway.

As reported by @akulhalli in https://github.com/opencryptoki/opencryptoki/pull/749#issuecomment-2031165150