### PR TITLE
README.md: Fix Coverity badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://app.travis-ci.com/opencryptoki/opencryptoki.svg?branch=master)](https://app.travis-ci.com/opencryptoki/opencryptoki)
-['![Coverity Scan Build Status](https://img.shields.io/coverity/scan/16802.svg)'](https://scan.coverity.com/projects/opencryptoki-opencryptoki)
+[![Coverity Scan Build Status](https://img.shields.io/coverity/scan/16802.svg?branch=master)](https://scan.coverity.com/projects/opencryptoki-opencryptoki)
 
 # openCryptoki
 


### PR DESCRIPTION
Don't enclose it in single quotes, and add query parameter (which is ignored) to avoid caching of outdated image.