### PR TITLE
EP11: Reject strict-session of VHSM mode in a Secure Execution guest

### DIFF
--- a/usr/lib/ep11_stdll/ep11_specific.h
+++ b/usr/lib/ep11_stdll/ep11_specific.h
@@ -343,6 +343,8 @@ typedef struct {
 #define REGEX_SUB_CARD_PATTERN  "[0-9a-fA-F]+\\.[0-9a-fA-F]+"
 #define MASK_EP11               0x04000000
 
+#define SYSFS_SEL_GUEST        "/sys/firmware/uv/prot_virt_guest"
+
 typedef struct {
     STDLL_TokData_t *tokdata;
     ep11_session_t *ep11_session;


### PR DESCRIPTION
Strict-session of VHSM mode uses the m_Login() function to login the respective EP11 sessions. In an Secure Execution for Linux guest only m_LoginExtended() with XCP_LOGIN_ALG_F2021 is supported, and can be correctly intercepted by the Ultravisor.

Reject the use of strict-session of VHSM mode when running in a Secure Execution for Linux guest.