### PR TITLE
COMMON: CKA_IBM_PROTKEY_NEVER_EXTRACTABLE is read only

### DIFF
--- a/testcases/crypto/ec_func.c
+++ b/testcases/crypto/ec_func.c
@@ -2062,11 +2062,11 @@ CK_RV run_GenerateECCKeyPairSignVerify(void)
         if (rc == CKR_OK) {
             testcase_fail
                 ("generate_EC_KeyPair with invalid input failed at i=%lu (%s)",
-                 i, der_ec_supported[i].name);
+                 i, der_ec_notsupported[i].name);
             goto testcase_cleanup;
         }
         testcase_pass("*Generate unsupported key pair curve=%s passed.",
-                      der_ec_supported[i].name);
+                      der_ec_notsupported[i].name);
     }
 
     rc = CKR_OK;
@@ -3213,7 +3213,7 @@ int main(int argc, char **argv)
 #ifndef NO_PKEY
     if (is_ep11_token(SLOT_ID) || is_cca_token(SLOT_ID)) {
         pkey = CK_TRUE;
-        rv = run_GenerateECCKeyPairSignVerify();
+        rv += run_GenerateECCKeyPairSignVerify();
         rv += run_ImportECCKeyPairSignVerify();
         rv += run_TransferECCKeyPairSignVerify();
         rv += run_DeriveECDHKey();

--- a/usr/lib/common/key.c
+++ b/usr/lib/common/key.c
@@ -342,7 +342,9 @@ CK_RV key_object_validate_attribute(TEMPLATE *tmpl, CK_ATTRIBUTE *attr,
             }
         }
         return CKR_OK;
-        break;
+    case CKA_IBM_PROTKEY_NEVER_EXTRACTABLE:
+        TRACE_ERROR("%s\n", ock_err(ERR_ATTRIBUTE_READ_ONLY));
+        return CKR_ATTRIBUTE_READ_ONLY;
     case CKA_IBM_ATTRBOUND:
         if (attr->ulValueLen != sizeof(CK_BBOOL) || attr->pValue == NULL) {
             TRACE_ERROR("%s\n", ock_err(ERR_ATTRIBUTE_VALUE_INVALID));

--- a/usr/lib/common/pkey_utils.c
+++ b/usr/lib/common/pkey_utils.c
@@ -1770,6 +1770,11 @@ struct {                            \
             ret = CKR_ARGUMENTS_BAD;
             goto done;
         }
+        if (ecpoint_len != sizeof(edparam.ED25519.pub)) {
+            TRACE_ERROR("Public key has an invalid length of %ld bytes.\n", ecpoint_len);
+            ret = CKR_ATTRIBUTE_VALUE_INVALID;
+            goto done;
+        }
         fc = KDSA_EDDSA_VERIFY_ED25519;
         /*
          * The flip_endian_32 will copy the 32-byte signature parts and public
@@ -1786,6 +1791,11 @@ struct {                            \
             ret = CKR_ARGUMENTS_BAD;
             goto done;
         }
+        if (ecpoint_len != sizeof(edparam.ED448.pub) - ED448_BUF_OFFSET) {
+            TRACE_ERROR("Public key has an invalid length of %ld bytes.\n", ecpoint_len);
+            ret = CKR_ATTRIBUTE_VALUE_INVALID;
+            goto done;
+        }
         fc = KDSA_EDDSA_VERIFY_ED448;
         /*
          * Copy the 57-byte signature parts and public key into the CPACF parm
@@ -1795,7 +1805,8 @@ struct {                            \
          */
         memcpy(edparam.ED448.sig_r, sig, sig_len / 2);
         memcpy(edparam.ED448.sig_s, sig + (sig_len / 2), sig_len / 2);
-        memcpy(edparam.ED448.pub, ecpoint, sizeof(edparam.ED448.pub));
+        memcpy(edparam.ED448.pub, ecpoint,
+               MIN(ecpoint_len, sizeof(edparam.ED448.pub)));
         s390_flip_endian_64(edparam.ED448.sig_r, edparam.ED448.sig_r);
         s390_flip_endian_64(edparam.ED448.sig_s, edparam.ED448.sig_s);
         s390_flip_endian_64(edparam.ED448.pub, edparam.ED448.pub);


### PR DESCRIPTION
Add a check that CKA_IBM_PROTKEY_NEVER_EXTRACTABLE can not be modified. Like the other CKA_NEVER_xxx or CKA_ALWAYS_xxx attributes, it is only updated internally (i.e. when CKA_IBM_PROTKEY_EXTRACTABLE is updated), but can not be set from external.

And additional fixes....