### PR TITLE
P11KMIP: Fix Coverity scan findings

### DIFF
--- a/usr/sbin/p11kmip/kmipclient/attribute.c
+++ b/usr/sbin/p11kmip/kmipclient/attribute.c
@@ -2432,7 +2432,7 @@ out:
 	kmip_node_free(iv);
 	kmip_node_free(tag);
 	kmip_node_free(ffl);
-	kmip_node_free(ffl);
+	kmip_node_free(ifl);
 	kmip_node_free(cnt);
 	kmip_node_free(icv);
 	kmip_node_free(salt);

--- a/usr/sbin/p11kmip/kmipclient/kmip.c
+++ b/usr/sbin/p11kmip/kmipclient/kmip.c
@@ -1497,7 +1497,7 @@ retry:
 	chain = SSL_get_peer_cert_chain(conn->plain_tls.ssl);
 	if (chain == NULL) {
 		kmip_debug(debug, "SSL_get_peer_cert_chain failed");
-		return -EIO;
+		rc = -EIO;
 		goto out;
 	}
 

--- a/usr/sbin/p11kmip/kmipclient/request.c
+++ b/usr/sbin/p11kmip/kmipclient/request.c
@@ -210,6 +210,8 @@ struct kmip_node *kmip_new_request_header(const struct kmip_version *version,
 out:
 	kmip_node_free(ver);
 	kmip_node_free(max);
+	kmip_node_free(ccorr);
+	kmip_node_free(scorr);
 	kmip_node_free(async);
 	kmip_node_free(err);
 	kmip_node_free(ord);

--- a/usr/sbin/p11kmip/kmipclient/response.c
+++ b/usr/sbin/p11kmip/kmipclient/response.c
@@ -1369,7 +1369,7 @@ int kmip_get_get_response_payload(const struct kmip_node *node,
 	return 0;
 
 error:
-	if (*unique_id != NULL) {
+	if (unique_id != NULL && *unique_id != NULL) {
 		kmip_node_free(*unique_id);
 		*unique_id = NULL;
 	}

--- a/usr/sbin/p11kmip/kmipclient/tls.c
+++ b/usr/sbin/p11kmip/kmipclient/tls.c
@@ -352,7 +352,6 @@ int kmip_connection_tls_init(struct kmip_connection *conn, bool debug)
 		if (tok == NULL) {
 			kmip_debug(debug, "malformed IPv6 address");
 			rc = -EINVAL;
-			free(hostname);
 			goto out;
 		}
 		tok++;


### PR DESCRIPTION
Mostly trivial changes.

@john-craig Please double check the change in function `get_kmip_usage_mask_p11()` in p11kmip.c.
The Coverity scan reported the following for the construct there:
```
CID 551165: (#1 of 1): Operands don't affect result (CONSTANT_EXPRESSION_RESULT)
result_independent_of_operands: keytype->encrypt_decrypt & (12 /* KMIP_CRY_USAGE_MASK_ENCRYPT | KMIP_CRY_USAGE_MASK_DECRYPT */) is always 0 regardless of the values of its operands. This occurs as the bitwise first operand of "|".
```

I fixed this using a series of explicit if statements. Please check if this produces the intended result.