### PR TITLE
p11sak: Add support to export a key or certificate as URI-PEM

### DIFF
--- a/man/man1/p11sak.1.in
+++ b/man/man1/p11sak.1.in
@@ -1038,7 +1038,11 @@ option to import an opaque secure key blob. Not all tokens support this.
 .BR \-\-file | \-F
 .I FILENAME
 .RB [ \-\-opaque | \-o ]
-.RB [ \-\-spki | \- S ]
+.RB [ \-\-spki | \-S ]
+.RB [ \-\-uri\-pem | \-u ]
+.RB [ \-\-uri\-pin\-value ]
+.RB [ \-\-uri\-pin\-source
+.IR FILENAME ]
 .RB [ \-\-help | \-h ]
 .PP
 Use the
@@ -1127,6 +1131,32 @@ exported in clear, even if the attributes would allow it. For such keys only the
 opaque secure key blob can be exported by using the
 .BR \-\-opaque | \-o
 option.
+.PP
+Specify the
+.BR \-\-uri\-pem | \-u
+option to export the PKCS#11 URI of the key in PEM form instead of the key
+material. Such an URI-PEM file can then be used with the
+.B pkcs11\-provider
+from
+.BR https://github.com/latchset/pkcs11\-provider .
+By default, the PKCS#11 URI does not contain the PKCS#11 user pin.
+Specify option
+.B \-\-uri\-pin\-value
+to include the PKCS#11 user pin in the URI using the
+.B pin\-value
+query attribute. This reveals the PKCS#11 user pin in clear, use with care!
+Alternatively, specify option
+.B \-\-uri\-pin\-source
+.I FILENAME
+to include the
+.B pin\-source
+query attribute in the URI, referencing the file name specified with this
+option. The PKCS#11 user pin value is written into that file as part of the
+export operation. This reveals the PKCS#11 user pin in clear, use with care!
+Adjust the file permissions of the specified pin\-source file so that it can
+only be read by the desired user(s). By default the file permissions are set so
+that only the owner user can read and write that file, but no one else (i.e.
+0600).
 .
 .
 .
@@ -1621,6 +1651,10 @@ as Certificate Authority (CA) certificate.
 .BR \-\-file | \-F
 .I FILENAME
 .RB [ \-\-der | \- D ]
+.RB [ \-\-uri\-pem | \-u ]
+.RB [ \-\-uri\-pin\-value ]
+.RB [ \-\-uri\-pin\-source
+.IR FILENAME ]
 .RB [ \-\-help | \-h ]
 .PP
 Use the
@@ -1674,6 +1708,32 @@ Specify the
 .BR \-\-der | \-D
 option to export the certificate(s) in binary (DER-encoded) form. Default is
 PEM format.
+.PP
+Specify the
+.BR \-\-uri\-pem | \-u
+option to export the PKCS#11 URI of the certificate in PEM form instead of the
+certificate material. Such an URI-PEM file can then be used with the
+.B pkcs11\-provider
+from
+.BR https://github.com/latchset/pkcs11\-provider .
+By default, the PKCS#11 URI does not contain the PKCS#11 user pin.
+Specify option
+.B \-\-uri\-pin\-value
+to include the PKCS#11 user pin in the URI using the
+.B pin\-value
+query attribute. This reveals the PKCS#11 user pin in clear, use with care!
+Alternatively, specify option
+.B \-\-uri\-pin\-source
+.I FILENAME
+to include the
+.B pin\-source
+query attribute in the URI, referencing the file name specified with this
+option. The PKCS#11 user pin value is written into that file as part of the
+export operation. This reveals the PKCS#11 user pin in clear, use with care!
+Adjust the file permissions of the specified pin\-source file so that it can
+only be read by the desired user(s). By default the file permissions are set so
+that only the owner user can read and write that file, but no one else (i.e.
+0600).
 .PP
 .
 .SS "Extracting the public key of certificates"
@@ -2363,6 +2423,66 @@ in PEM format.
 .
 .
 .TP 8
