### PR TITLE
CI: Fail early if token initialization fails

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -267,7 +267,7 @@ ci-prepare:
 	${srcdir}/testcases/ciconfig.sh "$(sysconfdir)/opencryptoki" "$(sysconfdir)/opencryptoki" "$(sysconfdir)/opencryptoki" "${srcdir}/testcases/test_combined_extract.slots"
 	@sbindir@/pkcsslotd
 	@sbindir@/pkcsstats --reset-all
-	for slot in `awk '/^slot (.*)/ { print $$2; }' $(sysconfdir)/opencryptoki/opencryptoki.conf`; do @sbindir@/pkcsconf -c $$slot -t | grep "Flags:" | grep -q TOKEN_INITIALIZED || PKCS11_USER_PIN=$(PKCS11_USER_PIN) PKCS11_SO_PIN=$(PKCS11_SO_PIN) PKCSLIB=$(PKCSLIB) ${srcdir}/testcases/init_token.sh $$slot; done
+	for slot in `awk '/^slot (.*)/ { print $$2; }' $(sysconfdir)/opencryptoki/opencryptoki.conf`; do @sbindir@/pkcsconf -c $$slot -t | grep "Flags:" | grep -q TOKEN_INITIALIZED || PKCS11_USER_PIN=$(PKCS11_USER_PIN) PKCS11_SO_PIN=$(PKCS11_SO_PIN) PKCSLIB=$(PKCSLIB) ${srcdir}/testcases/init_token.sh $$slot || exit; done
 #	cd ${srcdir}/testcases && PKCS11_USER_PIN=$(PKCS11_USER_PIN) PKCS11_VHSM_PIN=$(PKCS11_VHSM_PIN) PKCSLIB=$(PKCSLIB) ./init_vhsm.exp 42
 #	echo "VHSM_MODE" >> "$(sysconfdir)/opencryptoki/ep11tok42.conf"
 

--- a/testcases/init_token.sh.in
+++ b/testcases/init_token.sh.in
@@ -8,13 +8,16 @@
 # in the file LICENSE file or at https://opensource.org/licenses/cpl1.0.php
 #
 
+set timeout 30
 spawn @sbindir@/pkcsconf -c [lindex $argv 0] -I
 expect {
     "Enter the SO PIN: " { sleep .1; send "87654321\r"; }
+    timeout { send_user "Timeout when sending SO PIN during initialization\n"; exit 1 }
     default { send_user "Error sending SO PIN during initialization\n"; exit 1 }
 }
 expect {
     "label: " { sleep .1; send "ibmtest\r"; }
+    timeout { send_user "Timeout when sending label during initialization\n"; exit 1 }
     default { send_user "Error sending label during initialization\n"; exit 1 }
 }
 expect {
@@ -26,14 +29,17 @@ expect {
 spawn @sbindir@/pkcsconf -c [lindex $argv 0] -P
 expect {
     "Enter the SO PIN: " { sleep .1; send "87654321\r"; }
+    timeout { send_user "Timeout when sending SO PIN during SO PIN setting\n"; exit 1 }
     default { send_user "Error sending SO PIN during SO PIN setting\n"; exit 1 }
 }
 expect {
     "Enter the new SO PIN: " { sleep .1; send $env(PKCS11_SO_PIN); send "\r"; }
+    timeout { send_user "Timeout when sending new SO PIN during SO PIN setting\n"; exit 1 }
     default { send_user "Error sending new SO PIN during SO PIN setting\n"; exit 1 }
 }
 expect {
     "Re-enter the new SO PIN: " { sleep .1; send $env(PKCS11_SO_PIN); send "\r"; }
+    timeout { send_user "Timeout when resending new SO PIN during SO PIN setting\n"; exit 1 }
     default { send_user "Error resending new SO PIN during SO PIN setting\n"; exit 1 }
 }
 expect {
@@ -45,14 +51,17 @@ expect {
 spawn @sbindir@/pkcsconf -c [lindex $argv 0] -u
 expect {
     "Enter the SO PIN: " { sleep .1; send $env(PKCS11_SO_PIN); send "\r"; }
+    timeout { send_user "Timeout when sending SO PIN during user PIN initialization\n"; exit 1 }
     default { send_user "Error sending SO PIN during user PIN initialization\n"; exit 1 }
 }
 expect {
     "Enter the new user PIN: " { sleep .1; send "12345678\r"; }
+    timeout { send_user "Timeout when sending new user PIN during user PIN initialization\n"; exit 1 }
     default { send_user "Error sending new user PIN during user PIN initialization\n"; exit 1 }
 }
 expect {
     "Re-enter the new user PIN: " { sleep .1; send "12345678\r"; }
+    timeout { send_user "Timeout when resending new user during user PIN initialization\n"; exit 1 }
     default { send_user "Error resending new user during user PIN initialization\n"; exit 1 }
 }
 expect {
@@ -64,14 +73,17 @@ expect {
 spawn @sbindir@/pkcsconf -c [lindex $argv 0] -p
 expect {
     "Enter user PIN: " { sleep .1; send "12345678\r"; }
+    timeout { send_user "Timeout when sending user PIN during user PIN setting\n"; exit 1 }
     default { send_user "Error sending user PIN during user PIN setting\n"; exit 1 }
 }
 expect {
     "Enter the new user PIN: " { sleep .1; send $env(PKCS11_USER_PIN); send "\r"; }
+    timeout { send_user "Timeout when sending new user PIN during user PIN setting\n"; exit 1 }
     default { send_user "Error sending new user PIN during user PIN setting\n"; exit 1 }
 }
 expect {
     "Re-enter the new user PIN: " { sleep .1; send $env(PKCS11_USER_PIN); send "\r"; }
+    timeout { send_user "Timeout when resending new user PIN during user PIN setting\n"; exit 1 }
     default { send_user "Error resending new user PIN during user PIN setting\n"; exit 1 }
 }
 expect {


### PR DESCRIPTION
If token initialization fails (e.g. due to a timeout in the 'expect' script), fail the 'make ci-installcheck' entirely. Not failing here will leave the tokens uninitialized, and subsequent tests running against the token will each fail with CKR_USER_PIN_NOT_INITIALIZED, CKR_USER_NOT_LOGGED_IN, or similar.

Also increase the 'expect' timeout from the default (10 seconds) to 30 seconds, to give the pkcsconf tool more time to produce the expected output. Furthermore, clearly show if a timeout has happen.