### PR TITLE
MAKEFILE: Do not distribute generated man page files

### DIFF
--- a/man/man1/man1.mk
+++ b/man/man1/man1.mk
@@ -34,5 +34,4 @@ if ENABLE_P11SAK
 man1_MANS += man/man1/p11sak.1
 endif
 
-EXTRA_DIST += $(man1_MANS)
 CLEANFILES += man/man1/*.1

--- a/man/man5/man5.mk
+++ b/man/man5/man5.mk
@@ -3,5 +3,3 @@ man5_MANS += man/man5/opencryptoki.conf.5 man/man5/strength.conf.5 man/man5/poli
 if ENABLE_P11SAK
 man5_MANS += man/man5/p11sak_defined_attrs.conf.5
 endif
-
-EXTRA_DIST += $(man5_MANS)

--- a/man/man7/man7.mk
+++ b/man/man7/man7.mk
@@ -1,3 +1,1 @@
 man7_MANS += man/man7/opencryptoki.7
-
-EXTRA_DIST += $(man7_MANS)

--- a/man/man8/man8.mk
+++ b/man/man8/man8.mk
@@ -1,3 +1,1 @@
 man8_MANS += man/man8/pkcsslotd.8
-
-EXTRA_DIST += $(man8_MANS)


### PR DESCRIPTION
When using 'make dist', only distribute the man page sources, i.e. the *.in files, but not the generated man page files. Mentioning them in EXTRA_DIST is not necessary, because they are input to AC_CONFIG_FILES in configure.ac, and thus are distributed automatically.