+.BR \-\-uri\-pem | \-u
+Export the key's or certificate’s PKCS#11 URI in PEM form instead of the key or
+certificate material. Such an URI-PEM file can then be used with the
+.B pkcs11\-provider
+from
+.BR https://github.com/latchset/pkcs11\-provider .
+.RE
+.PP
+.
+.
+.
+.TP 8
+.BR \-\-uri\-pin\-value
+When exporting the key's or certificate's PKCS#11 URI in PEM form, include the
+PKCS#11 user pin value in the URI using the
+.B pin\-value
+query attribute. This reveals the PKCS#11 user pin in clear, use with care!
+This option can only be used together with the
+.BR \-\-uri\-pem | \-u
+option, and when options
+.BR \-\-no\-login | \-N
+and
+.BR \-\-so
+are not specified.
+.RE
+.PP
+.
+.
+.
+.TP 8
+.BR \-\-uri\-pin\-source\~\fIFILENAME\fP
+When exporting the key's or certificate's PKCS#11 URI in PEM form, include the
+.B pin-source
+query attribute in the URI, referencing the file name specified with this
+option. The PKCS#11 user pin value is written into that file as part of the
+export operation. This reveals the PKCS#11 user pin in clear, use with care!
+Adjust the file permissions of the specified file so that it can only be read
+by the desired user(s). This option can only be used together with the
+.BR \-\-uri\-pem | \-u
+option, and when options
+.BR \-\-no\-login | \-N
+and
+.BR \-\-so
+are not specified.
+.RE
+.PP
+.
+.
+.
+.TP 8
+.BR \-\-ca\-cert | \-C
+Flag the certificate as a Certificate Authority (CA) certificate.
+If the certificate has the \fBBasicConstraints CA\fP flag on, it is also flagged
+as Certificate Authority (CA) certificate.
+.RE
+.PP
+.
+.
+.
+.TP 8
 .BR \-\-help | \-h
 Prints help for the usage of the
 .B p11sak
@@ -2377,16 +2497,6 @@ tool and/or the respective command and then exits.
 Prints the version of the
 .B p11sak
 tool and then exits.
-.RE
-.PP
-.
-.
-.
-.TP 8
-.BR \-\-ca\-cert | \-C
-Flag the certificate as a Certificate Authority (CA) certificate.
-If the certificate has the \fBBasicConstraints CA\fP flag on, it is also flagged
-as Certificate Authority (CA) certificate.
 .RE
 .PP
 .

--- a/testcases/misc_tests/p11sak_test.sh
+++ b/testcases/misc_tests/p11sak_test.sh
@@ -454,6 +454,23 @@ if [[ -n $( pkcsconf -m -c $SLOT | grep CKM_IBM_KYBER) ]]; then
 else
 	echo "Skip exporting ibm-kyber keys, slot does not support CKM_IBM_KYBER"
 fi
+# export to URI-PEM
+p11sak export-key aes --slot $SLOT --pin $PKCS11_USER_PIN --label "import-aes" --file export-uri-pem1.pem --force --uri-pem
+RC_P11SAK_EXPORT=$((RC_P11SAK_EXPORT + $?))
+openssl asn1parse -i -in export-uri-pem1.pem  > /dev/null
+RC_P11SAK_EXPORT=$((RC_P11SAK_EXPORT + $?))
+p11sak export-key aes --slot $SLOT --pin $PKCS11_USER_PIN --label "import-aes" --file export-uri-pem2.pem --force --uri-pem --uri-pin-value
+RC_P11SAK_EXPORT=$((RC_P11SAK_EXPORT + $?))
+openssl asn1parse -i -in export-uri-pem2.pem  > /dev/null
+RC_P11SAK_EXPORT=$((RC_P11SAK_EXPORT + $?))
+p11sak export-key aes --slot $SLOT --pin $PKCS11_USER_PIN --label "import-aes" --file export-uri-pem3.pem --force --uri-pem --uri-pin-source pin1.txt
+RC_P11SAK_EXPORT=$((RC_P11SAK_EXPORT + $?))
+openssl asn1parse -i -in export-uri-pem3.pem  > /dev/null
+RC_P11SAK_EXPORT=$((RC_P11SAK_EXPORT + $?))
+if [[ $(cat pin1.txt) != $PKCS11_USER_PIN ]]; then
+	echo "Pin file does not contain the PKCS#11 user pin"
+	RC_P11SAK_EXPORT=$((RC_P11SAK_EXPORT + 1))
+fi
 
 
 echo "** Now remove keys - 'p11sak_test.sh'"
