### PR TITLE
Fix '-Wunterminated-string-initialization' warnings

### DIFF
--- a/testcases/misc_tests/events.c
+++ b/testcases/misc_tests/events.c
@@ -17,7 +17,7 @@
 #include "regress.h"
 #include "defs.h"
 
-const char payload[20] = "12345678901234567890";
+const char payload[20 + 1] = "12345678901234567890";
 
 static inline void init_event_destination(struct event_destination *dest,
                                           unsigned int token_type,

--- a/testcases/pkcs11/destroyobjects.c
+++ b/testcases/pkcs11/destroyobjects.c
@@ -45,21 +45,21 @@ CK_RV do_DestroyObjects(void)
     CK_BBOOL true = TRUE;
     CK_KEY_TYPE aes_type = CKK_AES;
     CK_OBJECT_CLASS key_class = CKO_SECRET_KEY;
-    CK_CHAR aes_value[] = "This is a fake aes key.";
-    CK_CHAR test_id[5] = "abcde";
+    CK_CHAR aes_value[32] = "This is a fake aes key.";
+    CK_CHAR test_id[5 + 1] = "abcde";
     CK_ULONG aesgen_keylen = 32;
 
     CK_ATTRIBUTE aes_tmpl[] = {
         {CKA_CLASS, &key_class, sizeof(key_class)},
         {CKA_KEY_TYPE, &aes_type, sizeof(aes_type)},
-        {CKA_ID, &test_id, sizeof(test_id)},
+        {CKA_ID, &test_id, strlen((char *)test_id)},
         {CKA_VALUE, &aes_value, sizeof(aes_value)}
     };
 
     CK_ATTRIBUTE aes_tmpl_no_destroy[] = {
         {CKA_CLASS, &key_class, sizeof(key_class)},
         {CKA_KEY_TYPE, &aes_type, sizeof(aes_type)},
-        {CKA_ID, &test_id, sizeof(test_id)},
+        {CKA_ID, &test_id, strlen((char *)test_id)},
         {CKA_VALUE, &aes_value, sizeof(aes_value)},
         {CKA_DESTROYABLE, &false, sizeof(false)},
     };
@@ -67,14 +67,14 @@ CK_RV do_DestroyObjects(void)
     CK_ATTRIBUTE aesgen_tmpl[] = {
         {CKA_CLASS, &key_class, sizeof(key_class)},
         {CKA_KEY_TYPE, &aes_type, sizeof(aes_type)},
-        {CKA_ID, &test_id, sizeof(test_id)},
+        {CKA_ID, &test_id, strlen((char *)test_id)},
         {CKA_VALUE_LEN, &aesgen_keylen, sizeof(aesgen_keylen)},
         {CKA_TOKEN, &true, sizeof(true)}
     };
 
     CK_ATTRIBUTE find_tmpl[] = {
         {CKA_KEY_TYPE, &aes_type, sizeof(aes_type)},
-        {CKA_ID, &test_id, sizeof(test_id)}
+        {CKA_ID, &test_id, strlen((char *)test_id)}
     };
 
     testcase_begin("");

--- a/usr/lib/api/socket_client.c
+++ b/usr/lib/api/socket_client.c
@@ -203,7 +203,7 @@ static bool match_token_label_filter(event_msg_t *event, API_Slot_t *sltp)
 
 struct type_model {
     unsigned int type;
-    char model[member_size(CK_TOKEN_INFO_32, model)];
+    char model[member_size(CK_TOKEN_INFO_32, model) + 1];
 };
 
 static const struct type_model type_model_flt[] = {
@@ -221,7 +221,8 @@ static bool match_token_type_filter(event_msg_t *event, API_Slot_t *sltp)
     for (i = 0; i < sizeof(type_model_flt) / sizeof(struct type_model); i++) {
         if (memcmp(sltp->TokData->nv_token_data->token_info.model,
                    type_model_flt[i].model,
-                   sizeof(type_model_flt[i].model)) == 0 &&
+                   sizeof(sltp->TokData->nv_token_data->token_info.model))
+                                                                    == 0 &&
             (event->token_type & type_model_flt[i].type) != 0)
             return true;
     }

--- a/usr/lib/cca_stdll/cca_specific.c
+++ b/usr/lib/cca_stdll/cca_specific.c
@@ -5055,7 +5055,7 @@ static CK_RV cca_cipher_key_gen(STDLL_TokData_t *tokdata, TEMPLATE *tmpl,
     unsigned char rule_array[CCA_RULE_ARRAY_SIZE] = { 0x20, };
     long exit_data_len = 0, rule_array_count;
     unsigned char exit_data[4] = { 0, };
-    unsigned char key_type_2[CCA_KEYWORD_SIZE] = "        ";
+    unsigned char key_type_2[CCA_KEYWORD_SIZE + 1] = "        ";
     long clear_key_bit_length, zero_length = 0, key_token_len;
     enum cca_token_type keytype;
     unsigned int keybitsize;


### PR DESCRIPTION
Newer GCC versions report errors for string initialization where the terminating NULL character does not fit into the target variable.

All the fixed places use non-zero-terminated strings, but add an additional character to make the compiler happy.