### PR TITLE
TESTCASES: Print CK_SESSION_INFO.ulDeviceError in case of CKR_FUNCTION_FAILED

### DIFF
--- a/testcases/common/common.c
+++ b/testcases/common/common.c
@@ -163,6 +163,11 @@ int is_rejected_by_policy(CK_RV ret_code, CK_SESSION_HANDLE session)
         return 0;
     }
 
+    if (info.ulDeviceError != 0 && info.ulDeviceError != CKR_POLICY_VIOLATION) {
+        testcase_notice("CK_SESSION_INFO.ulDeviceError: 0x%lx",
+                        info.ulDeviceError);
+    }
+
     return (info.ulDeviceError == CKR_POLICY_VIOLATION);
 }
 


### PR DESCRIPTION
Field ulDeviceError in struct CK_SESSION_INFO might be set in case of a CKR_FUNCTION_FAILED. This can be due to a policy rejection (ulDeviceError is CKR_POLICY_VIOLATION), or due to other token internal errors.

Print the value of ulDeviceError in case its non-zero and not indicating a policy error.