### PR TITLE
ICSF: Fix covscan findings on potential integer overflows

### DIFF
--- a/usr/lib/icsf_stdll/icsf.c
+++ b/usr/lib/icsf_stdll/icsf.c
@@ -148,7 +148,7 @@ static void strpad(char *dest, const char *orig, size_t len, int padding_char)
         str_len = len;
 
     memcpy(dest, orig, str_len);
-    if ((len - str_len) > 0)
+    if (len > str_len)
         memset(dest + str_len, ' ', len - str_len);
 }
 

--- a/usr/lib/icsf_stdll/icsf_specific.c
+++ b/usr/lib/icsf_stdll/icsf_specific.c
@@ -2766,7 +2766,7 @@ CK_RV icsftok_encrypt_update(STDLL_TokData_t * tokdata,
         goto done;
     }
     memcpy(buffer, multi_part_ctx->data, multi_part_ctx->used_data_len);
-    if (input_part_len - remaining > 0)
+    if (input_part_len > remaining)
         memcpy(buffer + multi_part_ctx->used_data_len, input_part,
                input_part_len - remaining);
 
@@ -3309,7 +3309,7 @@ CK_RV icsftok_decrypt_update(STDLL_TokData_t * tokdata,
         goto done;
     }
     memcpy(buffer, multi_part_ctx->data, multi_part_ctx->used_data_len);
-    if (input_part_len - remaining > 0)
+    if (input_part_len > remaining)
         memcpy(buffer + multi_part_ctx->used_data_len, input_part,
                input_part_len - remaining);
 
@@ -4420,7 +4420,7 @@ CK_RV icsftok_sign_update(STDLL_TokData_t * tokdata,
                 }
                 memcpy(buffer, multi_part_ctx->data,
                        multi_part_ctx->used_data_len);
-                if (out_len - multi_part_ctx->used_data_len > 0)
+                if (out_len > multi_part_ctx->used_data_len)
                     memcpy(buffer + multi_part_ctx->used_data_len,
                            (char *)in_data,
                            out_len - multi_part_ctx->used_data_len);
@@ -5020,7 +5020,7 @@ CK_RV icsftok_verify_update(STDLL_TokData_t * tokdata,
                 }
                 memcpy(buffer, multi_part_ctx->data,
                        multi_part_ctx->used_data_len);
-                if (out_len - multi_part_ctx->used_data_len > 0)
+                if (out_len > multi_part_ctx->used_data_len)
                     memcpy(buffer + multi_part_ctx->used_data_len,
                            (char *)in_data,
                            out_len - multi_part_ctx->used_data_len);


### PR DESCRIPTION
Fix covscan warnings on cases like 'if (a - b > 0)' where both 'a' and 'b' are unsigned types. In case 'b' is larger than 'a', then the subtraction result may overflow because the result is also treated as unsigned type. Fix this by using 'if (a > b)' instead.

Note that in the changed places 'a' is always larger than or equal to 'b' so the overflow does not happen. Still, changing the code to be less error-prone is a good thing.

Closes: https://github.com/opencryptoki/opencryptoki/issues/782

Suggested-by: @ngothan 