### PR TITLE
Add support for CKA_ALWAYS_AUTHENTICATE

### DIFF
--- a/man/man1/p11sak.1.in
+++ b/man/man1/p11sak.1.in
@@ -2236,6 +2236,10 @@ The following letters are associated with the respective
 .B I
 \- CKA_WRAP_WITH_TRUSTED
 .IP "\(bu" 2
+.B H
+\- CKA_ALWAYS_AUTHENTICATE (for keys of class CKO_PRIVATE_KEY only, can only be
+set to TRUE if CKA_PRIVATE is also TRUE)
+.IP "\(bu" 2
 .B K
 \- CKA_IBM_PROTKEY_EXTRACTABLE (IBM specific, not all tokens support this)
 .IP "\(bu" 2

--- a/testcases/misc_tests/always_auth.c
+++ b/testcases/misc_tests/always_auth.c
@@ -1,0 +1,442 @@
+/*
+ * COPYRIGHT (c) International Business Machines Corp. 2024
+ *
+ * This program is provided under the terms of the Common Public License,
+ * version 1.0 (CPL-1.0). Any use, reproduction or distribution for this
+ * software constitutes recipient's acceptance of CPL-1.0 terms which can be
+ * found in the file LICENSE file or at
+ * https://opensource.org/licenses/cpl1.0.php
+ */
+
+/* File: always_auth.c
+ *
+ * Test driver.  In-depth regression test for PKCS #11
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <memory.h>
+#include <unistd.h>
+
+#include "pkcs11types.h"
+#include "regress.h"
+#include "common.c"
+#include "mechtable.h"
+#include "mech_to_str.h"
+
+
+CK_MECHANISM rsakeygen_mech = { CKM_RSA_PKCS_KEY_PAIR_GEN, NULL, 0 };
+CK_MECHANISM signver_mech = { CKM_SHA256_RSA_PKCS, NULL, 0 };
+CK_MECHANISM endecrypt_mech = { CKM_RSA_PKCS, NULL, 0 };
+
+CK_RV do_auth_sign(void)
+{
+    CK_SESSION_HANDLE session;
+    CK_BYTE user_pin[PKCS11_MAX_PIN_LEN];
+    CK_ULONG user_pin_len;
+    CK_RV rc = CKR_OK, loc_rc;
+    CK_FLAGS flags;
+    CK_OBJECT_HANDLE rsa_pub_key = CK_INVALID_HANDLE;
+    CK_OBJECT_HANDLE rsa_priv_key = CK_INVALID_HANDLE;
+    CK_BYTE subject[] = {0};
+    CK_BYTE id[] = { 123 };
+    CK_BBOOL true = TRUE;
+    CK_ULONG modulusBits = 2048;
+    CK_BYTE publicExponent[] = { 0x01, 0x00, 0x01 };
+    CK_BYTE data[20] = { 0x00 };
+    CK_BYTE signature[256] = { 0x00 };
+    CK_ULONG signature_len  = sizeof(signature);
+
+    CK_ATTRIBUTE publicKeyTemplate[] = {
+        {CKA_ENCRYPT, &true, sizeof(true)},
+        {CKA_VERIFY, &true, sizeof(true)},
+        {CKA_WRAP, &true, sizeof(true)},
+        {CKA_MODULUS_BITS, &modulusBits, sizeof(modulusBits)},
+        {CKA_PUBLIC_EXPONENT, publicExponent, sizeof(publicExponent)}
+    };
+    CK_ULONG publicKeyTemplate_len =
+                    sizeof(publicKeyTemplate) / sizeof(CK_ATTRIBUTE);
+    CK_ATTRIBUTE privateKeyTemplate[] = {
+        {CKA_TOKEN, &true, sizeof(true)},
+        {CKA_PRIVATE, &true, sizeof(true)},
+        {CKA_SUBJECT, subject, 0},
+        {CKA_ID, id, sizeof(id)},
+        {CKA_SENSITIVE, &true, sizeof(true)},
+        {CKA_DECRYPT, &true, sizeof(true)},
+        {CKA_SIGN, &true, sizeof(true)},
+        {CKA_UNWRAP, &true, sizeof(true)},
+        {CKA_ALWAYS_AUTHENTICATE, &true, sizeof(true)},
+    };
+    CK_ULONG privateKeyTemplate_len =
+                    sizeof(privateKeyTemplate) / sizeof(CK_ATTRIBUTE);
+
+    testcase_begin("C_Sign with %s and CKA_ALWAYS_AUTHENTICATE=TRUE",
+                   mech_to_str(signver_mech.mechanism));
+
+    testcase_rw_session();
+    testcase_user_login();
+
+    if (!mech_supported(SLOT_ID, signver_mech.mechanism)) {
+        testcase_skip("Slot %u doesn't support %s (0x%x)",
+                      (unsigned int)SLOT_ID,
+                      mech_to_str(signver_mech.mechanism),
+                      (unsigned int)signver_mech.mechanism);
+        goto testcase_cleanup;
+    }
+    if (!mech_supported(SLOT_ID, rsakeygen_mech.mechanism)) {
+        testcase_skip("Slot %u doesn't support %s (0x%x)",
+                      (unsigned int)SLOT_ID,
+                      mech_to_str(rsakeygen_mech.mechanism),
+                      (unsigned int)rsakeygen_mech.mechanism);
+        goto testcase_cleanup;
+    }
+
+    testcase_new_assertion();
+
+    /* generate an RSA key */
+    rc = funcs->C_GenerateKeyPair(session,
+                                  &rsakeygen_mech,
+                                  publicKeyTemplate, publicKeyTemplate_len,
+                                  privateKeyTemplate, privateKeyTemplate_len,
+                                  &rsa_pub_key, &rsa_priv_key);
+    if (is_rejected_by_policy(rc, session)) {
+        testcase_skip("generate key with mech %s (%u) in slot %lu "
+                      "is not allowed by policy",
+                      mech_to_str(rsakeygen_mech.mechanism),
+                      (unsigned int)rsakeygen_mech.mechanism,
+                      SLOT_ID);
+        rc = CKR_OK;
+        goto testcase_cleanup;
+    }
+    if (rc != CKR_OK) {
+        testcase_error("generate key with mech %s (%u) in slot %lu failed, rc=%s",
+                       mech_to_str(rsakeygen_mech.mechanism),
+                       (unsigned int)rsakeygen_mech.mechanism,
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    /* Initialize operation */
+    rc = funcs->C_SignInit(session, &signver_mech, rsa_priv_key);
+    if (rc != CKR_OK) {
+        testcase_error("C_SignInit with mech %s (%u) in slot %lu failed, rc=%s",
+                       mech_to_str(signver_mech.mechanism),
+                       (unsigned int)signver_mech.mechanism,
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    /* Perform C_Sign without doing a C_Login first, expected to fail */
+    rc = funcs->C_Sign(session, data, sizeof(data), signature, &signature_len);
+    if (rc != CKR_USER_NOT_LOGGED_IN) {
+        testcase_fail("C_Sign without C_Login returned rc=%s, expected %s",
+                      p11_get_ckr(rc), p11_get_ckr(CKR_USER_NOT_LOGGED_IN));
+        goto testcase_cleanup;
+    }
+
+    /* Initialize the operation again, CKR_USER_NOT_LOGGED_IN terminated it */
+    rc = funcs->C_SignInit(session, &signver_mech, rsa_priv_key);
+    if (rc != CKR_OK) {
+        testcase_error("C_SignInit with mech %s (%u) in slot %lu failed, rc=%s",
+                       mech_to_str(signver_mech.mechanism),
+                       (unsigned int)signver_mech.mechanism,
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    /* Perform C_Login with CKU_CONTEXT_SPECIFIC and USER pin */
+    rc = funcs->C_Login(session, CKU_CONTEXT_SPECIFIC, user_pin, user_pin_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_Login with type CKU_CONTEXT_SPECIFIC failed, rc=%s",
+                       p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    /* Perform C_Sign after doing a C_Login */
+    rc = funcs->C_Sign(session, data, sizeof(data), signature, &signature_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_Sign after C_Login failed, rc=%s",
+                       p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    /* Perform C_Login after operation is complete, expected to fail */
+    rc = funcs->C_Login(session, CKU_CONTEXT_SPECIFIC, user_pin, user_pin_len);
+    if (rc != CKR_OPERATION_NOT_INITIALIZED) {
+        testcase_fail("C_Login after op is complete returned rc=%s, expected %s",
+                      p11_get_ckr(rc),
+                      p11_get_ckr(CKR_OPERATION_NOT_INITIALIZED));
+        goto testcase_cleanup;
+    }
+
+    testcase_pass("C_Sign with %s and CKA_ALWAYS_AUTHENTICATE=TRUE",
+                  mech_to_str(signver_mech.mechanism));
+
+testcase_cleanup:
+    if (rsa_pub_key != CK_INVALID_HANDLE) {
+        loc_rc = funcs->C_DestroyObject(session, rsa_pub_key);
+        if (loc_rc != CKR_OK)
+            testcase_error("C_DestroyObject(), rc=%s.", p11_get_ckr(loc_rc));
+    }
+    if (rsa_priv_key != CK_INVALID_HANDLE) {
+        loc_rc = funcs->C_DestroyObject(session, rsa_priv_key);
+        if (loc_rc != CKR_OK)
+            testcase_error("C_DestroyObject(), rc=%s.", p11_get_ckr(loc_rc));
+    }
+
+    testcase_user_logout();
+    rc = funcs->C_CloseAllSessions(SLOT_ID);
+    if (rc != CKR_OK) {
+        testcase_error("C_CloseAllSessions rc=%s", p11_get_ckr(rc));
+    }
+
+    return rc;
+}
+
+CK_RV do_auth_decrypt(void)
+{
+    CK_SESSION_HANDLE session;
+    CK_BYTE user_pin[PKCS11_MAX_PIN_LEN];
+    CK_ULONG user_pin_len;
+    CK_RV rc = CKR_OK, loc_rc;
+    CK_FLAGS flags;
+    CK_OBJECT_HANDLE rsa_pub_key = CK_INVALID_HANDLE;
+    CK_OBJECT_HANDLE rsa_priv_key = CK_INVALID_HANDLE;
+    CK_BYTE subject[] = {0};
+    CK_BYTE id[] = { 123 };
+    CK_BBOOL true = TRUE;
+    CK_ULONG modulusBits = 2048;
+    CK_BYTE publicExponent[] = { 0x01, 0x00, 0x01 };
+    CK_BYTE data[20] = { 0x00 };
+    CK_BYTE cipher[256] = { 0x00 };
+    CK_ULONG cipher_len = sizeof(cipher);
+    CK_BYTE clear[256] = { 0x00 };
+    CK_ULONG clear_len = sizeof(clear);
+
+    CK_ATTRIBUTE publicKeyTemplate[] = {
+        {CKA_ENCRYPT, &true, sizeof(true)},
+        {CKA_VERIFY, &true, sizeof(true)},
+        {CKA_WRAP, &true, sizeof(true)},
+        {CKA_MODULUS_BITS, &modulusBits, sizeof(modulusBits)},
+        {CKA_PUBLIC_EXPONENT, publicExponent, sizeof(publicExponent)}
+    };
+    CK_ULONG publicKeyTemplate_len =
+                    sizeof(publicKeyTemplate) / sizeof(CK_ATTRIBUTE);
+    CK_ATTRIBUTE privateKeyTemplate[] = {
+        {CKA_TOKEN, &true, sizeof(true)},
+        {CKA_PRIVATE, &true, sizeof(true)},
+        {CKA_SUBJECT, subject, 0},
+        {CKA_ID, id, sizeof(id)},
+        {CKA_SENSITIVE, &true, sizeof(true)},
+        {CKA_DECRYPT, &true, sizeof(true)},
+        {CKA_SIGN, &true, sizeof(true)},
+        {CKA_UNWRAP, &true, sizeof(true)},
+        {CKA_ALWAYS_AUTHENTICATE, &true, sizeof(true)},
+    };
+    CK_ULONG privateKeyTemplate_len =
+                    sizeof(privateKeyTemplate) / sizeof(CK_ATTRIBUTE);
+
+    testcase_begin("C_Decrypt with %s and CKA_ALWAYS_AUTHENTICATE=TRUE",
+                   mech_to_str(endecrypt_mech.mechanism));
+
+    testcase_rw_session();
+    testcase_user_login();
+
+    if (!mech_supported(SLOT_ID, endecrypt_mech.mechanism)) {
+        testcase_skip("Slot %u doesn't support %s (0x%x)",
+                      (unsigned int)SLOT_ID,
+                      mech_to_str(endecrypt_mech.mechanism),
+                      (unsigned int)endecrypt_mech.mechanism);
+        goto testcase_cleanup;
+    }
+    if (!mech_supported(SLOT_ID, rsakeygen_mech.mechanism)) {
+        testcase_skip("Slot %u doesn't support %s (0x%x)",
+                      (unsigned int)SLOT_ID,
+                      mech_to_str(rsakeygen_mech.mechanism),
+                      (unsigned int)rsakeygen_mech.mechanism);
+        goto testcase_cleanup;
+    }
+
+    testcase_new_assertion();
+
+    /* generate an RSA key */
+    rc = funcs->C_GenerateKeyPair(session,
+                                  &rsakeygen_mech,
+                                  publicKeyTemplate, publicKeyTemplate_len,
+                                  privateKeyTemplate, privateKeyTemplate_len,
+                                  &rsa_pub_key, &rsa_priv_key);
+    if (is_rejected_by_policy(rc, session)) {
+        testcase_skip("generate key with mech %s (%u) in slot %lu "
+                      "is not allowed by policy",
+                      mech_to_str(rsakeygen_mech.mechanism),
+                      (unsigned int)rsakeygen_mech.mechanism,
+                      SLOT_ID);
+        rc = CKR_OK;
+        goto testcase_cleanup;
+    }
+    if (rc != CKR_OK) {
+        testcase_error("generate key with mech %s (%u) in slot %lu failed, rc=%s",
+                       mech_to_str(rsakeygen_mech.mechanism),
+                       (unsigned int)rsakeygen_mech.mechanism,
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    /* Encrypt some data */
+    rc = funcs->C_EncryptInit(session, &endecrypt_mech, rsa_pub_key);
+    if (rc != CKR_OK) {
+        testcase_error("C_EncryptInit with mech %s (%u) in slot %lu failed, rc=%s",
+                       mech_to_str(endecrypt_mech.mechanism),
+                       (unsigned int)endecrypt_mech.mechanism,
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    rc = funcs->C_Encrypt(session, data, sizeof(data), cipher, &cipher_len);
+    if (rc != CKR_OK) {
+        testcase_fail("C_Encrypt failedrc=%s", p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    /* Initialize operation */
+    rc = funcs->C_DecryptInit(session, &endecrypt_mech, rsa_priv_key);
+    if (rc != CKR_OK) {
+        testcase_error("C_DecryptInit with mech %s (%u) in slot %lu failed, rc=%s",
+                       mech_to_str(endecrypt_mech.mechanism),
+                       (unsigned int)endecrypt_mech.mechanism,
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    /* Perform C_Decrypt without doing a C_Login first, expected to fail */
+    rc = funcs->C_Decrypt(session, cipher, cipher_len, clear, &clear_len);
+    if (rc != CKR_USER_NOT_LOGGED_IN) {
+        testcase_fail("C_Decrypt without C_Login returned rc=%s, expected %s",
+                      p11_get_ckr(rc), p11_get_ckr(CKR_USER_NOT_LOGGED_IN));
+        goto testcase_cleanup;
+    }
+
+    /* Initialize the operation again, CKR_USER_NOT_LOGGED_IN terminated it */
+    rc = funcs->C_DecryptInit(session, &endecrypt_mech, rsa_priv_key);
+    if (rc != CKR_OK) {
+        testcase_error("C_DecryptInit with mech %s (%u) in slot %lu failed, rc=%s",
+                       mech_to_str(endecrypt_mech.mechanism),
+                       (unsigned int)endecrypt_mech.mechanism,
+                       SLOT_ID, p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    /* Perform C_Login with CKU_CONTEXT_SPECIFIC and USER pin */
+    rc = funcs->C_Login(session, CKU_CONTEXT_SPECIFIC, user_pin, user_pin_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_Login with type CKU_CONTEXT_SPECIFIC failed, rc=%s",
+                       p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    /* Perform C_Decrypt after doing a C_Login */
+    rc = funcs->C_Decrypt(session, cipher, cipher_len, clear, &clear_len);
+    if (rc != CKR_OK) {
+        testcase_error("C_Decrypt after C_Login failed, rc=%s",
+                       p11_get_ckr(rc));
+        goto testcase_cleanup;
+    }
+
+    /* Perform C_Login after operation is complete, expected to fail */
+    rc = funcs->C_Login(session, CKU_CONTEXT_SPECIFIC, user_pin, user_pin_len);
+    if (rc != CKR_OPERATION_NOT_INITIALIZED) {
+        testcase_fail("C_Login after op is complete returned rc=%s, expected %s",
+                      p11_get_ckr(rc),
+                      p11_get_ckr(CKR_OPERATION_NOT_INITIALIZED));
+        goto testcase_cleanup;
+    }
+
+    testcase_pass("C_Decrypt with %s and CKA_ALWAYS_AUTHENTICATE=TRUE",
+                  mech_to_str(endecrypt_mech.mechanism));
+
+testcase_cleanup:
+    if (rsa_pub_key != CK_INVALID_HANDLE) {
+        loc_rc = funcs->C_DestroyObject(session, rsa_pub_key);
+        if (loc_rc != CKR_OK)
+            testcase_error("C_DestroyObject(), rc=%s.", p11_get_ckr(loc_rc));
+    }
+    if (rsa_priv_key != CK_INVALID_HANDLE) {
+        loc_rc = funcs->C_DestroyObject(session, rsa_priv_key);
+        if (loc_rc != CKR_OK)
+            testcase_error("C_DestroyObject(), rc=%s.", p11_get_ckr(loc_rc));
+    }
+
+    testcase_user_logout();
+    rc = funcs->C_CloseAllSessions(SLOT_ID);
+    if (rc != CKR_OK) {
+        testcase_error("C_CloseAllSessions rc=%s", p11_get_ckr(rc));
+    }
+
+    return rc;
+}
+
+CK_RV do_always_auth_tests(void)
+{
+    CK_RV rc = CKR_OK;
+
+    if (is_icsf_token(SLOT_ID)) {
+        testcase_skip("ICSF token does not support CKA_ALWAYS_AUTHENTICATE");
+        return rc;
+    }
+
+    rc |= do_auth_sign();
+
+    rc |= do_auth_decrypt();
+
+    return rc;
+}
+
+
+int main(int argc, char **argv)
+{
+    int rc;
+    CK_C_INITIALIZE_ARGS cinit_args;
+    CK_RV rv = 0;
+
+    rc = do_ParseArgs(argc, argv);
+    if (rc != 1)
+        return rc;
+
+    printf("Using slot #%lu...\n\n", SLOT_ID);
+
+    rc = do_GetFunctionList();
+    if (!rc) {
+        testcase_error("do_getFunctionList(), rc=%s", p11_get_ckr(rc));
+        return rc;
+    }
+
+    memset(&cinit_args, 0x0, sizeof(cinit_args));
+    cinit_args.flags = CKF_OS_LOCKING_OK;
+    funcs->C_Initialize(&cinit_args);
+
+    testcase_setup();
+
+    rv = do_always_auth_tests();
+    if (rv != CKR_OK)
+        goto finalize;
+
+    rv = funcs->C_Finalize(NULL);
+    if (rv != CKR_OK) {
+        testcase_fail("C_Finalize rc = %s", p11_get_ckr(rv));
+        goto out;
+    }
+
+    rv = 0;
+    goto out;
+
+finalize:
+    rv = funcs->C_Finalize(NULL);
+    if (rv != CKR_OK) {
+        testcase_fail("C_Finalize rc = %s", p11_get_ckr(rv));
+        rv = 1;
+    }
+out:
+    testcase_print_result();
+    return testcase_return(rv);
+}

--- a/testcases/misc_tests/misc_tests.mk
+++ b/testcases/misc_tests/misc_tests.mk
@@ -8,7 +8,8 @@ noinst_PROGRAMS +=							\
 	testcases/misc_tests/obj_lock testcases/misc_tests/tok2tok_transport \
 	testcases/misc_tests/obj_lock testcases/misc_tests/reencrypt    \
 	testcases/misc_tests/cca_export_import_test			\
-	testcases/misc_tests/events testcases/misc_tests/dual_functions
+	testcases/misc_tests/events testcases/misc_tests/dual_functions \
+	testcases/misc_tests/always_auth
 
 EXTRA_DIST += testcases/misc_tests/dh-key.pem				\
 	testcases/misc_tests/dsa-key.pem				\
@@ -116,3 +117,8 @@ testcases_misc_tests_dual_functions_CFLAGS = ${testcases_inc}
 testcases_misc_tests_dual_functions_LDADD = testcases/common/libcommon.la
 testcases_misc_tests_dual_functions_SOURCES = 				\
 	testcases/misc_tests/dual_functions.c
+	
+testcases_misc_tests_always_auth_CFLAGS = ${testcases_inc}
+testcases_misc_tests_always_auth_LDADD = testcases/common/libcommon.la
+testcases_misc_tests_always_auth_SOURCES = 				\
+	testcases/misc_tests/always_auth.c

--- a/testcases/ock_tests.sh.in
+++ b/testcases/ock_tests.sh.in
@@ -69,7 +69,7 @@ OCK_TESTS+=" pkcs11/get_interface pkcs11/getobjectsize pkcs11/sess_opstate"
 OCK_TESTS+=" misc_tests/fork misc_tests/obj_mgmt_tests" 
 OCK_TESTS+=" misc_tests/obj_mgmt_lock_tests misc_tests/reencrypt"
 OCK_TESTS+=" misc_tests/events misc_tests/cca_export_import_test"
-OCK_TESTS+=" misc_tests/dual_functions"
+OCK_TESTS+=" misc_tests/dual_functions misc_tests/always_auth"
 OCK_TEST=""
 OCK_BENCHS="pkcs11/*bench"
 

--- a/usr/include/pkcs11types.h
+++ b/usr/include/pkcs11types.h
@@ -314,6 +314,8 @@ typedef CK_ULONG CK_USER_TYPE;
 #define CKU_SO    0
 /* Normal user */
 #define CKU_USER  1
+/* Context specific */
+#define CKU_CONTEXT_SPECIFIC    2
 
 
 /* CK_STATE enumerates the session states */
@@ -563,8 +565,8 @@ typedef CK_ULONG CK_ATTRIBUTE_TYPE;
 #define CKA_EC_PARAMS          0x00000180
 #define CKA_EC_POINT           0x00000181
 /* The following are new for v2.11 */
-#define CKA_SECONDARY_AUTH     0x00000200
-#define CKA_AUTH_PIN_FLAGS     0x00000201
+#define CKA_SECONDARY_AUTH     0x00000200 /* Deprecated since 2.11 */
+#define CKA_AUTH_PIN_FLAGS     0x00000201 /* Deprecated since 2.11 */
 #define CKA_ALWAYS_AUTHENTICATE 0x00000202
 #define CKA_WRAP_WITH_TRUSTED  0x00000210
 #define CKA_HW_FEATURE_TYPE    0x00000300

--- a/usr/lib/common/decr_mgr.c
+++ b/usr/lib/common/decr_mgr.c
@@ -709,6 +709,10 @@ CK_RV decr_mgr_decrypt(STDLL_TokData_t *tokdata,
         TRACE_ERROR("%s\n", ock_err(ERR_OPERATION_NOT_INITIALIZED));
         return CKR_OPERATION_NOT_INITIALIZED;
     }
+    if (ctx->auth_required == TRUE) {
+        TRACE_ERROR("%s\n", ock_err(ERR_USER_NOT_LOGGED_IN));
+        return CKR_USER_NOT_LOGGED_IN;
+    }
     if (ctx->multi_init == FALSE) {
         ctx->multi = FALSE;
         ctx->multi_init = TRUE;
@@ -875,6 +879,10 @@ CK_RV decr_mgr_decrypt_update(STDLL_TokData_t *tokdata,
         TRACE_ERROR("%s\n", ock_err(ERR_OPERATION_NOT_INITIALIZED));
         return CKR_OPERATION_NOT_INITIALIZED;
     }
+    if (ctx->auth_required == TRUE) {
+        TRACE_ERROR("%s\n", ock_err(ERR_USER_NOT_LOGGED_IN));
+        return CKR_USER_NOT_LOGGED_IN;
+    }
     if (ctx->multi_init == FALSE) {
         ctx->multi = TRUE;
         ctx->multi_init = TRUE;
@@ -1023,6 +1031,10 @@ CK_RV decr_mgr_decrypt_final(STDLL_TokData_t *tokdata,
     if (ctx->active == FALSE) {
         TRACE_ERROR("%s\n", ock_err(ERR_OPERATION_NOT_INITIALIZED));
         return CKR_OPERATION_NOT_INITIALIZED;
+    }
+    if (ctx->auth_required == TRUE) {
+        TRACE_ERROR("%s\n", ock_err(ERR_USER_NOT_LOGGED_IN));
+        return CKR_USER_NOT_LOGGED_IN;
     }
     if (ctx->multi_init == FALSE) {
         ctx->multi = TRUE;

--- a/usr/lib/common/encr_mgr.c
+++ b/usr/lib/common/encr_mgr.c
@@ -1213,7 +1213,7 @@ CK_RV encr_mgr_reencrypt_single(STDLL_TokData_t *tokdata, SESSION *sess,
     /* No token specific reencrypt_single function, perform it manually */
     /* Enforces policy */
     rc = decr_mgr_init(tokdata, sess, decr_ctx, OP_DECRYPT_INIT, decr_mech,
-                       decr_key, TRUE);
+                       decr_key, TRUE, TRUE);
     if (rc != CKR_OK)
         goto done;
     /* Enforces Policy */

--- a/usr/lib/common/h_extern.h
+++ b/usr/lib/common/h_extern.h
@@ -1961,7 +1961,7 @@ CK_RV decr_mgr_init(STDLL_TokData_t *tokdata,
                     ENCR_DECR_CONTEXT *ctx,
                     CK_ULONG operation,
                     CK_MECHANISM *mech, CK_OBJECT_HANDLE key_handle,
-                    CK_BBOOL checkpolicy);
+                    CK_BBOOL checkpolicy, CK_BBOOL checkauth);
 
 CK_RV decr_mgr_cleanup(STDLL_TokData_t *tokdata, SESSION *sess,
                        ENCR_DECR_CONTEXT *ctx);
@@ -2103,7 +2103,7 @@ CK_RV sign_mgr_init(STDLL_TokData_t *tokdata,
                     SIGN_VERIFY_CONTEXT *ctx,
                     CK_MECHANISM *mech,
                     CK_BBOOL recover_mode, CK_OBJECT_HANDLE key_handle,
-                    CK_BBOOL checkpolicy);
+                    CK_BBOOL checkpolicy, CK_BBOOL checkauth);
 
 CK_RV sign_mgr_cleanup(STDLL_TokData_t *tokdata, SESSION *sess,
                        SIGN_VERIFY_CONTEXT *ctx);
@@ -2592,6 +2592,7 @@ CK_RV key_object_apply_template_attr(TEMPLATE *unwrap_tmpl,
                                      CK_ULONG attrs_count,
                                      CK_ATTRIBUTE_PTR *new_attrs,
                                      CK_ULONG *new_attrs_count);
+CK_RV key_object_is_always_authenticate(TEMPLATE *tmpl, CK_BBOOL *auth);
 
 CK_RV publ_key_check_required_attributes(TEMPLATE *tmpl, CK_ULONG mode);
 CK_RV publ_key_set_default_attributes(TEMPLATE *tmpl, CK_ULONG mode);

--- a/usr/lib/common/host_defs.h
+++ b/usr/lib/common/host_defs.h
@@ -47,6 +47,7 @@ typedef struct _ENCR_DECR_CONTEXT {
     CK_BBOOL pkey_active;
     CK_BBOOL state_unsaveable;
     CK_BBOOL count_statistics;
+    CK_BBOOL auth_required;
 } ENCR_DECR_CONTEXT;
 
 typedef struct _DIGEST_CONTEXT {
@@ -77,6 +78,7 @@ typedef struct _SIGN_VERIFY_CONTEXT {
     CK_BBOOL pkey_active;
     CK_BBOOL state_unsaveable;
     CK_BBOOL count_statistics;
+    CK_BBOOL auth_required;
 } SIGN_VERIFY_CONTEXT;
 
 

--- a/usr/lib/common/key_mgr.c
+++ b/usr/lib/common/key_mgr.c
@@ -1363,7 +1363,7 @@ CK_RV key_mgr_unwrap_key(STDLL_TokData_t *tokdata,
 
     /* Policy already checked */
     rc = decr_mgr_init(tokdata, sess, ctx, OP_UNWRAP, mech, h_unwrapping_key,
-                       FALSE);
+                       FALSE, FALSE);
     if (rc != CKR_OK)
         goto done;
 

--- a/usr/lib/common/mech_ec.c
+++ b/usr/lib/common/mech_ec.c
@@ -309,7 +309,7 @@ CK_RV ec_hash_sign(STDLL_TokData_t *tokdata,
     sign_mech.pParameter = NULL;
 
     rc = sign_mgr_init(tokdata, sess, &sign_ctx, &sign_mech, FALSE, ctx->key,
-                       FALSE);
+                       FALSE, FALSE);
     if (rc != CKR_OK) {
         TRACE_DEVEL("Sign Mgr Init failed.\n");
         goto error;
@@ -418,7 +418,7 @@ CK_RV ec_hash_sign_final(STDLL_TokData_t *tokdata,
     sign_mech.pParameter = NULL;
 
     rc = sign_mgr_init(tokdata, sess, &sign_ctx, &sign_mech, FALSE, ctx->key,
-                       FALSE);
+                       FALSE, FALSE);
     if (rc != CKR_OK) {
         TRACE_DEVEL("Sign Mgr Init failed.\n");
         goto done;

--- a/usr/lib/common/mech_rsa.c
+++ b/usr/lib/common/mech_rsa.c
@@ -1609,7 +1609,7 @@ CK_RV rsa_hash_pss_sign(STDLL_TokData_t *tokdata, SESSION *sess,
     sign_mech.pParameter = ctx->mech.pParameter;
 
     rc = sign_mgr_init(tokdata, sess, &sign_ctx, &sign_mech, FALSE, ctx->key,
-                       FALSE);
+                       FALSE, FALSE);
     if (rc != CKR_OK) {
         TRACE_DEVEL("Sign Mgr Init failed.\n");
         goto done;
@@ -1713,7 +1713,7 @@ CK_RV rsa_hash_pss_sign_final(STDLL_TokData_t *tokdata, SESSION *sess,
     sign_mech.pParameter = ctx->mech.pParameter;
 
     rc = sign_mgr_init(tokdata, sess, &sign_ctx, &sign_mech, FALSE, ctx->key,
-                       FALSE);
+                       FALSE, FALSE);
     if (rc != CKR_OK) {
         TRACE_DEVEL("Sign Mgr Init failed.\n");
         goto done;
@@ -2007,7 +2007,7 @@ CK_RV rsa_hash_pkcs_sign(STDLL_TokData_t *tokdata,
     sign_mech.pParameter = NULL;
 
     rc = sign_mgr_init(tokdata, sess, &sign_ctx, &sign_mech, FALSE, ctx->key,
-                       FALSE);
+                       FALSE, FALSE);
     if (rc != CKR_OK) {
         TRACE_DEVEL("Sign Mgr Init failed.\n");
         goto error;
@@ -2303,7 +2303,7 @@ CK_RV rsa_hash_pkcs_sign_final(STDLL_TokData_t *tokdata,
     sign_mech.pParameter = NULL;
 
     rc = sign_mgr_init(tokdata, sess, &sign_ctx, &sign_mech, FALSE, ctx->key,
-                       FALSE);
+                       FALSE, FALSE);
     if (rc != CKR_OK) {
         TRACE_DEVEL("Sign Mgr Init failed.\n");
         goto done;

--- a/usr/lib/common/mech_ssl3.c
+++ b/usr/lib/common/mech_ssl3.c
@@ -465,7 +465,7 @@ CK_RV ssl3_mac_verify(STDLL_TokData_t *tokdata,
     memset(&mac_ctx, 0, sizeof(SIGN_VERIFY_CONTEXT));
 
     rc = sign_mgr_init(tokdata, sess, &mac_ctx, &ctx->mech, FALSE, ctx->key,
-                       FALSE);
+                       FALSE, FALSE);
     if (rc != CKR_OK) {
         TRACE_DEVEL("Sign Init failed.\n");
         goto error;

--- a/usr/lib/common/new_host.c
+++ b/usr/lib/common/new_host.c
@@ -2322,7 +2322,7 @@ CK_RV SC_DecryptInit(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
 
     sess->decr_ctx.count_statistics = TRUE;
     rc = decr_mgr_init(tokdata, sess, &sess->decr_ctx, OP_DECRYPT_INIT,
-                       pMechanism, hKey, TRUE);
+                       pMechanism, hKey, TRUE, TRUE);
     if (rc != CKR_OK)
         TRACE_DEVEL("decr_mgr_init() failed.\n");
 
@@ -2816,7 +2816,7 @@ CK_RV SC_SignInit(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
 
     sess->sign_ctx.count_statistics = TRUE;
     rc = sign_mgr_init(tokdata, sess, &sess->sign_ctx, pMechanism, FALSE, hKey,
-                       TRUE);
+                       TRUE, TRUE);
     if (rc != CKR_OK)
         TRACE_DEVEL("sign_mgr_init() failed.\n");
 
@@ -3037,7 +3037,7 @@ CK_RV SC_SignRecoverInit(STDLL_TokData_t *tokdata,
     }
 
     rc = sign_mgr_init(tokdata, sess, &sess->sign_ctx, pMechanism, TRUE, hKey,
-                       TRUE);
+                       TRUE, TRUE);
     if (rc != CKR_OK)
         TRACE_DEVEL("sign_mgr_init() failed.\n");
 

--- a/usr/lib/common/new_host.c
+++ b/usr/lib/common/new_host.c
@@ -52,6 +52,7 @@
 #include "../api/policy.h"
 
 void SC_SetFunctionList(void);
+CK_RV SC_Logout(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession);
 CK_RV SC_Finalize(STDLL_TokData_t *tokdata, CK_SLOT_ID sid, SLOT_INFO *sinfp,
                   struct trace_handle_t *t, CK_BBOOL in_fork_initializer);
 
@@ -1285,7 +1286,8 @@ CK_RV SC_Login(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
     /* PKCS #11 v2.01 requires that all sessions have the same login status:
      * --> all sessions are public, all are SO or all are USER
      */
-    if (userType == CKU_USER) {
+    switch (userType) {
+    case CKU_USER:
         if (session_mgr_so_session_exists(tokdata)) {
             TRACE_ERROR("%s\n", ock_err(ERR_USER_ANOTHER_ALREADY_LOGGED_IN));
             rc = CKR_USER_ANOTHER_ALREADY_LOGGED_IN;
@@ -1294,7 +1296,9 @@ CK_RV SC_Login(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
             TRACE_ERROR("%s\n", ock_err(ERR_USER_ALREADY_LOGGED_IN));
             rc = CKR_USER_ALREADY_LOGGED_IN;
         }
-    } else if (userType == CKU_SO) {
+        break;
+
+    case CKU_SO:
         if (session_mgr_user_session_exists(tokdata)) {
             TRACE_ERROR("%s\n", ock_err(ERR_USER_ANOTHER_ALREADY_LOGGED_IN));
             rc = CKR_USER_ANOTHER_ALREADY_LOGGED_IN;
@@ -1307,24 +1311,51 @@ CK_RV SC_Login(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
             TRACE_ERROR("%s\n", ock_err(ERR_SESSION_READ_ONLY_EXISTS));
             rc = CKR_SESSION_READ_ONLY_EXISTS;
         }
-    } else {
+        break;
+
+    case CKU_CONTEXT_SPECIFIC:
+        /*
+         * Although not explicitly required by the PKCS#11 standard, check that
+         * a USER session exists. C_Login with CKU_CONTEXT_SPECIFIC is performed
+         * due to CKA_ALWAYS_AUTHENTICATE=TRUE on a key used with an operation.
+         * CKA_ALWAYS_AUTHENTICATE=TRUE is only allowed for keys of class
+         * CKO_PRIVATE_KEY that have CKA_PRIVATE=TRUE. Key objects with
+         * CKA_PRIVATE=TRUE can only be accessed in a USER session, so a
+         * C_Login with CKU_CONTEXT_SPECIFIC can also only happen when a USER
+         * session exists.
+         */
+        if (!session_mgr_user_session_exists(tokdata)) {
+            TRACE_ERROR("%s\n", ock_err(ERR_USER_NOT_LOGGED_IN));
+            rc = CKR_USER_NOT_LOGGED_IN;
+        }
+        if (!(sess->sign_ctx.active && sess->sign_ctx.auth_required) &&
+            !(sess->decr_ctx.active && sess->decr_ctx.auth_required)) {
+            TRACE_ERROR("%s\n", ock_err(ERR_OPERATION_NOT_INITIALIZED));
+            rc = CKR_OPERATION_NOT_INITIALIZED;
+        }
+        break;
+
+    default:
         rc = CKR_USER_TYPE_INVALID;
         TRACE_ERROR("%s\n", ock_err(ERR_USER_TYPE_INVALID));
+        break;
     }
     if (rc != CKR_OK)
         goto done;
 
     dat = &tokdata->nv_token_data->dat;
 
-    if (userType == CKU_USER) {
+    switch (userType) {
+    case CKU_USER:
         if (*flags & CKF_USER_PIN_LOCKED) {
             TRACE_ERROR("%s\n", ock_err(ERR_PIN_LOCKED));
             rc = CKR_PIN_LOCKED;
             goto done;
         }
 
-        /* Check if token has a specific handler for this, otherwise
-         * fall back to default behaviour.
+        /*
+         * Check if token has a specific handler for this, otherwise
+         * fall back to default behavior.
          */
         if (token_specific.t_login) {
             // call the pluggable login function here - KEY
@@ -1430,15 +1461,18 @@ CK_RV SC_Login(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
             TRACE_ERROR("Failed to release process lock.\n");
             goto done;
         }
-    } else {
+        break;
+
+    case CKU_SO:
         if (*flags & CKF_SO_PIN_LOCKED) {
             TRACE_ERROR("%s\n", ock_err(ERR_PIN_LOCKED));
             rc = CKR_PIN_LOCKED;
             goto done;
         }
 
-        /* Check if token has a specific handler for this, otherwise
-         * fall back to default behaviour.
+        /*
+         * Check if token has a specific handler for this, otherwise
+         * fall back to default behavior.
          */
         if (token_specific.t_login) {
             /* call the pluggable login function here - KEY */
@@ -1508,15 +1542,117 @@ CK_RV SC_Login(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
         }
 
         rc = load_masterkey_so(tokdata);
-        if (rc != CKR_OK)
+        if (rc != CKR_OK) {
             TRACE_DEVEL("Failed to load SO's masterkey.\n");
+        }
+        break;
+
+    case CKU_CONTEXT_SPECIFIC:
+        if (*flags & CKF_USER_PIN_LOCKED) {
+            TRACE_ERROR("%s\n", ock_err(ERR_PIN_LOCKED));
+            rc = CKR_PIN_LOCKED;
+            goto done;
+        }
+
+        /*
+         * Check if token has a specific handler for this, otherwise
+         * fall back to default behavior.
+         */
+        if (token_specific.t_login) {
+            // call the pluggable login function here - KEY
+            rc = token_specific.t_login(tokdata, sess, userType,
+                                        pPin, ulPinLen);
+            if (rc == CKR_OK) {
+                *flags &= ~(CKF_USER_PIN_LOCKED |
+                            CKF_USER_PIN_FINAL_TRY | CKF_USER_PIN_COUNT_LOW);
+            } else if (rc == CKR_PIN_INCORRECT) {
+                set_login_flags(userType, flags);
+            }
+            goto done;
+        }
+
+        if (!(*flags & CKF_USER_PIN_INITIALIZED)) {
+            TRACE_ERROR("%s\n", ock_err(ERR_USER_PIN_NOT_INITIALIZED));
+            rc = CKR_USER_PIN_NOT_INITIALIZED;
+            goto done;
+        }
+
+        if (tokdata->version < TOK_NEW_DATA_STORE) {
+            rc = compute_sha1(tokdata, pPin, ulPinLen, hash_sha);
+            if (rc != CKR_OK) {
+                TRACE_DEVEL("compute_sha1 failed.\n");
+                goto done;
+            }
+            if (memcmp(tokdata->nv_token_data->user_pin_sha, hash_sha,
+                       SHA1_HASH_SIZE) != 0) {
+                set_login_flags(userType, flags);
+                TRACE_ERROR("%s\n", ock_err(ERR_PIN_INCORRECT));
+                rc = CKR_PIN_INCORRECT;
+                goto done;
+            }
+            /* Successful login, clear flags */
+            *flags &= ~(CKF_USER_PIN_LOCKED |
+                        CKF_USER_PIN_FINAL_TRY | CKF_USER_PIN_COUNT_LOW);
+
+        } else {
+            rc = compute_PKCS5_PBKDF2_HMAC(tokdata, pPin, ulPinLen,
+                                           dat->user_login_salt, 64,
+                                           dat->user_login_it, EVP_sha512(),
+                                           256 / 8, login_key);
+            if (rc != CKR_OK) {
+                TRACE_DEVEL("PBKDF2 failed.\n");
+                goto done;
+            }
+
+            if (CRYPTO_memcmp(dat->user_login_key,
+                              login_key, 256 / 8) != 0) {
+                set_login_flags(userType, flags);
+                TRACE_ERROR("%s\n", ock_err(ERR_PIN_INCORRECT));
+                rc = CKR_PIN_INCORRECT;
+                goto done;
+            }
+
+            /* Successful login, clear flags */
+            *flags &= ~(CKF_USER_PIN_LOCKED |
+                        CKF_USER_PIN_FINAL_TRY | CKF_USER_PIN_COUNT_LOW);
+        }
+
+        /*
+         * Reset flag in operation context to indicate that a login has been
+         * successfully performed
+         */
+        if (sess->sign_ctx.active && sess->sign_ctx.auth_required)
+            sess->sign_ctx.auth_required = FALSE;
+        if (sess->decr_ctx.active && sess->decr_ctx.auth_required)
+            sess->decr_ctx.auth_required = FALSE;
+        break;
+
+    default:
+        rc = CKR_USER_TYPE_INVALID;
+        TRACE_ERROR("%s\n", ock_err(ERR_USER_TYPE_INVALID));
+        goto done;
     }
 
 done:
-    if (rc == CKR_OK) {
+    if (rc == CKR_OK && userType != CKU_CONTEXT_SPECIFIC) {
         rc = session_mgr_login_all(tokdata, userType);
         if (rc != CKR_OK)
             TRACE_DEVEL("session_mgr_login_all failed.\n");
+    }
+
+    /*
+     * PKCS#11 states for failing C_Login with user type CKU_CONTEXT_SPECIFIC:
+     * '... repeated failed re-authentication attempts may cause the PIN to be
+     * locked. C_Login returns in this case CKR_PIN_LOCKED and this also logs
+     * the user out from the token'
+     */
+    if (userType == CKU_CONTEXT_SPECIFIC &&
+        rc == CKR_PIN_INCORRECT &&
+        pin_locked(&sess->session_info,
+                    tokdata->nv_token_data->token_info.flags)) {
+        TRACE_DEVEL("USER pin now locked, logout the user\n");
+        SC_Logout(tokdata, sSession);
+        rc = CKR_PIN_LOCKED;
     }
 
     TRACE_INFO("C_Login: rc = 0x%08lx\n", rc);

--- a/usr/lib/common/sign_mgr.c
+++ b/usr/lib/common/sign_mgr.c
@@ -934,6 +934,10 @@ CK_RV sign_mgr_sign(STDLL_TokData_t *tokdata,
         TRACE_ERROR("%s\n", ock_err(ERR_OPERATION_NOT_INITIALIZED));
         return CKR_OPERATION_NOT_INITIALIZED;
     }
+    if (ctx->auth_required == TRUE) {
+        TRACE_ERROR("%s\n", ock_err(ERR_USER_NOT_LOGGED_IN));
+        return CKR_USER_NOT_LOGGED_IN;
+    }
     if (ctx->multi_init == FALSE) {
         ctx->multi = FALSE;
         ctx->multi_init = TRUE;
@@ -1098,6 +1102,10 @@ CK_RV sign_mgr_sign_update(STDLL_TokData_t *tokdata,
         TRACE_ERROR("%s\n", ock_err(ERR_OPERATION_NOT_INITIALIZED));
         return CKR_OPERATION_NOT_INITIALIZED;
     }
+    if (ctx->auth_required == TRUE) {
+        TRACE_ERROR("%s\n", ock_err(ERR_USER_NOT_LOGGED_IN));
+        return CKR_USER_NOT_LOGGED_IN;
+    }
     if (ctx->multi_init == FALSE) {
         ctx->multi = TRUE;
         ctx->multi_init = TRUE;
@@ -1215,6 +1223,10 @@ CK_RV sign_mgr_sign_final(STDLL_TokData_t *tokdata,
     if (ctx->recover == TRUE) {
         TRACE_ERROR("%s\n", ock_err(ERR_OPERATION_NOT_INITIALIZED));
         return CKR_OPERATION_NOT_INITIALIZED;
+    }
+    if (ctx->auth_required == TRUE) {
+        TRACE_ERROR("%s\n", ock_err(ERR_USER_NOT_LOGGED_IN));
+        return CKR_USER_NOT_LOGGED_IN;
     }
     if (ctx->multi_init == FALSE || ctx->multi == FALSE) {
         TRACE_ERROR("%s\n", ock_err(ERR_OPERATION_ACTIVE));
@@ -1338,6 +1350,10 @@ CK_RV sign_mgr_sign_recover(STDLL_TokData_t *tokdata,
     if (ctx->recover == FALSE) {
         TRACE_ERROR("%s\n", ock_err(ERR_OPERATION_NOT_INITIALIZED));
         return CKR_OPERATION_NOT_INITIALIZED;
+    }
+    if (ctx->auth_required == TRUE) {
+        TRACE_ERROR("%s\n", ock_err(ERR_USER_NOT_LOGGED_IN));
+        return CKR_USER_NOT_LOGGED_IN;
     }
     // if the caller just wants the signature length, there is no reason to
     // specify the input data.  I just need the input data length

--- a/usr/lib/common/template.c
+++ b/usr/lib/common/template.c
@@ -1868,19 +1868,6 @@ CK_RV template_validate_base_attribute(TEMPLATE *tmpl, CK_ATTRIBUTE *attr,
                      MODE_UNWRAP)) != 0)
             return CKR_OK;
         break;
-    case CKA_ALWAYS_AUTHENTICATE:
-        if (attr->ulValueLen != sizeof(CK_BBOOL) || attr->pValue == NULL) {
-            TRACE_ERROR("%s\n", ock_err(ERR_ATTRIBUTE_VALUE_INVALID));
-            return CKR_ATTRIBUTE_VALUE_INVALID;
-        }
-        if (mode == MODE_MODIFY || mode == MODE_COPY) {
-            TRACE_ERROR("%s\n", ock_err(ERR_ATTRIBUTE_READ_ONLY));
-            return CKR_ATTRIBUTE_READ_ONLY;
-        }
-        if (*(CK_BBOOL *)attr->pValue == FALSE)
-            return CKR_OK;
-        TRACE_ERROR("%s\n", ock_err(ERR_ATTRIBUTE_VALUE_INVALID));
-        return CKR_ATTRIBUTE_VALUE_INVALID;
     case CKA_LABEL:
         return CKR_OK;
     case CKA_IBM_OPAQUE:

--- a/usr/lib/ep11_stdll/ep11_specific.h
+++ b/usr/lib/ep11_stdll/ep11_specific.h
@@ -470,13 +470,14 @@ CK_RV ep11tok_generate_key_pair(STDLL_TokData_t * tokdata, SESSION * sess,
 
 CK_RV ep11tok_check_single_mech_key(STDLL_TokData_t *tokdata, SESSION * session,
                                     CK_MECHANISM *mech, CK_OBJECT_HANDLE key,
-                                    CK_ULONG operation);
+                                    CK_ULONG operation,
+                                    CK_BBOOL *auth_required);
 
 CK_BOOL ep11tok_mech_single_only(CK_MECHANISM *mech);
 
 CK_RV ep11tok_sign_init(STDLL_TokData_t * tokdata, SESSION * session,
                         CK_MECHANISM * mech, CK_BBOOL recover_mode,
-                        CK_OBJECT_HANDLE key);
+                        CK_OBJECT_HANDLE key, CK_BBOOL checkauth);
 
 CK_RV ep11tok_sign(STDLL_TokData_t * tokdata, SESSION * session,
                    CK_BBOOL length_only, CK_BYTE * in_data,
@@ -551,7 +552,8 @@ CK_RV ep11tok_encrypt_single(STDLL_TokData_t *tokdata, SESSION *session,
                              CK_ULONG_PTR p_output_data_len);
 
 CK_RV ep11tok_decrypt_init(STDLL_TokData_t * tokdata, SESSION * session,
-                           CK_MECHANISM_PTR mech, CK_OBJECT_HANDLE key);
+                           CK_MECHANISM_PTR mech, CK_OBJECT_HANDLE key,
+                           CK_BBOOL checkauth);
 
 CK_RV ep11tok_decrypt_single(STDLL_TokData_t *tokdata, SESSION *session,
                              CK_MECHANISM *mech, CK_BBOOL length_only,

--- a/usr/lib/ep11_stdll/new_host.c
+++ b/usr/lib/ep11_stdll/new_host.c
@@ -2512,6 +2512,11 @@ CK_RV SC_Decrypt(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
         rc = CKR_OPERATION_NOT_INITIALIZED;
         goto done;
     }
+    if (sess->decr_ctx.auth_required == TRUE) {
+        TRACE_ERROR("%s\n", ock_err(ERR_USER_NOT_LOGGED_IN));
+        rc = CKR_USER_NOT_LOGGED_IN;
+        goto done;
+    }
 
     if (!pData)
         length_only = TRUE;
@@ -2612,6 +2617,11 @@ CK_RV SC_DecryptUpdate(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
         rc = CKR_OPERATION_NOT_INITIALIZED;
         goto done;
     }
+    if (sess->decr_ctx.auth_required == TRUE) {
+        TRACE_ERROR("%s\n", ock_err(ERR_USER_NOT_LOGGED_IN));
+        rc = CKR_USER_NOT_LOGGED_IN;
+        goto done;
+    }
 
     if (sess->decr_ctx.multi_init == FALSE) {
         sess->decr_ctx.multi = TRUE;
@@ -2695,6 +2705,11 @@ CK_RV SC_DecryptFinal(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
         ep11tok_mech_single_only(&sess->decr_ctx.mech)) {
         TRACE_ERROR("%s\n", ock_err(ERR_OPERATION_NOT_INITIALIZED));
         rc = CKR_OPERATION_NOT_INITIALIZED;
+        goto done;
+    }
+    if (sess->decr_ctx.auth_required == TRUE) {
+        TRACE_ERROR("%s\n", ock_err(ERR_USER_NOT_LOGGED_IN));
+        rc = CKR_USER_NOT_LOGGED_IN;
         goto done;
     }
 
@@ -3109,6 +3124,11 @@ CK_RV SC_Sign(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
         rc = CKR_OPERATION_NOT_INITIALIZED;
         goto done;
     }
+    if (sess->sign_ctx.auth_required == TRUE) {
+        TRACE_ERROR("%s\n", ock_err(ERR_USER_NOT_LOGGED_IN));
+        rc = CKR_USER_NOT_LOGGED_IN;
+        goto done;
+    }
 
     if (!pSignature)
         length_only = TRUE;
@@ -3203,6 +3223,11 @@ CK_RV SC_SignUpdate(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
         rc = CKR_OPERATION_NOT_INITIALIZED;
         goto done;
     }
+    if (sess->sign_ctx.auth_required == TRUE) {
+        TRACE_ERROR("%s\n", ock_err(ERR_USER_NOT_LOGGED_IN));
+        rc = CKR_USER_NOT_LOGGED_IN;
+        goto done;
+    }
 
     if (ep11tok_libica_mech_available(tokdata, sess->sign_ctx.mech.mechanism,
                                       sess->sign_ctx.key)) {
@@ -3284,6 +3309,11 @@ CK_RV SC_SignFinal(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
         ep11tok_mech_single_only(&sess->sign_ctx.mech)) {
         TRACE_ERROR("%s\n", ock_err(ERR_OPERATION_NOT_INITIALIZED));
         rc = CKR_OPERATION_NOT_INITIALIZED;
+        goto done;
+    }
+    if (sess->sign_ctx.auth_required == TRUE) {
+        TRACE_ERROR("%s\n", ock_err(ERR_USER_NOT_LOGGED_IN));
+        rc = CKR_USER_NOT_LOGGED_IN;
         goto done;
     }
 

--- a/usr/lib/ep11_stdll/new_host.c
+++ b/usr/lib/ep11_stdll/new_host.c
@@ -2094,7 +2094,7 @@ CK_RV SC_EncryptInit(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
          * when EncryptUpdate comes into play.
          */
         rc = ep11tok_check_single_mech_key(tokdata, sess, pMechanism, hKey,
-                                           OP_ENCRYPT_INIT);
+                                           OP_ENCRYPT_INIT, NULL);
         if (rc != CKR_OK)
             goto done;
 
@@ -2435,7 +2435,8 @@ CK_RV SC_DecryptInit(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
          * when DecryptUpdate comes into play.
          */
         rc = ep11tok_check_single_mech_key(tokdata, sess, pMechanism, hKey,
-                                           OP_DECRYPT_INIT);
+                                           OP_DECRYPT_INIT,
+                                           &sess->decr_ctx.auth_required);
         if (rc != CKR_OK)
             goto done;
 
@@ -2461,7 +2462,7 @@ CK_RV SC_DecryptInit(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
             sess->decr_ctx.mech.ulParameterLen = 0;
         }
     } else {
-        rc = ep11tok_decrypt_init(tokdata, sess, pMechanism, hKey);
+        rc = ep11tok_decrypt_init(tokdata, sess, pMechanism, hKey, TRUE);
         if (rc != CKR_OK)
             TRACE_DEVEL("ep11tok_decrypt_init() failed.\n");
     }
@@ -2625,7 +2626,7 @@ CK_RV SC_DecryptUpdate(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
 
     if (sess->decr_ctx.init_pending) {
         rc = ep11tok_decrypt_init(tokdata, sess, &sess->decr_ctx.mech,
-                                  sess->decr_ctx.key);
+                                  sess->decr_ctx.key, FALSE);
         if (rc != CKR_OK) {
             TRACE_DEVEL("ep11tok_decr_init() failed.\n");
             goto done;
@@ -3007,7 +3008,7 @@ CK_RV SC_SignInit(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
     if (ep11tok_libica_mech_available(tokdata, pMechanism->mechanism, hKey)) {
         sess->sign_ctx.count_statistics = TRUE;
         rc = sign_mgr_init(tokdata, sess, &sess->sign_ctx, pMechanism, FALSE,
-                           hKey, TRUE);
+                           hKey, TRUE, TRUE);
         if (rc != CKR_OK)
             TRACE_DEVEL("sign_mgr_init() failed.\n");
 
@@ -3032,7 +3033,8 @@ CK_RV SC_SignInit(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
          * SignUpdate comes into play.
          */
         rc = ep11tok_check_single_mech_key(tokdata, sess, pMechanism, hKey,
-                                           OP_SIGN_INIT);
+                                           OP_SIGN_INIT,
+                                           &sess->sign_ctx.auth_required);
         if (rc != CKR_OK)
             goto done;
 
@@ -3058,7 +3060,7 @@ CK_RV SC_SignInit(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
             sess->sign_ctx.mech.ulParameterLen = 0;
         }
     } else {
-        rc = ep11tok_sign_init(tokdata, sess, pMechanism, FALSE, hKey);
+        rc = ep11tok_sign_init(tokdata, sess, pMechanism, FALSE, hKey, TRUE);
         if (rc != CKR_OK)
             TRACE_DEVEL("ep11tok_sign_init() failed.\n");
     }
@@ -3225,7 +3227,7 @@ CK_RV SC_SignUpdate(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
 
     if (sess->sign_ctx.init_pending) {
         rc = ep11tok_sign_init(tokdata, sess, &sess->sign_ctx.mech,
-                               FALSE, sess->sign_ctx.key);
+                               FALSE, sess->sign_ctx.key, FALSE);
         if (rc != CKR_OK) {
             TRACE_DEVEL("ep11tok_sign_init() failed.\n");
             goto done;
@@ -3444,7 +3446,7 @@ CK_RV SC_VerifyInit(STDLL_TokData_t *tokdata, ST_SESSION_HANDLE *sSession,
          * when VerifyUpdate comes into play.
          */
         rc = ep11tok_check_single_mech_key(tokdata, sess, pMechanism, hKey,
-                                           OP_VERIFY_INIT);
+                                           OP_VERIFY_INIT, NULL);
         if (rc != CKR_OK)
             goto done;
 

--- a/usr/sbin/p11sak/p11sak.c
+++ b/usr/sbin/p11sak/p11sak.c
@@ -1027,8 +1027,8 @@ static const struct p11sak_opt p11sak_generic_opts[] = {
       .arg =  { .type = ARG_TYPE_STRING, .required = true,                     \
                 .value.string = &opt_attr, .name = "ATTRS", },                 \
       .description = "Filter the key by its boolean attribute values:\n"       \
-                     "P L M B Y R E D G C V O W U S A X N T I K Z (optional). "\
-                     "Specify a set of these letters without any blanks in "   \
+                     "P L M B Y R E D G C V O W U S A X N T I H K Z (optional)"\
+                     ". Specify a set of these letters without any blanks in " \
                      "between. See below for the meaning of the attribute "    \
                      "letters. Attributes that are not specified are not "     \
                      "used to filter the keys.", }
@@ -1115,7 +1115,7 @@ static const struct p11sak_opt p11sak_generate_key_opts[] = {
       .arg =  { .type = ARG_TYPE_STRING, .required = true,
                 .value.string = &opt_attr, .name = "ATTRS", },
       .description = "The boolean attributes to set for the key:\n"
-                     "P M B Y R E D G C V O W U S X T I K (optional). "
+                     "P M B Y R E D G C V O W U S X T I H K (optional). "
                      "Specify a set of these letters without any blanks in "
                      "between. See below for the meaning of the attribute "
                      "letters. For asymmetric keys set individual key "
@@ -1698,7 +1698,7 @@ static const struct p11sak_opt p11sak_import_key_opts[] = {
       .arg =  { .type = ARG_TYPE_STRING, .required = true,
                 .value.string = &opt_attr, .name = "ATTRS", },
       .description = "The boolean attributes to set for the key:\n"
-                     "P M B Y R E D G C V O W U S X T I K (optional). "
+                     "P M B Y R E D G C V O W U S X T I H K (optional). "
                      "Specify a set of these letters without any blanks in "
                      "between. See below for the meaning of the attribute "
                      "letters.", },
@@ -2228,9 +2228,11 @@ static const struct p11sak_attr p11sak_bool_attrs[] = {
     DECLARE_BOOL_ATTR(CKA_ALWAYS_SENSITIVE,  'A', true,  false, true,  false),
     DECLARE_BOOL_ATTR(CKA_EXTRACTABLE,       'X', true,  false, true,  true),
     DECLARE_BOOL_ATTR(CKA_NEVER_EXTRACTABLE, 'N', true,  false, true,  false),
-    DECLARE_BOOL_ATTR_SO(CKA_TRUSTED,        'T', true,  true,  false,  true,
+    DECLARE_BOOL_ATTR_SO(CKA_TRUSTED,        'T', true,  true,  false, true,
                                                   true),
     DECLARE_BOOL_ATTR(CKA_WRAP_WITH_TRUSTED, 'I', true,  false, true,  true),
+    DECLARE_BOOL_ATTR(CKA_ALWAYS_AUTHENTICATE,
+                                             'H', false, false, true,  true),
     DECLARE_BOOL_ATTR(CKA_IBM_PROTKEY_EXTRACTABLE,
                                              'K', true,  false, true,  true),
     DECLARE_BOOL_ATTR(CKA_IBM_PROTKEY_NEVER_EXTRACTABLE,


### PR DESCRIPTION
This PR adds support for the CKA_ALWAYS_AUTHENTICATE attribute.
CKA_ALWAYS_AUTHENTICATE can be set for a private key object (i.e. an object of class CLO_PRIVATE_KEY), and if it si TRUE, then the user must authenticate on each 'use' of that key. 

From https://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/os/pkcs11-base-v2.40-os.html#_Toc416959719:

> The CKA_ALWAYS_AUTHENTICATE attribute can be used to force re-authentication (i.e. force the user to provide a PIN) for each use of a private key. “Use” in this case means a cryptographic operation such as sign or decrypt. This attribute may only be set to CK_TRUE when CKA_PRIVATE is also CK_TRUE.
> 
> Re-authentication occurs by calling C_Login with userType set to CKU_CONTEXT_SPECIFIC immediately after a cryptographic operation using the key has been initiated (e.g. after C_SignInit). In this call, the actual user type is implicitly given by the usage requirements of the active key. If C_Login returns CKR_OK the user was successfully authenticated and this sets the active key in an authenticated state that lasts until the cryptographic operation has successfully or unsuccessfully been completed (e.g. by C_Sign, C_SignFinal,..). A return value CKR_PIN_INCORRECT from C_Login means that the user was denied permission to use the key and continuing the cryptographic operation will result in a behavior as if C_Login had not been called. In both of these cases the session state will remain the same, however repeated failed re-authentication attempts may cause the PIN to be locked. C_Login returns in this case CKR_PIN_LOCKED and this also logs the user out from the token. Failing or omitting to re-authenticate when CKA_ALWAYS_AUTHENTICATE is set to CK_TRUE will result in CKR_USER_NOT_LOGGED_IN to be returned from calls using the key. C_Login will return CKR_OPERATION_NOT_INITIALIZED, but the active cryptographic operation will not be affected, if an attempt is made to re-authenticate when CKA_ALWAYS_AUTHENTICATE is set to CK_FALSE.

Yes, it is strange that this is attribute defined only for private keys, but not also for secret keys, although one can also decrypt (AES, 3DES, etc) and sign (HMAC) with a secret key. Nevertheless, the PKCS#11 standard only defines this attribute for private keys. 

Furthermore, the re-authentication only works for operations that have an C_XXXInit call, becaue the C_Login must happen after the C_XXXInit and before any C_XXX, C_XXXUpdate, or C_XXXFinal calls. However operations like Wrap/Unwrap and Derive do not have an Init call, so those operations can be performed without extra authentication.

Anyway that's how the PKCS#11 standard defines it. 