### PR TITLE
COMMON: Fix sensitive IBM Kyber attribute

### DIFF
--- a/usr/lib/common/key.c
+++ b/usr/lib/common/key.c
@@ -5757,7 +5757,7 @@ CK_BBOOL ibm_kyber_priv_check_exportability(CK_ATTRIBUTE_TYPE type)
 {
     switch (type) {
     case CKA_VALUE:
-    case CKA_IBM_KYBER_PK:
+    case CKA_IBM_KYBER_SK:
         return FALSE;
     }
 


### PR DESCRIPTION
For the IBM Kyber key type, the CKA_IBM_KYBER_SK attribute contains the private key and thus, this attribute is sensitive. Attribute CKA_IBM_KYBER_PK contains the public key and is not sensitive.

Fixes: https://github.com/opencryptoki/opencryptoki/commit/f8ad4f039599ebe1f86381449eea885497ba05a2