### PR TITLE
CCA: Also treat RSA-OAEP error 8/2053 as CKR_ENCRYPTED_DATA_INVALID

### DIFF
--- a/usr/lib/cca_stdll/cca_specific.c
+++ b/usr/lib/cca_stdll/cca_specific.c
@@ -5197,6 +5197,9 @@ CK_RV token_specific_rsa_oaep_decrypt(STDLL_TokData_t *tokdata,
     rc = constant_time_select(constant_time_eq(return_code, 8) &
                               constant_time_eq(reason_code, 2054),
                               CKR_ENCRYPTED_DATA_INVALID, rc);
+    rc = constant_time_select(constant_time_eq(return_code, 8) &
+                              constant_time_eq(reason_code, 2053),
+                              CKR_ENCRYPTED_DATA_INVALID, rc);
 
 done:
     object_put(tokdata, key_obj, TRUE);


### PR DESCRIPTION
CCA error 8/2053 means "No message found in the OAEP-decoded data" and is an additional error (in addition to the already handled 8/2054 error: "There is a non-valid RSA Enciphered Key cryptogram: OAEP optional encoding parameters failed validation") that could be returned by CCA verb CSNDPKD in case of RSA-OAEP on invalid encoded messages.

Translate this error also to CKR_ENCRYPTED_DATA_INVALID to not allow any distinction between these two error situations. Until now 8/2053 was translated to CKR_FUNCTION_FAILED, like any other CCA error codes.