### PR TITLE
Support live guest relocations for protected key ops

### DIFF
--- a/testcases/common/common.c
+++ b/testcases/common/common.c
@@ -630,6 +630,7 @@ CK_RV generate_EC_KeyPair(CK_SESSION_HANDLE session,
     CK_ATTRIBUTE publicKeyTemplate[] = {
         {CKA_VERIFY, &true, sizeof(true)},
         {CKA_EC_PARAMS, ec_params, ec_params_len},
+        {CKA_IBM_PROTKEY_EXTRACTABLE, &pkeyextractable, sizeof(CK_BBOOL)},
     };
     CK_ATTRIBUTE privateKeyTemplate[] = {
         {CKA_TOKEN, &true, sizeof(true)},
@@ -717,10 +718,12 @@ CK_RV create_ECPublicKey(CK_SESSION_HANDLE session,
                          CK_BYTE params[],
                          CK_ULONG params_len,
                          CK_BYTE pointq[],
-                         CK_ULONG pointq_len, CK_OBJECT_HANDLE * publ_key)
+                         CK_ULONG pointq_len, CK_OBJECT_HANDLE * publ_key,
+                         CK_BBOOL extractable)
 {
     CK_RV rc;
     CK_OBJECT_CLASS class = CKO_PUBLIC_KEY;
+    CK_BBOOL pkeyextractable = !extractable;
     CK_KEY_TYPE keyType = CKK_EC;
     CK_UTF8CHAR label[] = "An EC public key object";
     CK_BBOOL true = TRUE;
@@ -732,7 +735,8 @@ CK_RV create_ECPublicKey(CK_SESSION_HANDLE session,
         {CKA_VERIFY, &true, sizeof(true)},
         {CKA_DERIVE, &true, sizeof(true)},
         {CKA_EC_PARAMS, params, params_len},
-        {CKA_EC_POINT, pointq, pointq_len}
+        {CKA_EC_POINT, pointq, pointq_len},
+        {CKA_IBM_PROTKEY_EXTRACTABLE, &pkeyextractable, sizeof(CK_BBOOL)},
     };
 
     // create key

--- a/testcases/crypto/ec_func.c
+++ b/testcases/crypto/ec_func.c
@@ -1246,7 +1246,7 @@ CK_RV run_DeriveECDHKeyKAT(void)
         rc = create_ECPublicKey(session,
                                 ecdh_tv[i].params, ecdh_tv[i].params_len,
                                 ecdh_tv[i].pubkeyA, ecdh_tv[i].pubkey_len,
-                                &publ_keyA);
+                                &publ_keyA, !pkey);
         if (rc != CKR_OK) {
             if (rc == CKR_POLICY_VIOLATION) {
                 testcase_skip("EC key import is not allowed by policy");
@@ -1284,7 +1284,7 @@ CK_RV run_DeriveECDHKeyKAT(void)
         rc = create_ECPublicKey(session,
                                 ecdh_tv[i].params, ecdh_tv[i].params_len,
                                 ecdh_tv[i].pubkeyB, ecdh_tv[i].pubkey_len,
-                                &publ_keyB);
+                                &publ_keyB, !pkey);
         if (rc != CKR_OK) {
             if (rc == CKR_CURVE_NOT_SUPPORTED) {
                 testcase_skip("Slot %u doesn't support this curve: %s",
@@ -2029,7 +2029,7 @@ CK_RV run_ImportECCKeyPairSignVerify(void)
 
         rc = create_ECPublicKey(session, ec_tv[i].params, ec_tv[i].params_len,
                                 ec_tv[i].pubkey, ec_tv[i].pubkey_len,
-                                &publ_key);
+                                &publ_key, !pkey);
         if (rc != CKR_OK) {
             if (rc == CKR_POLICY_VIOLATION) {
                 testcase_skip("EC key import is not allowed by policy");
@@ -2239,7 +2239,7 @@ CK_RV run_TransferECCKeyPairSignVerify(void)
 
         rc = create_ECPublicKey(session, ec_tv[i].params, ec_tv[i].params_len,
                                 ec_tv[i].pubkey, ec_tv[i].pubkey_len,
-                                &publ_key);
+                                &publ_key, !pkey);
         if (rc != CKR_OK) {
             if (rc == CKR_POLICY_VIOLATION) {
                 testcase_skip("EC key import is not allowed by policy");

--- a/usr/lib/cca_stdll/cca_specific.c
+++ b/usr/lib/cca_stdll/cca_specific.c
@@ -3309,8 +3309,9 @@ CK_RV token_specific_aes_xts(STDLL_TokData_t *tokdata, SESSION *session,
     rc = ccatok_pkey_check(tokdata, session, key_obj, &mech);
     switch (rc) {
     case CKR_OK:
-        rc = pkey_aes_xts(key_obj, init_v, in_data, in_data_len,
-                          out_data, out_data_len, encrypt, initial, final, iv);
+        rc = pkey_aes_xts(tokdata, session, key_obj, init_v,
+                          in_data, in_data_len, out_data, out_data_len,
+                          encrypt, initial, final, iv);
         goto done;
     default:
         goto done;
@@ -5771,7 +5772,7 @@ CK_RV token_specific_aes_ecb(STDLL_TokData_t * tokdata,
     rc = ccatok_pkey_check(tokdata, session, key, &mech);
     switch (rc) {
     case CKR_OK:
-        rc = pkey_aes_ecb(key, in_data, in_data_len,
+        rc = pkey_aes_ecb(tokdata, session, key, in_data, in_data_len,
                           out_data, out_data_len, encrypt);
         goto done;
     case CKR_FUNCTION_NOT_SUPPORTED:
@@ -5911,7 +5912,7 @@ CK_RV token_specific_aes_cbc(STDLL_TokData_t * tokdata,
     rc = ccatok_pkey_check(tokdata, session, key, &mech);
     switch (rc) {
     case CKR_OK:
-        rc = pkey_aes_cbc(key, init_v, in_data, in_data_len,
+        rc = pkey_aes_cbc(tokdata, session, key, init_v, in_data, in_data_len,
                           out_data, out_data_len, encrypt);
         goto done;
     case CKR_FUNCTION_NOT_SUPPORTED:

--- a/usr/lib/cca_stdll/cca_specific.c
+++ b/usr/lib/cca_stdll/cca_specific.c
@@ -3289,7 +3289,7 @@ static CK_RV ccatok_pkey_check_attrs(STDLL_TokData_t *tokdata,
         return CKR_OK;
 
     /*
-     * At this point, the key has CKA_IBM_PROKEY_EXTRACTABLE = true and it has
+     * At this point, the key has CKA_IBM_PROTKEY_EXTRACTABLE = true and it has
      * a secure key token, so let's check if the secure key token is
      * CPACF-exportable.
      */
@@ -3305,7 +3305,8 @@ static CK_RV ccatok_pkey_check_attrs(STDLL_TokData_t *tokdata,
          */
         if (pkey_op_ec_curve_supported_by_cpacf(templ) &&
             !ccatok_token_is_cpacf_exportable(sec_key, sec_len)) {
-            TRACE_ERROR("ECC secure key is CKA_IBM_PROTKEY_EXTRACTABLE, but token is not CPACF-exportable.\n");
+            TRACE_ERROR("ECC secure key is CKA_IBM_PROTKEY_EXTRACTABLE, "
+                        "but token is not CPACF-exportable.\n");
             return CKR_TEMPLATE_INCONSISTENT;
         }
         break;
@@ -3314,7 +3315,6 @@ static CK_RV ccatok_pkey_check_attrs(STDLL_TokData_t *tokdata,
     }
 
     return CKR_OK;
-
 }
 
 CK_RV ccatok_pkey_check_aes_xts(TEMPLATE *tmpl)

--- a/usr/lib/cca_stdll/cca_specific.c
+++ b/usr/lib/cca_stdll/cca_specific.c
@@ -5981,7 +5981,8 @@ CK_RV token_specific_aes_ecb(STDLL_TokData_t * tokdata,
     switch (rc) {
     case CKR_OK:
         rc = pkey_aes_ecb(tokdata, session, key, in_data, in_data_len,
-                          out_data, out_data_len, encrypt);
+                          out_data, out_data_len, encrypt,
+                          ccatok_pkey_convert_key);
         goto done;
     case CKR_FUNCTION_NOT_SUPPORTED:
         /* fallback */
@@ -6121,7 +6122,8 @@ CK_RV token_specific_aes_cbc(STDLL_TokData_t * tokdata,
     switch (rc) {
     case CKR_OK:
         rc = pkey_aes_cbc(tokdata, session, key, init_v, in_data, in_data_len,
-                          out_data, out_data_len, encrypt);
+                          out_data, out_data_len, encrypt,
+                          ccatok_pkey_convert_key);
         goto done;
     case CKR_FUNCTION_NOT_SUPPORTED:
         /* fallback */

--- a/usr/lib/cca_stdll/cca_specific.c
+++ b/usr/lib/cca_stdll/cca_specific.c
@@ -3511,7 +3511,8 @@ CK_RV token_specific_aes_xts(STDLL_TokData_t *tokdata, SESSION *session,
     case CKR_OK:
         rc = pkey_aes_xts(tokdata, session, key_obj, init_v,
                           in_data, in_data_len, out_data, out_data_len,
-                          encrypt, initial, final, iv);
+                          encrypt, initial, final, iv,
+                          ccatok_pkey_convert_key);
         goto done;
     default:
         goto done;

--- a/usr/lib/cca_stdll/cca_specific.c
+++ b/usr/lib/cca_stdll/cca_specific.c
@@ -6760,7 +6760,8 @@ CK_RV token_specific_ec_sign(STDLL_TokData_t * tokdata,
     switch (rc) {
     case CKR_OK:
         rc = pkey_ec_sign(tokdata, sess, key_obj, in_data, in_data_len,
-                          out_data, out_data_len, NULL);
+                          out_data, out_data_len, NULL,
+                          ccatok_pkey_convert_key);
         goto done;
     case CKR_FUNCTION_NOT_SUPPORTED:
         /* fallback */

--- a/usr/lib/cca_stdll/cca_specific.c
+++ b/usr/lib/cca_stdll/cca_specific.c
@@ -6548,7 +6548,7 @@ CK_RV token_specific_ec_sign(STDLL_TokData_t * tokdata,
     rc = ccatok_pkey_check(tokdata, sess, key_obj, &mech);
     switch (rc) {
     case CKR_OK:
-        rc = pkey_ec_sign(key_obj, in_data, in_data_len,
+        rc = pkey_ec_sign(tokdata, sess, key_obj, in_data, in_data_len,
                           out_data, out_data_len, NULL);
         goto done;
     case CKR_FUNCTION_NOT_SUPPORTED:

--- a/usr/lib/cca_stdll/cca_specific.c
+++ b/usr/lib/cca_stdll/cca_specific.c
@@ -2939,6 +2939,126 @@ done:
 
     return ret;
 }
+
+static CK_RV ccatok_pkey_convert_key(STDLL_TokData_t *tokdata, SESSION *session,
+                                     OBJECT *key_obj, CK_BBOOL xts_mode,
+                                     CK_BYTE *protkey, CK_ULONG *protkey_len)
+{
+    struct cca_private_data *cca_private = tokdata->private_data;
+    int num_retries = 0, vp_offset1, vp_offset2;
+    CK_ATTRIBUTE *skey_attr = NULL;
+    CK_ATTRIBUTE *pkey_attr = NULL;
+    CK_RV rc, rc2;
+
+    /* Try to obtain a write lock on the key_obj */
+    rc = object_unlock(key_obj);
+    if (rc != CKR_OK) {
+        TRACE_ERROR("object_unlock failed, rc=0x%lx\n", rc);
+        goto done;
+    }
+
+    rc = object_lock(key_obj, WRITE_LOCK);
+    if (rc != CKR_OK) {
+        TRACE_ERROR("Could not obtain write lock.\n");
+        goto done;
+    }
+
+    /*
+     * The key_obj could be modified between unlock and lock. Therefore get
+     * the attribute when we have the write lock here.
+     */
+    if (template_attribute_get_non_empty(key_obj->template,
+                                         CKA_IBM_OPAQUE, &skey_attr) != CKR_OK) {
+        TRACE_ERROR("This key has no blob: should not occur!\n");
+        rc = CKR_FUNCTION_FAILED;
+        goto unlock;
+    }
+
+retry:
+    /* Convert secure key to protected key. */
+    rc = ccatok_pkey_skey2pkey(tokdata, skey_attr, &pkey_attr, xts_mode);
+    if (rc != CKR_OK) {
+        TRACE_ERROR("protkey creation failed, rc=0x%lx\n", rc);
+        goto unlock;
+    }
+
+    /*
+     * In case of XTS, check if the wkvp's of the two keys are identical.
+     * An LGR could have happened between the creation of the two keys.
+     */
+    if (xts_mode) {
+        vp_offset1 = pkey_attr->ulValueLen / 2 - PKEY_MK_VP_LENGTH;
+        vp_offset2 = pkey_attr->ulValueLen - PKEY_MK_VP_LENGTH;
+        if (memcmp((CK_BYTE *)pkey_attr->pValue + vp_offset1,
+                   (CK_BYTE *)pkey_attr->pValue + vp_offset2,
+                   PKEY_MK_VP_LENGTH) != 0) {
+            num_retries++;
+            if (num_retries < PKEY_CONVERT_KEY_RETRIES) {
+                TRACE_DEVEL("%s vp of xts key 1 does not match with vp of "
+                            "xts key 2, retry %d of %d ...\n",
+                            __func__, num_retries, PKEY_CONVERT_KEY_RETRIES);
+                goto retry;
+            }
+            rc = CKR_FUNCTION_FAILED;
+            goto unlock;
+        }
+    }
+
+    /*
+     * Save new protkey attr in key_obj. This happens only in memory,
+     * works also for r/o sessions.
+     */
+    rc = template_update_attribute(key_obj->template, pkey_attr);
+    if (rc != CKR_OK) {
+        TRACE_ERROR("template_update_attribute failed, rc=0x%lx\n", rc);
+        goto unlock;
+    }
+
+    /* If we have a r/w session, also save obj to disk. */
+    if (ccatok_pkey_session_ok_for_obj(session, key_obj)) {
+        if (object_is_token_object(key_obj)) {
+            rc = object_mgr_save_token_object(tokdata, key_obj);
+            if (rc != CKR_OK) {
+                TRACE_ERROR("Could not save token obj to repository, rc=0x%lx.\n", rc);
+                goto unlock;
+            }
+        }
+    }
+
+    /* Update wkvp in CCA private data. */
+    memcpy(&cca_private->pkey_mk_vp,
+           (CK_BYTE *)pkey_attr->pValue + pkey_attr->ulValueLen - PKEY_MK_VP_LENGTH,
+           PKEY_MK_VP_LENGTH);
+
+    /* Pass back new protkey. Need to do this before unlocking the obj. */
+    if (*protkey_len < pkey_attr->ulValueLen) {
+        rc = CKR_BUFFER_TOO_SMALL;
+        goto unlock;
+    }
+    memcpy(protkey, pkey_attr->pValue, pkey_attr->ulValueLen);
+    *protkey_len = pkey_attr->ulValueLen;
+
+unlock:
+    rc2 = object_unlock(key_obj);
+    if (rc2 != CKR_OK) {
+        TRACE_ERROR("object_unlock failed, rc=0x%lx\n", rc2);
+        if (rc == CKR_OK)
+            rc = rc2;
+        goto done;
+    }
+
+    rc2 = object_lock(key_obj, READ_LOCK);
+    if (rc2 != CKR_OK) {
+        TRACE_ERROR("object_lock for READ failed, rc=0x%lx\n", rc2);
+        if (rc == CKR_OK)
+            rc = rc2;
+        goto done;
+    }
+
+done:
+
+    return rc;
+}
 #endif
 
 /*

--- a/usr/lib/cca_stdll/cca_stdll.h
+++ b/usr/lib/cca_stdll/cca_stdll.h
@@ -302,6 +302,7 @@ struct cca_private_data {
     int pkey_mode;
     int pkey_wrap_supported;
     char pkey_mk_vp[PKEY_MK_VP_LENGTH];
+    pthread_rwlock_t pkey_rwlock;
     int pkeyfd;
     int msa_level;
     CK_BBOOL cka_sensitive_default_true;

--- a/usr/lib/common/mech_aes.c
+++ b/usr/lib/common/mech_aes.c
@@ -2965,7 +2965,7 @@ static void aes_cmac_cleanup(STDLL_TokData_t *tokdata, SESSION *sess,
     UNUSED(context_len);
 
     if (((AES_CMAC_CONTEXT *)context)->ctx != NULL) {
-        token_specific.t_aes_cmac(tokdata, (CK_BYTE *)"", 0, NULL,
+        token_specific.t_aes_cmac(tokdata, sess, (CK_BYTE *)"", 0, NULL,
                                   ((AES_CMAC_CONTEXT *)context)->iv,
                                   CK_FALSE, CK_TRUE,
                                   ((AES_CMAC_CONTEXT *)context)->ctx);
@@ -3014,7 +3014,7 @@ CK_RV aes_cmac_sign(STDLL_TokData_t *tokdata,
         return rc;
     }
 
-    rc = token_specific.t_aes_cmac(tokdata, in_data, in_data_len,
+    rc = token_specific.t_aes_cmac(tokdata, sess, in_data, in_data_len,
                                    key_obj,
                                    ((AES_CMAC_CONTEXT *)ctx->context)->iv,
                                    CK_TRUE, CK_TRUE,
@@ -3089,7 +3089,7 @@ CK_RV aes_cmac_sign_update(STDLL_TokData_t *tokdata,
         memcpy(cipher, context->data, context->len);
         memcpy(cipher + context->len, in_data, out_len - context->len);
 
-        rc = token_specific.t_aes_cmac(tokdata, cipher, out_len, key_obj,
+        rc = token_specific.t_aes_cmac(tokdata, sess, cipher, out_len, key_obj,
                                        context->iv,
                                        !context->initialized, CK_FALSE,
                                        &context->ctx);
@@ -3160,7 +3160,7 @@ CK_RV aes_cmac_sign_final(STDLL_TokData_t *tokdata,
         return rc;
     }
 
-   rc = token_specific.t_aes_cmac(tokdata, context->data, context->len,
+   rc = token_specific.t_aes_cmac(tokdata, sess, context->data, context->len,
                                    key_obj, context->iv,
                                    !context->initialized, CK_TRUE,
                                    &context->ctx);
@@ -3218,7 +3218,7 @@ CK_RV aes_cmac_verify(STDLL_TokData_t *tokdata,
         return rc;
     }
 
-    rc = token_specific.t_aes_cmac(tokdata, in_data, in_data_len,
+    rc = token_specific.t_aes_cmac(tokdata, sess, in_data, in_data_len,
                                    key_obj,
                                    ((AES_CMAC_CONTEXT *) ctx->context)->iv,
                                    CK_TRUE, CK_TRUE,
@@ -3297,7 +3297,7 @@ CK_RV aes_cmac_verify_update(STDLL_TokData_t *tokdata,
         memcpy(cipher, context->data, context->len);
         memcpy(cipher + context->len, in_data, out_len - context->len);
 
-        rc = token_specific.t_aes_cmac(tokdata, cipher, out_len, key_obj,
+        rc = token_specific.t_aes_cmac(tokdata, sess, cipher, out_len, key_obj,
                                       context->iv,
                                       !context->initialized, CK_FALSE,
                                       &context->ctx);
@@ -3360,7 +3360,7 @@ CK_RV aes_cmac_verify_final(STDLL_TokData_t *tokdata,
         return rc;
     }
 
-    rc = token_specific.t_aes_cmac(tokdata, context->data, context->len,
+    rc = token_specific.t_aes_cmac(tokdata, sess, context->data, context->len,
                                    key_obj, context->iv,
                                    !context->initialized, CK_TRUE,
                                    &context->ctx);

--- a/usr/lib/common/mech_aes.c
+++ b/usr/lib/common/mech_aes.c
@@ -4216,7 +4216,7 @@ CK_RV aes_xts_cipher(CK_BYTE *in_data, CK_ULONG in_data_len,
 {
     unsigned char partial[AES_BLOCK_SIZE];
     unsigned char iv_prev[AES_INIT_VECTOR_SIZE] = { 0 };
-    CK_ULONG len, rest;
+    CK_ULONG len, rest, bytes_processed;
     CK_RV rc;
 
     /* Full block size unless final call */
@@ -4245,7 +4245,7 @@ CK_RV aes_xts_cipher(CK_BYTE *in_data, CK_ULONG in_data_len,
 
     rest = in_data_len % AES_BLOCK_SIZE;
     len = in_data_len - rest;
-    *out_data_len = 0;
+    bytes_processed = 0;
 
     /*
      * It was checked above that we have at least one full block if we are in
@@ -4265,7 +4265,7 @@ CK_RV aes_xts_cipher(CK_BYTE *in_data, CK_ULONG in_data_len,
         in_data += len;
         in_data_len -= len;
         out_data += len;
-        *out_data_len = len;
+        bytes_processed = len;
     }
 
     if (!encrypt && final) {
@@ -4281,7 +4281,7 @@ CK_RV aes_xts_cipher(CK_BYTE *in_data, CK_ULONG in_data_len,
         in_data += AES_BLOCK_SIZE;
         in_data_len -= AES_BLOCK_SIZE;
         out_data += AES_BLOCK_SIZE;
-        *out_data_len += AES_BLOCK_SIZE;
+        bytes_processed += AES_BLOCK_SIZE;
     }
 
     /* Partial block? Only possible for final call */
@@ -4314,7 +4314,7 @@ CK_RV aes_xts_cipher(CK_BYTE *in_data, CK_ULONG in_data_len,
         memcpy(out_data, out_data - AES_BLOCK_SIZE, in_data_len);
         memcpy(partial + in_data_len, out_data - AES_BLOCK_SIZE + in_data_len,
                AES_BLOCK_SIZE - in_data_len);
-        *out_data_len += in_data_len;
+        bytes_processed += in_data_len;
 
         rc = cipher_blocks(partial, out_data - AES_BLOCK_SIZE,
                            AES_BLOCK_SIZE, iv, cb_data);
@@ -4323,6 +4323,8 @@ CK_RV aes_xts_cipher(CK_BYTE *in_data, CK_ULONG in_data_len,
             return rc;
         }
     }
+
+    *out_data_len = bytes_processed;
 
     return CKR_OK;
 }

--- a/usr/lib/common/pkey_utils.c
+++ b/usr/lib/common/pkey_utils.c
@@ -116,13 +116,13 @@ int get_msa_level(void)
  * Returns 0 for the query func, number of processed
  * bytes for encryption/decryption funcs
  */
-static int s390_km(unsigned long func, void *param, unsigned char *dest,
-           const unsigned char *src, long src_len)
+static unsigned int s390_km(unsigned long func, void *param, unsigned char *dest,
+                            const unsigned char *src, unsigned long src_len)
 {
-    register long __func __asm__("0") = func;
+    register unsigned long __func __asm__("0") = func;
     register void *__param __asm__("1") = param;
     register const unsigned char *__src __asm__("2") = src;
-    register long __src_len __asm__("3") = src_len;
+    register unsigned long __src_len __asm__("3") = src_len;
     register unsigned char *__dest __asm__("4") = dest;
 
     __asm__ volatile (
@@ -148,13 +148,13 @@ static int s390_km(unsigned long func, void *param, unsigned char *dest,
  * Returns 0 for the query func, number of processed
  * bytes for encryption/decryption funcs
  */
-static int s390_kmc(unsigned long func, void *param, unsigned char *dest,
-            const unsigned char *src, long src_len)
+static unsigned int s390_kmc(unsigned long func, void *param, unsigned char *dest,
+                             const unsigned char *src, unsigned long src_len)
 {
-    register long __func __asm__("0") = func;
+    register unsigned long __func __asm__("0") = func;
     register void *__param __asm__("1") = param;
     register const unsigned char *__src __asm__("2") = src;
-    register long __src_len __asm__("3") = src_len;
+    register unsigned long __src_len __asm__("3") = src_len;
     register unsigned char *__dest __asm__("4") = dest;
 
     __asm__ volatile (
@@ -215,13 +215,13 @@ static int s390_kdsa(unsigned long func, void *param,
  * Returns 0 for the query func, number of processed
  * bytes for encryption/decryption funcs
  */
-static int s390_kmac(unsigned long func, void *param,
-            const unsigned char *src, long src_len)
+static unsigned int s390_kmac(unsigned long func, void *param,
+                              const unsigned char *src, unsigned long src_len)
 {
-    register long __func __asm__("0") = func;
+    register unsigned long __func __asm__("0") = func;
     register void *__param __asm__("1") = param;
     register const unsigned char *__src __asm__("2") = src;
-    register long __src_len __asm__("3") = src_len;
+    register unsigned long __src_len __asm__("3") = src_len;
 
     __asm__ volatile (
         "0:     .insn   rre, 0xb91e0000,%0,%0 \n"

--- a/usr/lib/common/pkey_utils.c
+++ b/usr/lib/common/pkey_utils.c
@@ -548,7 +548,7 @@ CK_RV pkey_aes_ecb(STDLL_TokData_t *tokdata, SESSION *session, OBJECT *key_obj,
     }
 
     /* Call CPACF */
-    memcpy(param.key, pkey_attr->pValue, pkey_attr->ulValueLen);
+    memcpy(param.key, pkey_attr->pValue, MIN(pkey_attr->ulValueLen, sizeof(param.key)));
     while (len > 0 && num_tries < PKEY_CONVERT_KEY_RETRIES) {
         bytes_processed = s390_km(fc, &param, out_pos, in_pos, len);
         if (bytes_processed < len) {
@@ -559,7 +559,7 @@ CK_RV pkey_aes_ecb(STDLL_TokData_t *tokdata, SESSION *session, OBJECT *key_obj,
                               protkey, &protkey_len);
             if (ret != CKR_OK)
                 goto done;
-            memcpy(param.key, protkey, protkey_len);
+            memcpy(param.key, protkey, MIN(protkey_len, sizeof(param.key)));
         }
         in_pos += bytes_processed;
         out_pos += bytes_processed;
@@ -645,7 +645,7 @@ CK_RV pkey_aes_cbc(STDLL_TokData_t *tokdata, SESSION *session, OBJECT *key_obj,
 
     /* Call CPACF */
     memcpy(param.iv, iv, 16);
-    memcpy(param.key, pkey_attr->pValue, pkey_attr->ulValueLen);
+    memcpy(param.key, pkey_attr->pValue, MIN(pkey_attr->ulValueLen, sizeof(param.key)));
 
     while (len > 0 || num_tries < PKEY_CONVERT_KEY_RETRIES) {
         bytes_processed = s390_kmc(fc, &param, out_pos, in_pos, len);
@@ -657,7 +657,7 @@ CK_RV pkey_aes_cbc(STDLL_TokData_t *tokdata, SESSION *session, OBJECT *key_obj,
                               protkey, &protkey_len);
             if (ret != CKR_OK)
                 goto done;
-            memcpy(param.key, protkey, protkey_len);
+            memcpy(param.key, protkey, MIN(protkey_len, sizeof(param.key)));
         }
         in_pos += bytes_processed;
         out_pos += bytes_processed;
@@ -758,7 +758,8 @@ CK_RV pkey_aes_cmac(STDLL_TokData_t *tokdata, SESSION *session,
     /* Setup parm block */
     memset(parm_block, 0, sizeof(parm_block));
     parm_block_lookup_init(&pb_lookup, parm_block, AES_BLOCK_SIZE);
-    memcpy(pb_lookup.keys, pkey_attr->pValue, pkey_attr->ulValueLen);
+    memcpy(pb_lookup.keys, pkey_attr->pValue,
+           MIN(pkey_attr->ulValueLen, MAXPROTKEYSIZE));
 
     /* copy iv into param block, if available (intermediate) */
     if (iv != NULL)
@@ -777,7 +778,7 @@ CK_RV pkey_aes_cmac(STDLL_TokData_t *tokdata, SESSION *session,
                                   protkey, &protkey_len);
                 if (ret != CKR_OK)
                     goto done;
-                memcpy(pb_lookup.keys, protkey, protkey_len);
+                memcpy(pb_lookup.keys, protkey, MIN(protkey_len, MAXPROTKEYSIZE));
             }
             in_pos += bytes_processed;
             out_pos += bytes_processed;
@@ -815,7 +816,7 @@ CK_RV pkey_aes_cmac(STDLL_TokData_t *tokdata, SESSION *session,
                                           protkey, &protkey_len);
                         if (ret != CKR_OK)
                             goto done;
-                        memcpy(pb_lookup.keys, protkey, protkey_len);
+                        memcpy(pb_lookup.keys, protkey, MIN(protkey_len, MAXPROTKEYSIZE));
                     }
                     in_pos += bytes_processed;
                     out_pos += bytes_processed;

--- a/usr/lib/common/pkey_utils.c
+++ b/usr/lib/common/pkey_utils.c
@@ -659,7 +659,8 @@ static inline void parm_block_lookup_init(struct parm_block_lookup *lookup,
 /**
  * Calculates an AES-CMAC via CPACF using a protected key.
  */
-CK_RV pkey_aes_cmac(OBJECT *key_obj, CK_BYTE *message,
+CK_RV pkey_aes_cmac(STDLL_TokData_t *tokdata, SESSION *session,
+                    OBJECT *key_obj, CK_BYTE *message,
                     CK_ULONG message_len, CK_BYTE *cmac, CK_BYTE *iv)
 {
     CK_RV ret;

--- a/usr/lib/common/pkey_utils.c
+++ b/usr/lib/common/pkey_utils.c
@@ -967,7 +967,8 @@ done:
 /**
  * Sign the given hash via CPACF using the given protected private key.
  */
-CK_RV pkey_ec_sign(OBJECT *privkey, CK_BYTE *hash, CK_ULONG hash_len,
+CK_RV pkey_ec_sign(STDLL_TokData_t *tokdata, SESSION *session,
+                   OBJECT *privkey, CK_BYTE *hash, CK_ULONG hash_len,
                    CK_BYTE *sig, CK_ULONG *sig_len,
                    void (*rng_cb)(unsigned char *, size_t))
 {
@@ -996,6 +997,9 @@ CK_RV pkey_ec_sign(OBJECT *privkey, CK_BYTE *hash, CK_ULONG hash_len,
     CK_ATTRIBUTE *pkey_attr = NULL;
     int rc, off;
     cpacf_curve_type_t curve_type;
+
+    UNUSED(tokdata);
+    UNUSED(session);
 
     /* Get protected key from key object */
     if (template_attribute_get_non_empty(privkey->template, CKA_IBM_OPAQUE_PKEY,
@@ -1143,7 +1147,8 @@ done:
  * Note: The original input message is passed to CPACF without being
  * pre-hashed. Hashing is done internally in CPACF.
  */
-CK_RV pkey_ibm_ed_sign(OBJECT *privkey, CK_BYTE *msg, CK_ULONG msg_len,
+CK_RV pkey_ibm_ed_sign(STDLL_TokData_t *tokdata, SESSION *session,
+                       OBJECT *privkey, CK_BYTE *msg, CK_ULONG msg_len,
                        CK_BYTE *sig, CK_ULONG *sig_len)
 {
 #define DEF_EDPARAM(curve, size)      \
@@ -1169,6 +1174,9 @@ CK_RV pkey_ibm_ed_sign(OBJECT *privkey, CK_BYTE *msg, CK_ULONG msg_len,
     CK_ATTRIBUTE *pkey_attr = NULL;
     int rc;
     cpacf_curve_type_t curve_type;
+
+    UNUSED(tokdata);
+    UNUSED(session);
 
     /* Get protected key from key object */
     if (template_attribute_get_non_empty(privkey->template, CKA_IBM_OPAQUE_PKEY,

--- a/usr/lib/common/pkey_utils.c
+++ b/usr/lib/common/pkey_utils.c
@@ -113,7 +113,7 @@ int get_msa_level(void)
  *
  * Executes the KM (CIPHER MESSAGE) operation of the CPU.
  *
- * Returns -1 for failure, 0 for the query func, number of processed
+ * Returns 0 for the query func, number of processed
  * bytes for encryption/decryption funcs
  */
 static int s390_km(unsigned long func, void *param, unsigned char *dest,
@@ -145,7 +145,7 @@ static int s390_km(unsigned long func, void *param, unsigned char *dest,
  *
  * Executes the KMC (CIPHER MESSAGE WITH CHAINING) operation of the CPU.
  *
- * Returns -1 for failure, 0 for the query func, number of processed
+ * Returns 0 for the query func, number of processed
  * bytes for encryption/decryption funcs
  */
 static int s390_kmc(unsigned long func, void *param, unsigned char *dest,
@@ -212,7 +212,7 @@ static int s390_kdsa(unsigned long func, void *param,
  *
  * Executes the KMAC (COMPUTE MESSAGE AUTHENTICATION CODE) operation of the CPU.
  *
- * Returns -1 for failure, 0 for the query func, number of processed
+ * Returns 0 for the query func, number of processed
  * bytes for encryption/decryption funcs
  */
 static int s390_kmac(unsigned long func, void *param,

--- a/usr/lib/common/pkey_utils.c
+++ b/usr/lib/common/pkey_utils.c
@@ -838,13 +838,13 @@ static CK_RV pkey_aes_xts_cipher_blocks(CK_BYTE *in, CK_BYTE *out, CK_ULONG len,
                                         CK_BYTE *iv, void *cb_data)
 {
     struct aes_xts_param *param = cb_data;
-    int rc;
+    int bytes_processed;
 
     int offset = AES_XTS_KM_XTSPARAM(param->keylen * 8);
     memcpy(param->param_km + offset, iv, AES_BLOCK_SIZE);
 
-    rc = s390_km(param->fc, param->param_km, out, in, len);
-    if (rc < 0) {
+    bytes_processed = s390_km(param->fc, param->param_km, out, in, len);
+    if (bytes_processed < len) {
         TRACE_ERROR("s390_km function failed\n");
         return CKR_FUNCTION_FAILED;
     }

--- a/usr/lib/common/pkey_utils.c
+++ b/usr/lib/common/pkey_utils.c
@@ -489,7 +489,8 @@ unsigned long get_function_code(CK_ULONG clear_keylen, CK_BYTE encrypt)
  * via the KM-encrypted-AES instruction. The protected key must be
  * available in the key template as CKA_IBM_OPAQUE_PKEY.
  */
-CK_RV pkey_aes_ecb(OBJECT *key_obj, CK_BYTE *in_data,
+CK_RV pkey_aes_ecb(STDLL_TokData_t *tokdata, SESSION *session,
+                   OBJECT *key_obj, CK_BYTE *in_data,
                    CK_ULONG in_data_len, CK_BYTE *out_data,
                    CK_ULONG_PTR p_output_data_len, CK_BYTE encrypt)
 {
@@ -501,6 +502,9 @@ CK_RV pkey_aes_ecb(OBJECT *key_obj, CK_BYTE *in_data,
         uint8_t key[MAXPROTKEYSIZE];
     } param;
     int bytes_processed = 0;
+
+    UNUSED(tokdata);
+    UNUSED(session);
 
     /* Check parms */
     if (in_data_len == 0) {
@@ -560,7 +564,8 @@ done:
 /**
  * Performs an AES-CBC operation via CPACF using a protected key.
  */
-CK_RV pkey_aes_cbc(OBJECT *key_obj, CK_BYTE *iv,
+CK_RV pkey_aes_cbc(STDLL_TokData_t *tokdata, SESSION *session,
+                   OBJECT *key_obj, CK_BYTE *iv,
                    CK_BYTE *in_data, CK_ULONG in_data_len, CK_BYTE *out_data,
                    CK_ULONG_PTR p_output_data_len, CK_BYTE encrypt)
 {
@@ -573,6 +578,9 @@ CK_RV pkey_aes_cbc(OBJECT *key_obj, CK_BYTE *iv,
         uint8_t key[MAXPROTKEYSIZE];
     } param;
     int bytes_processed = 0;
+
+    UNUSED(tokdata);
+    UNUSED(session);
 
     /* Check parms */
     if (in_data_len == 0) {
@@ -857,7 +865,8 @@ static CK_RV pkey_aes_xts_cipher_blocks(CK_BYTE *in, CK_BYTE *out, CK_ULONG len,
 /**
  * Performs an AES-XTS operation via CPACF using a protected key.
  */
-CK_RV pkey_aes_xts(OBJECT *key_obj, CK_BYTE *tweak,
+CK_RV pkey_aes_xts(STDLL_TokData_t *tokdata, SESSION *session,
+                   OBJECT *key_obj, CK_BYTE *tweak,
                    CK_BYTE *in_data, CK_ULONG in_data_len, CK_BYTE *out_data,
                    CK_ULONG_PTR p_output_data_len, CK_BYTE encrypt,
                    CK_BBOOL initial, CK_BBOOL final, CK_BYTE *iv)
@@ -867,6 +876,9 @@ CK_RV pkey_aes_xts(OBJECT *key_obj, CK_BYTE *tweak,
     struct aes_xts_param param = {0};
     CK_ULONG keylen = 0;
     unsigned long fc;
+
+    UNUSED(tokdata);
+    UNUSED(session);
 
     /* Check parms */
     if (in_data_len == 0) {

--- a/usr/lib/common/pkey_utils.h
+++ b/usr/lib/common/pkey_utils.h
@@ -102,7 +102,8 @@ CK_RV pkey_aes_cbc(OBJECT *key, CK_BYTE *iv,
                    CK_BYTE *out_data, CK_ULONG_PTR p_output_data_len,
                    CK_BYTE encrypt);
 
-CK_RV pkey_aes_cmac(OBJECT *key_obj, CK_BYTE *message,
+CK_RV pkey_aes_cmac(STDLL_TokData_t *tokdata, SESSION *session,
+                    OBJECT *key_obj, CK_BYTE *message,
                     CK_ULONG message_len, CK_BYTE *cmac, CK_BYTE *iv);
 
 CK_RV pkey_aes_xts(OBJECT *key_obj, CK_BYTE *tweak,

--- a/usr/lib/common/pkey_utils.h
+++ b/usr/lib/common/pkey_utils.h
@@ -93,11 +93,13 @@ CK_BBOOL pkey_op_supported_by_cpacf(int msa_level, CK_MECHANISM_TYPE type,
 
 CK_BBOOL pkey_op_ec_curve_supported_by_cpacf(TEMPLATE *tmpl);
 
-CK_RV pkey_aes_ecb(OBJECT *key, CK_BYTE * in_data,
+CK_RV pkey_aes_ecb(STDLL_TokData_t *tokdata, SESSION *session,
+                   OBJECT *key, CK_BYTE * in_data,
                    CK_ULONG in_data_len, CK_BYTE * out_data,
                    CK_ULONG_PTR p_output_data_len, CK_BYTE encrypt);
 
-CK_RV pkey_aes_cbc(OBJECT *key, CK_BYTE *iv,
+CK_RV pkey_aes_cbc(STDLL_TokData_t *tokdata, SESSION *session,
+                   OBJECT *key, CK_BYTE *iv,
                    CK_BYTE *in_data, CK_ULONG in_data_len,
                    CK_BYTE *out_data, CK_ULONG_PTR p_output_data_len,
                    CK_BYTE encrypt);
@@ -106,7 +108,8 @@ CK_RV pkey_aes_cmac(STDLL_TokData_t *tokdata, SESSION *session,
                     OBJECT *key_obj, CK_BYTE *message,
                     CK_ULONG message_len, CK_BYTE *cmac, CK_BYTE *iv);
 
-CK_RV pkey_aes_xts(OBJECT *key_obj, CK_BYTE *tweak,
+CK_RV pkey_aes_xts(STDLL_TokData_t *tokdata, SESSION *session,
+                   OBJECT *key_obj, CK_BYTE *tweak,
                    CK_BYTE *in_data, CK_ULONG in_data_len, CK_BYTE *out_data,
                    CK_ULONG_PTR p_output_data_len, CK_BYTE encrypt, CK_BBOOL initial,
                    CK_BBOOL final, CK_BYTE *iv);

--- a/usr/lib/common/pkey_utils.h
+++ b/usr/lib/common/pkey_utils.h
@@ -81,6 +81,11 @@ typedef enum {
     curve_ed448,
 } cpacf_curve_type_t;
 
+#define PKEY_CONVERT_KEY_RETRIES    100
+typedef CK_RV (*convert_key_t) (STDLL_TokData_t *tokdata, SESSION *session,
+                                OBJECT *key_obj, CK_BBOOL xts_mode,
+                                CK_BYTE *protkey, CK_ULONG *protkey_len);
+
 int get_msa_level(void);
 
 CK_BBOOL pkey_is_ec_public_key(TEMPLATE *tmpl);
@@ -93,20 +98,20 @@ CK_BBOOL pkey_op_supported_by_cpacf(int msa_level, CK_MECHANISM_TYPE type,
 
 CK_BBOOL pkey_op_ec_curve_supported_by_cpacf(TEMPLATE *tmpl);
 
-CK_RV pkey_aes_ecb(STDLL_TokData_t *tokdata, SESSION *session,
-                   OBJECT *key, CK_BYTE * in_data,
-                   CK_ULONG in_data_len, CK_BYTE * out_data,
-                   CK_ULONG_PTR p_output_data_len, CK_BYTE encrypt);
-
-CK_RV pkey_aes_cbc(STDLL_TokData_t *tokdata, SESSION *session,
-                   OBJECT *key, CK_BYTE *iv,
+CK_RV pkey_aes_ecb(STDLL_TokData_t *tokdata, SESSION *session, OBJECT *key_obj,
                    CK_BYTE *in_data, CK_ULONG in_data_len,
                    CK_BYTE *out_data, CK_ULONG_PTR p_output_data_len,
-                   CK_BYTE encrypt);
+                   CK_BYTE encrypt, convert_key_t convert_key);
+
+CK_RV pkey_aes_cbc(STDLL_TokData_t *tokdata, SESSION *session, OBJECT *key_obj,
+                   CK_BYTE *iv, CK_BYTE *in_data, CK_ULONG in_data_len,
+                   CK_BYTE *out_data, CK_ULONG_PTR p_output_data_len,
+                   CK_BYTE encrypt, convert_key_t convert_key);
 
 CK_RV pkey_aes_cmac(STDLL_TokData_t *tokdata, SESSION *session,
                     OBJECT *key_obj, CK_BYTE *message,
-                    CK_ULONG message_len, CK_BYTE *cmac, CK_BYTE *iv);
+                    CK_ULONG message_len, CK_BYTE *cmac, CK_BYTE *iv,
+                    convert_key_t convert_key);
 
 CK_RV pkey_aes_xts(STDLL_TokData_t *tokdata, SESSION *session,
                    OBJECT *key_obj, CK_BYTE *tweak,

--- a/usr/lib/common/pkey_utils.h
+++ b/usr/lib/common/pkey_utils.h
@@ -120,13 +120,15 @@ CK_RV pkey_aes_xts(STDLL_TokData_t *tokdata, SESSION *session,
                    CK_BBOOL final, CK_BYTE *iv);
 
 CK_RV pkey_ec_sign(STDLL_TokData_t *tokdata, SESSION *session,
-                   OBJECT *privkey, CK_BYTE *hash, CK_ULONG hashlen,
+                   OBJECT *privkey, CK_BYTE *hash, CK_ULONG hash_len,
                    CK_BYTE *sig, CK_ULONG *sig_len,
-                   void (*rng_cb)(unsigned char *, size_t));
+                   void (*rng_cb)(unsigned char *, size_t),
+                   convert_key_t convert_key);
 
 CK_RV pkey_ibm_ed_sign(STDLL_TokData_t *tokdata, SESSION *session,
                        OBJECT *privkey, CK_BYTE *msg, CK_ULONG msg_len,
-                       CK_BYTE *sig, CK_ULONG *sig_len);
+                       CK_BYTE *sig, CK_ULONG *sig_len,
+                       convert_key_t convert_key);
 
 CK_RV pkey_ec_verify(OBJECT *pubkey, CK_BYTE *hash, CK_ULONG hashlen,
                      CK_BYTE *sig, CK_ULONG sig_len);

--- a/usr/lib/common/pkey_utils.h
+++ b/usr/lib/common/pkey_utils.h
@@ -111,11 +111,13 @@ CK_RV pkey_aes_xts(OBJECT *key_obj, CK_BYTE *tweak,
                    CK_ULONG_PTR p_output_data_len, CK_BYTE encrypt, CK_BBOOL initial,
                    CK_BBOOL final, CK_BYTE *iv);
 
-CK_RV pkey_ec_sign(OBJECT *privkey, CK_BYTE *hash, CK_ULONG hashlen,
+CK_RV pkey_ec_sign(STDLL_TokData_t *tokdata, SESSION *session,
+                   OBJECT *privkey, CK_BYTE *hash, CK_ULONG hashlen,
                    CK_BYTE *sig, CK_ULONG *sig_len,
                    void (*rng_cb)(unsigned char *, size_t));
 
-CK_RV pkey_ibm_ed_sign(OBJECT *privkey, CK_BYTE *msg, CK_ULONG msg_len,
+CK_RV pkey_ibm_ed_sign(STDLL_TokData_t *tokdata, SESSION *session,
+                       OBJECT *privkey, CK_BYTE *msg, CK_ULONG msg_len,
                        CK_BYTE *sig, CK_ULONG *sig_len);
 
 CK_RV pkey_ec_verify(OBJECT *pubkey, CK_BYTE *hash, CK_ULONG hashlen,

--- a/usr/lib/common/pkey_utils.h
+++ b/usr/lib/common/pkey_utils.h
@@ -117,7 +117,8 @@ CK_RV pkey_aes_xts(STDLL_TokData_t *tokdata, SESSION *session,
                    OBJECT *key_obj, CK_BYTE *tweak,
                    CK_BYTE *in_data, CK_ULONG in_data_len, CK_BYTE *out_data,
                    CK_ULONG_PTR p_output_data_len, CK_BYTE encrypt, CK_BBOOL initial,
-                   CK_BBOOL final, CK_BYTE *iv);
+                   CK_BBOOL final, CK_BYTE *iv,
+                   convert_key_t convert_key);
 
 CK_RV pkey_ec_sign(STDLL_TokData_t *tokdata, SESSION *session,
                    OBJECT *privkey, CK_BYTE *hash, CK_ULONG hash_len,

--- a/usr/lib/common/tok_spec_struct.h
+++ b/usr/lib/common/tok_spec_struct.h
@@ -250,7 +250,7 @@ struct token_specific_struct {
     CK_RV(*t_aes_mac) (STDLL_TokData_t *, CK_BYTE *, CK_ULONG, OBJECT *,
                        CK_BYTE *);
 
-    CK_RV(*t_aes_cmac) (STDLL_TokData_t *, CK_BYTE *, CK_ULONG, OBJECT *,
+    CK_RV(*t_aes_cmac) (STDLL_TokData_t *, SESSION *, CK_BYTE *, CK_ULONG, OBJECT *,
                         CK_BYTE *, CK_BBOOL, CK_BBOOL, CK_VOID_PTR *);
 
     CK_RV(*t_aes_xts) (STDLL_TokData_t *tokdata, SESSION *, CK_BYTE *, CK_ULONG,

--- a/usr/lib/common/tok_specific.h
+++ b/usr/lib/common/tok_specific.h
@@ -287,7 +287,7 @@ CK_RV token_specific_aes_cfb(STDLL_TokData_t *,
 CK_RV token_specific_aes_mac(STDLL_TokData_t *,
                              CK_BYTE *, CK_ULONG, OBJECT *, CK_BYTE *);
 
-CK_RV token_specific_aes_cmac(STDLL_TokData_t *,
+CK_RV token_specific_aes_cmac(STDLL_TokData_t *, SESSION *,
                               CK_BYTE *, CK_ULONG, OBJECT *, CK_BYTE *,
                               CK_BBOOL, CK_BBOOL, CK_VOID_PTR *);
 

--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -6064,10 +6064,7 @@ CK_RV token_specific_aes_ecb(STDLL_TokData_t *tokdata,
                              CK_BYTE *out_data, CK_ULONG *out_data_len,
                              OBJECT *key_obj, CK_BYTE encrypt)
 {
-    UNUSED(tokdata);
-    UNUSED(sess);
-
-    return pkey_aes_ecb(key_obj, in_data, in_data_len,
+    return pkey_aes_ecb(tokdata, sess, key_obj, in_data, in_data_len,
                         out_data, out_data_len, encrypt);
 }
 
@@ -6083,10 +6080,7 @@ CK_RV token_specific_aes_cbc(STDLL_TokData_t *tokdata,
                              OBJECT *key_obj, CK_BYTE *init_v,
                              CK_BYTE encrypt)
 {
-    UNUSED(tokdata);
-    UNUSED(sess);
-
-    return pkey_aes_cbc(key_obj, init_v, in_data, in_data_len,
+    return pkey_aes_cbc(tokdata, sess, key_obj, init_v, in_data, in_data_len,
                         out_data, out_data_len, encrypt);
 }
 
@@ -6127,11 +6121,9 @@ CK_RV token_specific_aes_xts(STDLL_TokData_t *tokdata, SESSION *session,
                              CK_BBOOL encrypt, CK_BBOOL initial,
                              CK_BBOOL final, CK_BYTE *iv)
 {
-    UNUSED(tokdata);
-    UNUSED(session);
-
-    return pkey_aes_xts(key_obj, init_v, in_data, in_data_len,
-                        out_data, out_data_len, encrypt, initial, final, iv);
+    return pkey_aes_xts(tokdata, session, key_obj, init_v,
+                        in_data, in_data_len, out_data, out_data_len,
+                        encrypt, initial, final, iv);
 }
 #endif /* NO_PKEY */
 

--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -15474,6 +15474,7 @@ static CK_RV update_ep11_attrs_from_blob(STDLL_TokData_t *tokdata,
     CK_RV rc = CKR_OK;
     CK_ULONG i;
     CK_BYTE *useblob, *blob;
+    CK_OBJECT_CLASS class;
     size_t usebloblen;
 
     CK_ATTRIBUTE ibm_attrs[] = {
@@ -15490,7 +15491,13 @@ static CK_RV update_ep11_attrs_from_blob(STDLL_TokData_t *tokdata,
     };
     CK_ULONG num_ibm_attrs = sizeof(ibm_attrs) / sizeof(CK_ATTRIBUTE);
 
-    if (!ep11_data->pkey_wrap_supported)
+    if (template_attribute_get_ulong(key_obj->template, CKA_CLASS,
+                                     &class) != CKR_OK) {
+        TRACE_ERROR("This key has no CKA_CLASS: should not occur!\n");
+        return CKR_FUNCTION_FAILED;
+    }
+
+    if (!ep11_data->pkey_wrap_supported || class == CKO_PUBLIC_KEY)
         num_ibm_attrs -= 2;
 
     if (template_attribute_get_non_empty(key_obj->template, CKA_IBM_OPAQUE,

--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -6257,7 +6257,8 @@ CK_RV token_specific_aes_ecb(STDLL_TokData_t *tokdata,
                              OBJECT *key_obj, CK_BYTE encrypt)
 {
     return pkey_aes_ecb(tokdata, sess, key_obj, in_data, in_data_len,
-                        out_data, out_data_len, encrypt);
+                        out_data, out_data_len, encrypt,
+                        ep11tok_pkey_convert_key);
 }
 
 /**
@@ -6273,7 +6274,8 @@ CK_RV token_specific_aes_cbc(STDLL_TokData_t *tokdata,
                              CK_BYTE encrypt)
 {
     return pkey_aes_cbc(tokdata, sess, key_obj, init_v, in_data, in_data_len,
-                        out_data, out_data_len, encrypt);
+                        out_data, out_data_len, encrypt,
+                        ep11tok_pkey_convert_key);
 }
 
 /**
@@ -6292,11 +6294,14 @@ CK_RV token_specific_aes_cmac(STDLL_TokData_t *tokdata, SESSION *session,
     UNUSED(context);
 
     if (first && last)
-        rc = pkey_aes_cmac(tokdata, session, key_obj, message, message_len, iv, NULL);
+        rc = pkey_aes_cmac(tokdata, session, key_obj, message, message_len,
+                           iv, NULL, ep11tok_pkey_convert_key);
     else if (!last)
-        rc = pkey_aes_cmac(tokdata, session, key_obj, message, message_len, NULL, iv);
+        rc = pkey_aes_cmac(tokdata, session, key_obj, message, message_len,
+                           NULL, iv, ep11tok_pkey_convert_key);
     else // last
-        rc = pkey_aes_cmac(tokdata, session, key_obj, message, message_len, iv, iv);
+        rc = pkey_aes_cmac(tokdata, session, key_obj, message, message_len,
+                           iv, iv, ep11tok_pkey_convert_key);
 
     return rc;
 }

--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -6084,7 +6084,8 @@ CK_RV token_specific_ec_sign(STDLL_TokData_t *tokdata, SESSION  *session,
     switch (rc) {
     case CKR_OK:
         rc = pkey_ec_sign(tokdata, session, key_obj, in_data, in_data_len,
-                          out_data, out_data_len, NULL);
+                          out_data, out_data_len, NULL,
+                          ep11tok_pkey_convert_key);
         goto done;
     case CKR_FUNCTION_NOT_SUPPORTED:
         break;
@@ -9632,8 +9633,9 @@ CK_RV ep11tok_sign(STDLL_TokData_t * tokdata, SESSION * session,
          * supported by the ep11token, so let's keep them local here. */
         if (ctx->mech.mechanism == CKM_IBM_ED25519_SHA512 ||
             ctx->mech.mechanism == CKM_IBM_ED448_SHA3) {
-            rc = pkey_ibm_ed_sign(tokdata, session, key_obj,
-                                  in_data, in_data_len, signature, sig_len);
+            rc = pkey_ibm_ed_sign(tokdata, session, key_obj, in_data,
+                                  in_data_len, signature, sig_len,
+                                  ep11tok_pkey_convert_key);
         } else {
             /* Release obj lock, sign_mgr_sign may re-acquire the lock */
             object_put(tokdata, key_obj, TRUE);

--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -6321,7 +6321,8 @@ CK_RV token_specific_aes_xts(STDLL_TokData_t *tokdata, SESSION *session,
 {
     return pkey_aes_xts(tokdata, session, key_obj, init_v,
                         in_data, in_data_len, out_data, out_data_len,
-                        encrypt, initial, final, iv);
+                        encrypt, initial, final, iv,
+                        ep11tok_pkey_convert_key);
 }
 #endif /* NO_PKEY */
 

--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -6095,7 +6095,7 @@ CK_RV token_specific_aes_cbc(STDLL_TokData_t *tokdata,
  * a protected key. Therefore we don't have (and don't need) an ep11
  * fallback here.
  */
-CK_RV token_specific_aes_cmac(STDLL_TokData_t *tokdata,
+CK_RV token_specific_aes_cmac(STDLL_TokData_t *tokdata, SESSION *session,
                               CK_BYTE *message, CK_ULONG message_len,
                               OBJECT *key_obj, CK_BYTE *iv,
                               CK_BBOOL first, CK_BBOOL last,
@@ -6103,15 +6103,14 @@ CK_RV token_specific_aes_cmac(STDLL_TokData_t *tokdata,
 {
     CK_RV rc;
 
-    UNUSED(tokdata);
     UNUSED(context);
 
     if (first && last)
-        rc = pkey_aes_cmac(key_obj, message, message_len, iv, NULL);
+        rc = pkey_aes_cmac(tokdata, session, key_obj, message, message_len, iv, NULL);
     else if (!last)
-        rc = pkey_aes_cmac(key_obj, message, message_len, NULL, iv);
+        rc = pkey_aes_cmac(tokdata, session, key_obj, message, message_len, NULL, iv);
     else // last
-        rc = pkey_aes_cmac(key_obj, message, message_len, iv, iv);
+        rc = pkey_aes_cmac(tokdata, session, key_obj, message, message_len, iv, iv);
 
     return rc;
 }

--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -5891,7 +5891,7 @@ CK_RV token_specific_ec_sign(STDLL_TokData_t *tokdata, SESSION  *session,
     rc = ep11tok_pkey_check(tokdata, session, key_obj, &ctx->mech);
     switch (rc) {
     case CKR_OK:
-        rc = pkey_ec_sign(key_obj, in_data, in_data_len,
+        rc = pkey_ec_sign(tokdata, session, key_obj, in_data, in_data_len,
                           out_data, out_data_len, NULL);
         goto done;
     case CKR_FUNCTION_NOT_SUPPORTED:
@@ -9443,7 +9443,8 @@ CK_RV ep11tok_sign(STDLL_TokData_t * tokdata, SESSION * session,
          * supported by the ep11token, so let's keep them local here. */
         if (ctx->mech.mechanism == CKM_IBM_ED25519_SHA512 ||
             ctx->mech.mechanism == CKM_IBM_ED448_SHA3) {
-            rc = pkey_ibm_ed_sign(key_obj, in_data, in_data_len, signature, sig_len);
+            rc = pkey_ibm_ed_sign(tokdata, session, key_obj,
+                                  in_data, in_data_len, signature, sig_len);
         } else {
             /* Release obj lock, sign_mgr_sign may re-acquire the lock */
             object_put(tokdata, key_obj, TRUE);

--- a/usr/lib/ica_s390_stdll/ica_specific.c
+++ b/usr/lib/ica_s390_stdll/ica_specific.c
@@ -4441,13 +4441,15 @@ CK_RV token_specific_aes_mac(STDLL_TokData_t *tokdata, CK_BYTE *message,
     return rc;
 }
 
-CK_RV token_specific_aes_cmac(STDLL_TokData_t *tokdata, CK_BYTE *message,
+CK_RV token_specific_aes_cmac(STDLL_TokData_t *tokdata, SESSION *session, CK_BYTE *message,
                               CK_ULONG message_len, OBJECT *key, CK_BYTE *mac,
                               CK_BBOOL first, CK_BBOOL last, CK_VOID_PTR *ctx)
 {
     ica_private_data_t *ica_data = (ica_private_data_t *)tokdata->private_data;
     CK_RV rc;
     CK_ATTRIBUTE *attr = NULL;
+
+    UNUSED(session);
 
     if (!ica_data->ica_aes_available)
         return openssl_specific_aes_cmac(tokdata, message, message_len,

--- a/usr/lib/soft_stdll/soft_specific.c
+++ b/usr/lib/soft_stdll/soft_specific.c
@@ -777,10 +777,12 @@ CK_RV token_specific_aes_mac(STDLL_TokData_t *tokdata, CK_BYTE *message,
     return openssl_specific_aes_mac(tokdata, message, message_len, key, mac);
 }
 
-CK_RV token_specific_aes_cmac(STDLL_TokData_t *tokdata, CK_BYTE *message,
+CK_RV token_specific_aes_cmac(STDLL_TokData_t *tokdata, SESSION *session, CK_BYTE *message,
                               CK_ULONG message_len, OBJECT *key, CK_BYTE *mac,
                               CK_BBOOL first, CK_BBOOL last, CK_VOID_PTR *ctx)
 {
+
+    UNUSED(session);
 
     return openssl_specific_aes_cmac(tokdata, message, message_len, key, mac,
                                      first, last, ctx);


### PR DESCRIPTION
This pr adds support for  live guest relocations (LGR) for protected key operations to the CCA and EP11 tokens.