### PR TITLE
TESTCASES: Fix out of bounds access

### DIFF
--- a/testcases/crypto/ec_func.c
+++ b/testcases/crypto/ec_func.c
@@ -1078,7 +1078,7 @@ CK_RV run_DeriveECDHKey(void)
                         }
 
                         if (enc1_len != enc2_len ||
-                            memcmp(enc1, enc2, mac1_len) != 0) {
+                            memcmp(enc1, enc2, enc1_len) != 0) {
                             testcase_fail("ERROR: derived keys do not produce the "
                                           "same encrypted cipher text");
                             goto testcase_cleanup;


### PR DESCRIPTION
Do the memcmp with the right length. Using a wrong length may cause it to overrun the buffers, or compare in a wrong length. Both most likely result in the false assumption that the testcase would have failed, because the two buffers would not be the same.