### PR TITLE
proposed patch to fix resource leaks

### DIFF
--- a/usr/lib/common/mech_dh.c
+++ b/usr/lib/common/mech_dh.c
@@ -124,6 +124,8 @@ CK_RV dh_pkcs_derive(STDLL_TokData_t *tokdata,
     if (rc != CKR_OK) {
         TRACE_ERROR("template_update_attribute failed\n");
         free(new_attr);
+        object_free(temp_obj);
+        temp_obj = NULL;
         return rc;
     }
 

--- a/usr/lib/common/mech_ec.c
+++ b/usr/lib/common/mech_ec.c
@@ -1152,6 +1152,8 @@ CK_RV ecdh_pkcs_derive(STDLL_TokData_t *tokdata, SESSION *sess,
         TRACE_ERROR("template_update_attribute failed\n");
         free(value_attr);
         free(vallen_attr);
+        object_free(temp_obj);
+        temp_obj = NULL;
         goto end;
     }
 
@@ -1160,6 +1162,8 @@ CK_RV ecdh_pkcs_derive(STDLL_TokData_t *tokdata, SESSION *sess,
         if (rc != CKR_OK) {
             TRACE_ERROR("template_update_attribute failed\n");
             free(vallen_attr);
+            object_free(temp_obj);
+            temp_obj = NULL;
             goto end;
         }
     }

--- a/usr/sbin/pkcscca/pkcscca.c
+++ b/usr/sbin/pkcscca/pkcscca.c
@@ -749,6 +749,7 @@ int add_key(CK_OBJECT_HANDLE handle, CK_ATTRIBUTE *attrs, struct key **keys)
     new_key->label = malloc(attrs[2].ulValueLen + 1);
     if (!new_key->label) {
         print_error("Malloc of %lu bytes failed!", attrs[2].ulValueLen + 1);
+        free(new_key->opaque_attr);
         free(new_key);
         return 2;
     }


### PR DESCRIPTION
There are 2 resource leaks in opencryptoki-3.24.0 found by covscan:

```
1. Defect type: RESOURCE_LEAK
  4. opencryptoki-3.24.0/usr/sbin/pkcscca/pkcscca.c:740:5: alloc_fn: Storage is returned from allocation function "malloc".
  5. opencryptoki-3.24.0/usr/sbin/pkcscca/pkcscca.c:740:5: var_assign: Assigning: "new_key->opaque_attr" = storage returned from "malloc(attrs[0].ulValueLen)".
  7. opencryptoki-3.24.0/usr/sbin/pkcscca/pkcscca.c:748:5: noescape: Resource "new_key->opaque_attr" is not freed or pointed-to in "memcpy". [Note: The source code implementation of the function has been overridden by a builtin model.]
  9. opencryptoki-3.24.0/usr/sbin/pkcscca/pkcscca.c:752:9: leaked_storage: Freeing "new_key" without freeing its pointer field "opaque_attr" leaks the storage that "opaque_attr" points to.
   750|       if (!new_key->label) {
   751|           print_error("Malloc of %lu bytes failed!", attrs[2].ulValueLen + 1);
   752|->         free(new_key);
   753|           return 2;
   754|       }

2. Defect type: RESOURCE_LEAK
   15. opencryptoki-3.24.0/usr/lib/common/mech_ec.c:1140:5: alloc_arg: "object_mgr_create_skel" allocates memory that is stored into "temp_obj".
   21. opencryptoki-3.24.0/usr/lib/common/mech_ec.c:1182:5: leaked_storage: Variable "temp_obj" going out of scope leaks the storage it points to.
     1180|       free(derived_key);
     1181|
     1182|->     return rc;
     1183|   }
     1184|
```
@ifranzki ,  i made a proposed patch 