### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/tools/tableidxgen.c
+++ b/tools/tableidxgen.c
@@ -589,8 +589,11 @@ static void generatelicense(FILE *fp)
     time_t t;
     struct tm *tm;
     char *tstr;
+    char *source_date_epoch;
 
-    t = time(NULL);
+    if ((source_date_epoch = getenv("SOURCE_DATE_EPOCH")) == NULL ||
+        (t = (time_t)strtoll(source_date_epoch, NULL, 10)) <= 0)
+            t = time(NULL);
     tm = localtime(&t);
     tstr = asctime(tm);
     /* Remove trailing newline character */


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH` to make builds reproducible.
See https://reproducible-builds.org/ for why this is good and https://reproducible-builds.org/specs/source-date-epoch/ for the definition of this variable.

Alternative: drop the timestamp

This patch was done while working on reproducible builds for openSUSE, sponsored by the NLnet NGI0 fund.