### PR TITLE
PKCSSTATS: Fix SHM owner checking

### DIFF
--- a/usr/sbin/pkcsstats/pkcsstats.c
+++ b/usr/sbin/pkcsstats/pkcsstats.c
@@ -111,10 +111,10 @@ static int open_shm(uid_t user_id, const char *user_name,
     }
 
     /*
-     * If the shared memory segment does not belong to the pkcs11 group or does
+     * If the shared memory segment does not belong to the user or does
      * not have correct permissions, do not use it.
      */
-    if (stat_buf.st_uid != user_id || stat_buf.st_gid != user_id ||
+    if (stat_buf.st_uid != user_id ||
         (stat_buf.st_mode & ~S_IFMT) != (S_IRUSR | S_IWUSR)) {
         warnx("Failed to open statistics for user '%s': SHM '%s' has wrong mode/owner",
               user_name, shm_name);


### PR DESCRIPTION
Only check for the user owner (st_uid) of the SHM to be the expected user, but do not check the group owner (st_gid). If the user has an initial group set, then files created by that user will be owned by its group.

This is in accordance to the code in statistics.c in function statistics_open_shm() where it also just checks the user owner, but not the group owner.

This fixes situations where a statistics SHM was created for a user, but when that user tries to display its statistics, it fails with:
   pkcsstats: Failed to open statistics for user 'uuuuuu':
   SHM '/var.lib.opencryptoki_stats_nnnn' has wrong mode/owner

Fixes: c12656dd653ed01b66d400253ea92d9614d3d5eb