### PR TITLE
TRAVIS: Set 'pipefail' to catch the return code of the testcases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,7 @@ before_script:
     - ./bootstrap.sh 2> >(tee)
 
 script:
+    - set -o pipefail
     - openssl version 2> >(tee)
     - ./configure --silent $CONFIG_OPTS 2> >(tee) && make -j 5 V=0 2> >(tee)
     - make check V=0 2> >(tee)


### PR DESCRIPTION
Running the testcases via ock_tests.sh uses a pipe construct to adjust the output. Without 'set -o pipefail' the return code of this is the return code of the last command in the pipe, but not the return code of ock_tests.sh.