@@ -1464,6 +1481,23 @@ if [[ -n $( pkcsconf -m -c $SLOT | grep CKM_DSA) ]]; then
 else
 	echo "Skip exporting x.509 certs with DSA key, slot does not support CKM_DSA"
 fi
+# export to URI-PEM
+p11sak export-cert x509 --slot $SLOT --pin $PKCS11_USER_PIN --label "p11sak-x509-rsa2048crt" --file export-uri-pem4.pem --force --uri-pem
+RC_P11SAK_X509_EXPORT=$((RC_P11SAK_X509_EXPORT + $?))
+openssl asn1parse -i -in export-uri-pem4.pem  > /dev/null
+RC_P11SAK_X509_EXPORT=$((RC_P11SAK_X509_EXPORT + $?))
+p11sak export-cert x509 --slot $SLOT --pin $PKCS11_USER_PIN --label "p11sak-x509-rsa2048crt" --file export-uri-pem5.pem --force --uri-pem --uri-pin-value
+RC_P11SAK_X509_EXPORT=$((RC_P11SAK_X509_EXPORT + $?))
+openssl asn1parse -i -in export-uri-pem5.pem  > /dev/null
+RC_P11SAK_X509_EXPORT=$((RC_P11SAK_X509_EXPORT + $?))
+p11sak export-cert x509 --slot $SLOT --pin $PKCS11_USER_PIN --label "p11sak-x509-rsa2048crt" --file export-uri-pem6.pem --force --uri-pem --uri-pin-source pin2.txt
+RC_P11SAK_X509_EXPORT=$((RC_P11SAK_X509_EXPORT + $?))
+openssl asn1parse -i -in export-uri-pem6.pem  > /dev/null
+RC_P11SAK_X509_EXPORT=$((RC_P11SAK_X509_EXPORT + $?))
+if [[ $(cat pin2.txt) != $PKCS11_USER_PIN ]]; then
+	echo "Pin file does not contain the PKCS#11 user pin"
+	RC_P11SAK_X509_EXPORT=$((RC_P11SAK_X509_EXPORT + 1))
+fi
 
 
 echo "** Now extracting public keys from x.509 certificates - 'p11sak_test.sh'"
@@ -2097,6 +2131,7 @@ rm -f $P11SAK_ALL_SO
 rm -f export-aes.key
 rm -f export-*.pem
 rm -f export-*.opaque
+rm -f pin*.txt
 
 echo "** Now remove temporary openssl files from x509 tests - "p11sak_test.sh""
 rm -f p11sak_*cert_exported.crt

--- a/usr/lib/common/uri.h
+++ b/usr/lib/common/uri.h
@@ -22,6 +22,8 @@ struct p11_uri {
     CK_ATTRIBUTE obj_id[1];
     CK_ATTRIBUTE obj_label[1];
     CK_ATTRIBUTE obj_class[1];
+    char *pin_value;
+    char *pin_source;
     void *priv;
 };
 

--- a/usr/sbin/p11sak/p11sak.h
+++ b/usr/sbin/p11sak/p11sak.h
@@ -39,6 +39,8 @@
 #define OPT_DETAILED_URI        257
 #define OPT_FORCE_PEM_PWD_PROMPT 258
 #define OPT_SO                  259
+#define OPT_URI_PIN_VALUE       260
+#define OPT_URI_PIN_SOURCE      261
 
 #define MAX_PRINT_LINE_LENGTH   80
 #define PRINT_INDENT_POS        35
@@ -49,6 +51,9 @@
 #define LIST_CERT_CN_CELL_SIZE  22
 
 #define MAX_SYM_CLEAR_KEY_SIZE  64
+
+#define PKCS11_URI_PEM_NAME     "PKCS#11 PROVIDER URI"
+#define PKCS11_URI_DESCRIPTION  "PKCS#11 Provider URI v1.0"
 
 enum p11sak_arg_type {
     ARG_TYPE_PLAIN = 0, /* no argument */


### PR DESCRIPTION
The pkcs11-provider from https://github.com/latchset/pkcs11-provider supports PEM files containing the PKCS#11 URI instead of the key or certificate material. Enhance p11sak to allow to export such URI-PEM files, optionally including the PKCS#11 user pin via `pin-value` (insecure) or `pin-source` query attribute of the URI.

@jschmidb Please give it a try if such a URI-PEM (with or without the pin) generated by p11sak really works with the pkcs11-provider.