### PR TITLE
POLICY: Fix signature size check for the Dilithium mechanism

### DIFF
--- a/usr/lib/api/policy.c
+++ b/usr/lib/api/policy.c
@@ -794,6 +794,9 @@ static CK_RV policy_check_signature_size(struct policy_private *pp,
             case CKM_SSL3_SHA1_MAC:
                 params = 8;
                 break;
+            case CKM_IBM_DILITHIUM:
+                siglen = 256;
+                break;
             default:
                 break;
             }


### PR DESCRIPTION
Handling for mechanism CKM_IBM_DILITHIUM is missing in function `policy_check_signature_size()`. This causes `policy_update_mech_info()` to remove the `CKF_SIGN` and `CKF_VERIFY` flags when a minimum strength of larger than 0 is configured in the policy config file, because function `policy_check_signature_size()` erroneously returns a signature size of zero, which is below the allowed signature size. Return a signature size of 256 bits instead.

This only affects the mechanism info returned by `C_GetMechanismInfo()`, when the policy defines minimum strength of larger than 0. It does not affect the mechanism execution, nor signature creation or verification.