### PR TITLE
COMMON: Fix AES-CTR counter width range checking

### DIFF
--- a/usr/lib/common/mech_openssl.c
+++ b/usr/lib/common/mech_openssl.c
@@ -3970,7 +3970,7 @@ CK_RV openssl_specific_aes_ctr(STDLL_TokData_t *tokdata,
 
     UNUSED(tokdata);
 
-    if (counter_width > AES_BLOCK_SIZE || counter_width == 0) {
+    if (counter_width > AES_BLOCK_SIZE * 8 || counter_width == 0) {
         TRACE_ERROR("%s\n", ock_err(ERR_ARGUMENTS_BAD));
         return CKR_ARGUMENTS_BAD;
     }


### PR DESCRIPTION
The range check for the AES-CTR counter width is off by a factor of 8.

According to the PKCS#11 standard, counter width is expressed in bits, and the range is supposed to be: 0 < ulCounterBits ≤ 128.

This affects the soft token, as well as the ICA token if the software fallback path is taken.

Closes: https://github.com/opencryptoki/opencryptoki/issues/881