### PR TITLE
Avoid incorrect copyright claims

### DIFF
--- a/tools/tableidxgen.c
+++ b/tools/tableidxgen.c
@@ -596,8 +596,7 @@ static void generatelicense(FILE *fp)
     /* Remove trailing newline character */
     tstr[strlen(tstr) - 1] = 0;
     fputs("/*\n", fp);
-    fprintf(fp, " * COPYRIGHT (c) International Business Machines Corp. %d\n",
-            tm->tm_year + 1900);
+    fprintf(fp, " * COPYRIGHT (c) International Business Machines Corp. 2024\n");
     fputs(" *\n", fp);
     fputs(" * This program is provided under the terms of the Common Public License,\n",
           fp);


### PR DESCRIPTION
When building this in 2025, it claims Copyright 2025 without any copyright-worthy work happening in that year.

Also note that the number does not have to be updated every year as copyright does not expire for 70+ years.

This patch was done while working on [reproducible builds](https://reproducible-builds.org/) for openSUSE, sponsored by the NLnet NGI0 fund.