### PR TITLE
EP11: Fix handling of bPrepend flag in CK_IBM_KYBER_PARAMS

### DIFF
--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -6430,7 +6430,7 @@ static CK_RV ep11tok_kyber_mech_pre_process(STDLL_TokData_t *tokdata,
         return CKR_MECHANISM_PARAM_INVALID;
     }
 
-    if (kyber_params->bPrepend) {
+    if (kyber_params->hSecret != CK_INVALID_HANDLE) {
         rc = h_opaque_2_blob(tokdata, kyber_params->hSecret,
                              &mech_ep11->params.pBlob,
                              &mech_ep11->params.ulBlobLen,


### PR DESCRIPTION
The bPrepend flag in CK_IBM_KYBER_PARAMS can not be used as an indication if the hSecret key handle is valid or not. The bPrepend flag only determines if the hybrid secret is prepended to the Kyber secret, or appended.

To check if a hybrid secret is specified check if the hSecret handle is CK_INVALID_HANDLE or a valid object handle value.