### PR TITLE
COMMON: Fix unwrap private keys to supply correct public attributes

### DIFF
--- a/usr/lib/common/h_extern.h
+++ b/usr/lib/common/h_extern.h
@@ -2683,7 +2683,8 @@ CK_RV rsa_priv_wrap_get_data(TEMPLATE *tmpl, CK_BBOOL length_only,
                              CK_BYTE **data, CK_ULONG *data_len);
 CK_RV rsa_priv_unwrap(TEMPLATE *tmpl, CK_BYTE *data, CK_ULONG data_len);
 CK_RV rsa_priv_unwrap_get_data(TEMPLATE *tmpl,
-                              CK_BYTE *data, CK_ULONG total_length);
+                               CK_BYTE *data, CK_ULONG total_length,
+                               CK_BBOOL is_public);
 CK_RV rsa_priv_check_and_swap_pq(TEMPLATE *tmpl);
 
 // dsa routines
@@ -2703,7 +2704,8 @@ CK_RV dsa_priv_wrap_get_data(TEMPLATE *tmpl, CK_BBOOL length_only,
                              CK_BYTE **data, CK_ULONG *data_len);
 CK_RV dsa_priv_unwrap(TEMPLATE *tmpl, CK_BYTE *data, CK_ULONG data_len);
 CK_RV dsa_priv_unwrap_get_data(TEMPLATE *tmpl,
-                              CK_BYTE *data, CK_ULONG total_length);
+                               CK_BYTE *data, CK_ULONG total_length,
+                               CK_BBOOL is_public);
 
 // ecdsa routines
 //
@@ -2721,7 +2723,7 @@ CK_RV ecdsa_priv_validate_attribute(STDLL_TokData_t *tokdata, TEMPLATE *tmpl,
 CK_RV ecdsa_priv_wrap_get_data(TEMPLATE *tmpl, CK_BBOOL length_only,
                                CK_BYTE **data, CK_ULONG *data_len);
 CK_RV ecdsa_priv_unwrap_get_data(TEMPLATE *tmpl, CK_BYTE *data,
-                                 CK_ULONG data_len);
+                                 CK_ULONG data_len, CK_BBOOL is_public);
 CK_RV ec_priv_unwrap(TEMPLATE *tmpl, CK_BYTE *data, CK_ULONG data_len);
 
 // Dilithium routines
@@ -2743,7 +2745,7 @@ CK_RV ibm_dilithium_priv_unwrap(TEMPLATE *tmpl, CK_BYTE *data,
                                 CK_ULONG total_length, CK_BBOOL add_value);
 CK_RV ibm_dilithium_priv_unwrap_get_data(TEMPLATE *tmpl,
                                          CK_BYTE *data, CK_ULONG total_length,
-                                         CK_BBOOL add_value);
+                                         CK_BBOOL is_public);
 
 // Kyber routines
 //
@@ -2764,7 +2766,7 @@ CK_RV ibm_kyber_priv_unwrap(TEMPLATE *tmpl, CK_BYTE *data,
                             CK_ULONG total_length, CK_BBOOL add_value);
 CK_RV ibm_kyber_priv_unwrap_get_data(TEMPLATE *tmpl,
                                      CK_BYTE *data, CK_ULONG total_length,
-                                     CK_BBOOL add_value);
+                                     CK_BBOOL is_public);
 
 // PQC helper routines
 //
@@ -2778,7 +2780,7 @@ CK_RV ibm_pqc_priv_unwrap(TEMPLATE *tmpl, CK_KEY_TYPE keytype, CK_BYTE *data,
                           CK_ULONG total_length, CK_BBOOL add_value);
 CK_RV ibm_pqc_priv_unwrap_get_data(TEMPLATE *tmpl, CK_KEY_TYPE keytype,
                                    CK_BYTE *data, CK_ULONG total_length,
-                                   CK_BBOOL add_value);
+                                   CK_BBOOL is_public);
 const struct pqc_oid *ibm_pqc_get_keyform_mode(TEMPLATE *tmpl,
                                                CK_MECHANISM_TYPE mech);
 CK_RV ibm_pqc_add_keyform_mode(TEMPLATE *tmpl, const struct pqc_oid *oid,
@@ -2801,7 +2803,8 @@ CK_RV dh_priv_wrap_get_data(TEMPLATE *tmpl,
                             CK_BBOOL length_only, CK_BYTE **data,
                             CK_ULONG *data_len);
 CK_RV dh_priv_unwrap_get_data(TEMPLATE *tmpl,
-                              CK_BYTE *data, CK_ULONG total_length);
+                              CK_BYTE *data, CK_ULONG total_length,
+                              CK_BBOOL is_public);
 CK_RV dh_priv_unwrap(TEMPLATE *tmpl, CK_BYTE *data, CK_ULONG data_len);
 
 // Generic secret key routines

--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -6574,7 +6574,7 @@ static CK_RV ep11tok_btc_mech_post_process(STDLL_TokData_t *tokdata,
     switch (class) {
     case CKO_PUBLIC_KEY:
         /* Derived blob is an SPKI, extract public EC key attributes */
-        rc = ecdsa_priv_unwrap_get_data(key_obj->template, blob, bloblen);
+        rc = ecdsa_priv_unwrap_get_data(key_obj->template, blob, bloblen, TRUE);
         if (rc != CKR_OK) {
             TRACE_ERROR("%s ecdsa_priv_unwrap_get_data failed with "
                         "rc=0x%lx\n", __func__, rc);
@@ -11778,16 +11778,20 @@ CK_RV ep11tok_unwrap_key(STDLL_TokData_t * tokdata, SESSION * session,
          */
         switch (*(CK_KEY_TYPE *) keytype_attr->pValue) {
         case CKK_EC:
-            rc = ecdsa_priv_unwrap_get_data(key_obj->template, csum, cslen);
+            rc = ecdsa_priv_unwrap_get_data(key_obj->template, csum, cslen,
+                                            FALSE);
             break;
         case CKK_RSA:
-            rc = rsa_priv_unwrap_get_data(key_obj->template, csum, cslen);
+            rc = rsa_priv_unwrap_get_data(key_obj->template, csum, cslen,
+                                          FALSE);
             break;
         case CKK_DSA:
-            rc = dsa_priv_unwrap_get_data(key_obj->template, csum, cslen);
+            rc = dsa_priv_unwrap_get_data(key_obj->template, csum, cslen,
+                                          FALSE);
             break;
         case CKK_DH:
-            rc = dh_priv_unwrap_get_data(key_obj->template, csum, cslen);
+            rc = dh_priv_unwrap_get_data(key_obj->template, csum, cslen,
+                                         FALSE);
             break;
         case CKK_IBM_PQC_DILITHIUM:
             rc = ibm_dilithium_priv_unwrap_get_data(key_obj->template,


### PR DESCRIPTION
When unwrapping a private key, the public attributes are also supplied to the key. However, not all public key attributes that can be extracted from the SPKI must be added to the private key.

Add a function parameter to the nnn_priv_unwrap_get_data() functions so that the caller can tell if the public attributes are to be supplied to the template of a private or public key object.