### PR TITLE
Support new gcm API in icatoken

### DIFF
--- a/usr/lib/common/mech_aes.c
+++ b/usr/lib/common/mech_aes.c
@@ -3516,11 +3516,7 @@ CK_RV aes_gcm_encrypt_final(STDLL_TokData_t *tokdata, SESSION *sess,
     tag_data_len = (aesgcm->ulTagBits + 7) / 8; /* round to full byte */
 
     if (length_only) {
-        if (context->len == 0) {
-            *out_data_len = tag_data_len;
-        } else {
-            *out_data_len = context->len + tag_data_len;
-        }
+        *out_data_len = context->len + tag_data_len;
         return CKR_OK;
     }
 
@@ -3661,11 +3657,7 @@ CK_RV aes_gcm_decrypt_final(STDLL_TokData_t *tokdata, SESSION *sess,
     context = (AES_GCM_CONTEXT *) ctx->context;
 
     if (length_only) {
-        if (context->len == 0) {
-            *out_data_len = 0;
-        } else {
-            *out_data_len = context->len;
-        }
+        *out_data_len = context->len;
         return CKR_OK;
     }
 

--- a/usr/lib/ica_s390_stdll/ica_specific.c
+++ b/usr/lib/ica_s390_stdll/ica_specific.c
@@ -3609,7 +3609,7 @@ CK_RV token_specific_aes_gcm(STDLL_TokData_t *tokdata, SESSION *sess,
     }
 
     if (rc != 0) {
-        TRACE_ERROR("ica_aes_gcm failed with rc = 0x%lx.\n", rc);
+        TRACE_ERROR("ica_aes_gcm failed with rc = %ld.\n", rc);
         (*out_data_len) = 0;
         rc = CKR_FUNCTION_FAILED;
     }
@@ -3751,7 +3751,7 @@ CK_RV token_specific_aes_gcm_update(STDLL_TokData_t *tokdata, SESSION *sess,
     }
 
     if (rc != 0) {
-        TRACE_ERROR("ica_aes_gcm_update failed with rc = 0x%lx.\n", rc);
+        TRACE_ERROR("ica_aes_gcm_update failed with rc = %ld.\n", rc);
         rc = CKR_FUNCTION_FAILED;
         goto done;
     }
@@ -3857,7 +3857,7 @@ CK_RV token_specific_aes_gcm_final(STDLL_TokData_t *tokdata, SESSION *sess,
                               (unsigned int) attr->ulValueLen, subkey, 1);
 
         if (rc != 0) {
-            TRACE_ERROR("ica_aes_gcm_final failed with rc = 0x%lx.\n", rc);
+            TRACE_ERROR("ica_aes_gcm_final failed with rc = %ld.\n", rc);
             rc = CKR_FUNCTION_FAILED;
             goto done;
         }
@@ -3909,7 +3909,7 @@ CK_RV token_specific_aes_gcm_final(STDLL_TokData_t *tokdata, SESSION *sess,
                               tag_data_len, attr->pValue,
                               (unsigned int) attr->ulValueLen, subkey, 0);
         if (rc != 0) {
-            TRACE_ERROR("ica_aes_gcm_final failed with rc = 0x%lx.\n", rc);
+            TRACE_ERROR("ica_aes_gcm_final failed with rc = %ld.\n", rc);
             rc = CKR_FUNCTION_FAILED;
         }
     }

--- a/usr/lib/ica_s390_stdll/ica_specific.c
+++ b/usr/lib/ica_s390_stdll/ica_specific.c
@@ -3704,7 +3704,7 @@ CK_RV token_specific_aes_gcm_update(STDLL_TokData_t *tokdata, SESSION *sess,
         memcpy(buffer, context->data, context->len);
         memcpy(buffer + context->len, in_data, out_len - context->len);
 
-        TRACE_DEVEL("Ciphertext length (%ld bytes).\n", in_data_len);
+        TRACE_DEVEL("plaintext length (%ld bytes).\n", in_data_len);
 
         rc = ica_aes_gcm_intermediate(buffer, (unsigned int) out_len,
                                       out_data, ucb, auth_data,

--- a/usr/lib/ica_s390_stdll/ica_specific.c
+++ b/usr/lib/ica_s390_stdll/ica_specific.c
@@ -3760,7 +3760,7 @@ CK_RV token_specific_aes_gcm_update(STDLL_TokData_t *tokdata, SESSION *sess,
 
     context->ulClen += out_len;
 
-    /* AAD only processed in first update seuence,
+    /* AAD only processed in first update sequence,
      * mark it empty for all subsequent calls
      */
     context->ulAlen = 0;


### PR DESCRIPTION
The new libica gcm api (ica_aes_gcm_kma_*) exploits the KMA instruction on z14 and later. This results in better performance.