### PR TITLE
COMMON/EP11: Fix keygen with CKM_RSA_X9_31_KEY_PAIR_GEN

### DIFF
--- a/testcases/crypto/rsa.h
+++ b/testcases/crypto/rsa.h
@@ -51,6 +51,7 @@ struct GENERATED_TEST_SUITE_INFO {
     unsigned int tvcount;
     struct RSA_GENERATED_TEST_VECTOR *tv;
     CK_MECHANISM mech;
+    CK_MECHANISM keygen_mech;
 };
 
 struct RSA_GENERATED_TEST_VECTOR rsa_oaep_generated_tv[] = {
@@ -340,12 +341,14 @@ struct GENERATED_TEST_SUITE_INFO generated_oaep_test_suites[] = {
         .tvcount = 29,
         .tv = rsa_oaep_generated_tv,
         .mech = {CKM_RSA_PKCS_OAEP, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     },
     {
         .name = "RSA AES KEY WRAP",
         .tvcount = 29,
         .tv = rsa_oaep_generated_tv,
         .mech = {CKM_RSA_AES_KEY_WRAP, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     }
 };
 
@@ -822,60 +825,70 @@ struct GENERATED_TEST_SUITE_INFO generated_pss_test_suites[] = {
         .tvcount = 16,
         .tv = rsa_pss_generated_tv,
         .mech = {CKM_RSA_PKCS_PSS, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     },
     {
         .name = "SHA1 RSA PKCS PSS",
         .tvcount = 4,
         .tv = sha1_rsa_pss_generated_tv,
         .mech = {CKM_SHA1_RSA_PKCS_PSS, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     },
     {
         .name = "SHA224 RSA PKCS PSS",
         .tvcount = 4,
         .tv = sha224_rsa_pss_generated_tv,
         .mech = {CKM_SHA224_RSA_PKCS_PSS, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     },
     {
         .name = "SHA256 RSA PKCS PSS",
         .tvcount = 4,
         .tv = sha256_rsa_pss_generated_tv,
         .mech = {CKM_SHA256_RSA_PKCS_PSS, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     },
     {
         .name = "SHA384 RSA PKCS PSS",
         .tvcount = 4,
         .tv = sha384_rsa_pss_generated_tv,
         .mech = {CKM_SHA384_RSA_PKCS_PSS, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     },
     {
         .name = "SHA512 RSA PKCS PSS",
         .tvcount = 4,
         .tv = sha512_rsa_pss_generated_tv,
         .mech = {CKM_SHA512_RSA_PKCS_PSS, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     },
     {
         .name = "SHA3-224 RSA PKCS PSS",
         .tvcount = 4,
         .tv = sha3_224_rsa_pss_generated_tv,
         .mech = {CKM_SHA3_224_RSA_PKCS_PSS, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     },
     {
         .name = "SHA3-256 RSA PKCS PSS",
         .tvcount = 4,
         .tv = sha3_256_rsa_pss_generated_tv,
         .mech = {CKM_SHA3_256_RSA_PKCS_PSS, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     },
     {
         .name = "SHA3-384 RSA PKCS PSS",
         .tvcount = 4,
         .tv = sha3_384_rsa_pss_generated_tv,
         .mech = {CKM_SHA3_384_RSA_PKCS_PSS, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     },
     {
         .name = "SHA3-512 RSA PKCS PSS",
         .tvcount = 4,
         .tv = sha3_512_rsa_pss_generated_tv,
         .mech = {CKM_SHA3_512_RSA_PKCS_PSS, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     }
 };
 
@@ -887,30 +900,35 @@ struct GENERATED_TEST_SUITE_INFO generated_pss_update_test_suites[] = {
         .tvcount = 4,
         .tv = sha1_rsa_pss_generated_tv,
         .mech = {CKM_SHA1_RSA_PKCS_PSS, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     },
     {
         .name = "SHA224 RSA PKCS PSS",
         .tvcount = 4,
         .tv = sha224_rsa_pss_generated_tv,
         .mech = {CKM_SHA224_RSA_PKCS_PSS, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     },
     {
         .name = "SHA256 RSA PKCS PSS",
         .tvcount = 4,
         .tv = sha256_rsa_pss_generated_tv,
         .mech = {CKM_SHA256_RSA_PKCS_PSS, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     },
     {
         .name = "SHA384 RSA PKCS PSS",
         .tvcount = 4,
         .tv = sha384_rsa_pss_generated_tv,
         .mech = {CKM_SHA384_RSA_PKCS_PSS, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     },
     {
         .name = "SHA512 RSA PKCS PSS",
         .tvcount = 4,
         .tv = sha512_rsa_pss_generated_tv,
         .mech = {CKM_SHA512_RSA_PKCS_PSS, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     }
 };
 
@@ -1842,12 +1860,14 @@ struct GENERATED_TEST_SUITE_INFO generated_keywrap_test_suites[] = {
         .tvcount = 74,
         .tv = rsa_keywrap_generated_tv,
         .mech = {CKM_RSA_PKCS, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     },
     {
         .name = "RSA X.509",
         .tvcount = 74,
         .tv = rsa_keywrap_generated_tv,
         .mech = {CKM_RSA_X_509, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     }
 };
 
@@ -1859,78 +1879,91 @@ struct GENERATED_TEST_SUITE_INFO generated_sigver_test_suites[] = {
         .tvcount = 30,
         .tv = rsa_generated_tv,
         .mech = {CKM_RSA_PKCS, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     },
     {
         .name = "RSA SHA1 PKCS",
         .tvcount = 30,
         .tv = rsa_generated_tv,
         .mech = {CKM_SHA1_RSA_PKCS, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     },
     {
         .name = "RSA SHA224 PKCS",
         .tvcount = 30,
         .tv = rsa_generated_tv,
         .mech = {CKM_SHA224_RSA_PKCS, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     },
     {
         .name = "RSA SHA256 PKCS",
         .tvcount = 30,
         .tv = rsa_generated_tv,
         .mech = {CKM_SHA256_RSA_PKCS, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     },
     {
         .name = "RSA SHA384 PKCS",
         .tvcount = 30,
         .tv = rsa_generated_tv,
         .mech = {CKM_SHA384_RSA_PKCS, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     },
     {
         .name = "RSA SHA512 PKCS",
         .tvcount = 30,
         .tv = rsa_generated_tv,
         .mech = {CKM_SHA512_RSA_PKCS, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     },
     {
         .name = "RSA SHA3-224 PKCS",
         .tvcount = 30,
         .tv = rsa_generated_tv,
         .mech = {CKM_SHA3_224_RSA_PKCS, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     },
     {
         .name = "RSA SHA3-256 PKCS",
         .tvcount = 30,
         .tv = rsa_generated_tv,
         .mech = {CKM_SHA3_256_RSA_PKCS, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     },
     {
         .name = "RSA SHA3-384 PKCS",
         .tvcount = 30,
         .tv = rsa_generated_tv,
         .mech = {CKM_SHA3_384_RSA_PKCS, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     },
     {
         .name = "RSA SHA3-512 PKCS",
         .tvcount = 30,
         .tv = rsa_generated_tv,
         .mech = {CKM_SHA3_512_RSA_PKCS, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     },
     {
         .name = "RSA MD2 PKCS",
         .tvcount = 30,
         .tv = rsa_generated_tv,
         .mech = {CKM_MD2_RSA_PKCS, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     },
     {
         .name = "RSA MD5 PKCS",
         .tvcount = 30,
         .tv = rsa_generated_tv,
         .mech = {CKM_MD5_RSA_PKCS, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     },
     {
         .name = "RSA X.509",
         .tvcount = 30,
         .tv = rsa_x509_generated_tv,
         .mech = {CKM_RSA_X_509, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     }
 };
 
@@ -1942,47 +1975,61 @@ struct GENERATED_TEST_SUITE_INFO generated_sigver_update_test_suites[] = {
         .tvcount = 30,
         .tv = rsa_generated_tv,
         .mech = {CKM_SHA1_RSA_PKCS, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     },
     {
         .name = "RSA SHA224 PKCS",
         .tvcount = 30,
         .tv = rsa_generated_tv,
         .mech = {CKM_SHA224_RSA_PKCS, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     },
     {
         .name = "RSA SHA256 PKCS",
         .tvcount = 30,
         .tv = rsa_generated_tv,
         .mech = {CKM_SHA256_RSA_PKCS, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     },
     {
         .name = "RSA MD2 PKCS",
         .tvcount = 30,
         .tv = rsa_generated_tv,
         .mech = {CKM_MD2_RSA_PKCS, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     },
     {
         .name = "RSA MD5 PKCS",
         .tvcount = 30,
         .tv = rsa_generated_tv,
         .mech = {CKM_MD5_RSA_PKCS, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     }
 };
 
-#define NUM_OF_GENERATED_CRYPTO_TESTSUITES 2
+#define NUM_OF_GENERATED_CRYPTO_TESTSUITES 3
 struct GENERATED_TEST_SUITE_INFO generated_crypto_test_suites[] = {
     {
         .name = "RSA PKCS",
         .tvcount = 30 - 4, /* Last 4: zero bytes data, not poss. for encrypt */
         .tv = rsa_generated_tv,
         .mech = {CKM_RSA_PKCS, 0, 0},
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
     },
     {
         .name = "RSA X.509",
         .tvcount = 30 - 4, /* Last 4: zero bytes data, not poss. for encrypt */
         .tv = rsa_x509_generated_tv,
         .mech = {CKM_RSA_X_509, 0, 0},
-    }
+        .keygen_mech = {CKM_RSA_PKCS_KEY_PAIR_GEN, 0, 0},
+    },
+    {
+        .name = "RSA PKCS (X9.31 KeyGen)",
+        .tvcount = 30 - 4, /* Last 4: zero bytes data, not poss. for encrypt */
+        .tv = rsa_generated_tv,
+        .mech = {CKM_RSA_PKCS, 0, 0},
+        .keygen_mech = {CKM_RSA_X9_31_KEY_PAIR_GEN, 0, 0},
+    },
 };
 
 struct RSA_PUBLISHED_TEST_VECTOR {

--- a/testcases/crypto/rsa_func.c
+++ b/testcases/crypto/rsa_func.c
@@ -83,6 +83,14 @@ CK_RV do_EncryptDecryptRSA(struct GENERATED_TEST_SUITE_INFO *tsuite)
                        (unsigned int) tsuite->mech.mechanism);
         goto testcase_cleanup;
     }
+    if (!mech_supported(slot_id, tsuite->keygen_mech.mechanism)) {
+        testsuite_skip(tsuite->tvcount,
+                       "Slot %u doesn't support %s (0x%x)",
+                       (unsigned int) slot_id,
+                       mech_to_str(tsuite->keygen_mech.mechanism),
+                       (unsigned int) tsuite->keygen_mech.mechanism);
+        goto testcase_cleanup;
+    }
     // iterate over test vectors
     for (i = 0; i < tsuite->tvcount; i++) {
 
@@ -214,6 +222,7 @@ CK_RV do_EncryptDecryptRSA(struct GENERATED_TEST_SUITE_INFO *tsuite)
 
         // generate key pair
         rc = generate_RSA_PKCS_KeyPair_cached(session,
+                                              tsuite->keygen_mech.mechanism,
                                               tsuite->tv[i].modbits,
                                               tsuite->tv[i].publ_exp,
                                               tsuite->tv[i].publ_exp_len,
@@ -812,6 +821,14 @@ CK_RV do_SignVerifyRSA(struct GENERATED_TEST_SUITE_INFO * tsuite,
                        (unsigned int) tsuite->mech.mechanism);
         goto testcase_cleanup;
     }
+    if (!mech_supported(slot_id, tsuite->keygen_mech.mechanism)) {
+        testsuite_skip(tsuite->tvcount,
+                       "Slot %u doesn't support %s (0x%x)",
+                       (unsigned int) slot_id,
+                       mech_to_str(tsuite->keygen_mech.mechanism),
+                       (unsigned int) tsuite->keygen_mech.mechanism);
+        goto testcase_cleanup;
+    }
     if (recover_mode) {
         if (!mech_supported_flags(slot_id, tsuite->mech.mechanism,
                                   CKF_SIGN_RECOVER | CKF_VERIFY_RECOVER)) {
@@ -928,6 +945,7 @@ CK_RV do_SignVerifyRSA(struct GENERATED_TEST_SUITE_INFO * tsuite,
 
         // generate key pair
         rc = generate_RSA_PKCS_KeyPair_cached(session,
+                                              tsuite->keygen_mech.mechanism,
                                               tsuite->tv[i].modbits,
                                               tsuite->tv[i].publ_exp,
                                               tsuite->tv[i].publ_exp_len,
@@ -1091,6 +1109,14 @@ CK_RV do_SignVerify_RSAPSS(struct GENERATED_TEST_SUITE_INFO * tsuite)
                        (unsigned int) tsuite->mech.mechanism);
         goto testcase_cleanup;
     }
+    if (!mech_supported(slot_id, tsuite->keygen_mech.mechanism)) {
+        testsuite_skip(tsuite->tvcount,
+                       "Slot %u doesn't support %s (0x%x)",
+                       (unsigned int) slot_id,
+                       mech_to_str(tsuite->keygen_mech.mechanism),
+                       (unsigned int) tsuite->keygen_mech.mechanism);
+        goto testcase_cleanup;
+    }
     // iterate over test vectors
     for (i = 0; i < tsuite->tvcount; i++) {
 
@@ -1149,7 +1175,9 @@ CK_RV do_SignVerify_RSAPSS(struct GENERATED_TEST_SUITE_INFO * tsuite)
         message_len = tsuite->tv[i].inputlen;
 
         // generate key pair
-        rc = generate_RSA_PKCS_KeyPair_cached(session, tsuite->tv[i].modbits,
+        rc = generate_RSA_PKCS_KeyPair_cached(session,
+                                              tsuite->keygen_mech.mechanism,
+                                              tsuite->tv[i].modbits,
                                               tsuite->tv[i].publ_exp,
                                               tsuite->tv[i].publ_exp_len,
                                               &publ_key, &priv_key);
@@ -1315,6 +1343,14 @@ CK_RV do_WrapUnwrapRSA(struct GENERATED_TEST_SUITE_INFO * tsuite)
         testsuite_skip(tsuite->tvcount,
                        "Slot %u doesn't support key wrapping",
                        (unsigned int) slot_id);
+        goto testcase_cleanup;
+    }
+    if (!mech_supported(slot_id, tsuite->keygen_mech.mechanism)) {
+        testsuite_skip(tsuite->tvcount,
+                       "Slot %u doesn't support %s (0x%x)",
+                       (unsigned int) slot_id,
+                       mech_to_str(tsuite->keygen_mech.mechanism),
+                       (unsigned int) tsuite->keygen_mech.mechanism);
         goto testcase_cleanup;
     }
 
@@ -1496,7 +1532,9 @@ CK_RV do_WrapUnwrapRSA(struct GENERATED_TEST_SUITE_INFO * tsuite)
         wrapped_keylen = 0;
 
         // generate RSA key pair
-        rc = generate_RSA_PKCS_KeyPair_cached(session, tsuite->tv[i].modbits,
+        rc = generate_RSA_PKCS_KeyPair_cached(session,
+                                              tsuite->keygen_mech.mechanism,
+                                              tsuite->tv[i].modbits,
                                               tsuite->tv[i].publ_exp,
                                               tsuite->tv[i].publ_exp_len,
                                               &publ_key, &priv_key);

--- a/testcases/crypto/rsaupdate_func.c
+++ b/testcases/crypto/rsaupdate_func.c
@@ -77,6 +77,14 @@ CK_RV do_SignVerifyUpdateRSA(struct GENERATED_TEST_SUITE_INFO *tsuite)
                        (unsigned int) tsuite->mech.mechanism);
         goto testcase_cleanup;
     }
+    if (!mech_supported(slot_id, tsuite->keygen_mech.mechanism)) {
+        testsuite_skip(tsuite->tvcount,
+                       "Slot %u doesn't support %s (0x%x)",
+                       (unsigned int) slot_id,
+                       mech_to_str(tsuite->keygen_mech.mechanism),
+                       (unsigned int) tsuite->keygen_mech.mechanism);
+        goto testcase_cleanup;
+    }
 
     // iterate over test vectors
     for (i = 0; i < tsuite->tvcount; i++) {
@@ -182,6 +190,7 @@ CK_RV do_SignVerifyUpdateRSA(struct GENERATED_TEST_SUITE_INFO *tsuite)
 
         // generate key pair
         rc = generate_RSA_PKCS_KeyPair_cached(session,
+                                              tsuite->keygen_mech.mechanism,
                                               tsuite->tv[i].modbits,
                                               tsuite->tv[i].publ_exp,
                                               tsuite->tv[i].publ_exp_len,
@@ -364,6 +373,14 @@ CK_RV do_SignVerifyUpdate_RSAPSS(struct GENERATED_TEST_SUITE_INFO * tsuite)
                        (unsigned int) tsuite->mech.mechanism);
         goto testcase_cleanup;
     }
+    if (!mech_supported(slot_id, tsuite->keygen_mech.mechanism)) {
+        testsuite_skip(tsuite->tvcount,
+                       "Slot %u doesn't support %s (0x%x)",
+                       (unsigned int) slot_id,
+                       mech_to_str(tsuite->keygen_mech.mechanism),
+                       (unsigned int) tsuite->keygen_mech.mechanism);
+        goto testcase_cleanup;
+    }
     // iterate over test vectors
     for (i = 0; i < tsuite->tvcount; i++) {
 
@@ -435,6 +452,7 @@ CK_RV do_SignVerifyUpdate_RSAPSS(struct GENERATED_TEST_SUITE_INFO * tsuite)
 
         // generate key pair
         rc = generate_RSA_PKCS_KeyPair_cached(session,
+                                              tsuite->keygen_mech.mechanism,
                                               tsuite->tv[i].modbits,
                                               tsuite->tv[i].publ_exp,
                                               tsuite->tv[i].publ_exp_len,

--- a/testcases/misc_tests/cca_ep11_export_import_test.c
+++ b/testcases/misc_tests/cca_ep11_export_import_test.c
@@ -1307,8 +1307,8 @@ static CK_RV rsa_export_import_tests(void)
 
         // create ock rsa keypair
 
-        rc = generate_RSA_PKCS_KeyPair(session, keybitlen,
-                                       exp, sizeof(exp),
+        rc = generate_RSA_PKCS_KeyPair(session, CKM_RSA_PKCS_KEY_PAIR_GEN,
+                                       keybitlen, exp, sizeof(exp),
                                        &publ_key, &priv_key);
         if (rc != CKR_OK) {
             if (rc == CKR_KEY_SIZE_RANGE) {

--- a/testcases/misc_tests/reencrypt.c
+++ b/testcases/misc_tests/reencrypt.c
@@ -403,7 +403,8 @@ CK_RV do_reencrypt(struct mech_info *mech1, struct mech_info *mech2)
                 goto testcase_cleanup;
             }
         }
-        rc = generate_RSA_PKCS_KeyPair(session, mech2->rsa_modbits,
+        rc = generate_RSA_PKCS_KeyPair(session, CKM_RSA_PKCS_KEY_PAIR_GEN,
+                                       mech2->rsa_modbits,
                                        mech2->rsa_publ_exp,
                                        mech2->rsa_publ_exp_len,
                                        &publ_key2, &priv_key2);
@@ -657,7 +658,8 @@ CK_RV do_encrypt_reencrypt(struct mech_info *mech1)
                 goto testcase_cleanup;
             }
         }
-        rc = generate_RSA_PKCS_KeyPair(session, mech1->rsa_modbits,
+        rc = generate_RSA_PKCS_KeyPair(session, CKM_RSA_PKCS_KEY_PAIR_GEN,
+                                       mech1->rsa_modbits,
                                        mech1->rsa_publ_exp,
                                        mech1->rsa_publ_exp_len,
                                        &publ_key1, &priv_key1);

--- a/testcases/misc_tests/tok2tok_transport.c
+++ b/testcases/misc_tests/tok2tok_transport.c
@@ -867,7 +867,8 @@ CK_RV do_wrap_key_test(struct wrapped_mech_info *tsuite,
             }
         }
 
-        rc = generate_RSA_PKCS_KeyPair(session1, tsuite->rsa_modbits,
+        rc = generate_RSA_PKCS_KeyPair(session1, CKM_RSA_PKCS_KEY_PAIR_GEN,
+                                       tsuite->rsa_modbits,
                                        tsuite->rsa_publ_exp,
                                        tsuite->rsa_publ_exp_len,
                                        &publ_key, &priv_key);
@@ -1342,7 +1343,8 @@ CK_RV do_wrapping_test(struct wrapping_mech_info *tsuite)
                 goto testcase_cleanup;
             }
         }
-        rc = generate_RSA_PKCS_KeyPair(session2, tsuite->rsa_modbits,
+        rc = generate_RSA_PKCS_KeyPair(session2, CKM_RSA_PKCS_KEY_PAIR_GEN,
+                                       tsuite->rsa_modbits,
                                        tsuite->rsa_publ_exp,
                                        tsuite->rsa_publ_exp_len,
                                        &publ_wrap_key2, &priv_wrap_key2);

--- a/usr/lib/common/utility.c
+++ b/usr/lib/common/utility.c
@@ -975,6 +975,7 @@ CK_RV pkcsget_keytype_for_mech(CK_MECHANISM_TYPE mech, CK_KEY_TYPE *keytype,
         *alt_keytype = CKK_SHA3_512_HMAC;
         break;
     case CKM_RSA_PKCS_KEY_PAIR_GEN:
+    case CKM_RSA_X9_31_KEY_PAIR_GEN:
         *keytype = CKK_RSA;
         break;
     case CKM_EC_KEY_PAIR_GEN:


### PR DESCRIPTION
Add CKM_RSA_X9_31_KEY_PAIR_GEN to function pkcsget_keytype_for_mech() so that a key gen with CKM_RSA_X9_31_KEY_PAIR_GEN can get the key type.

This fixes the EP11 token returning CKR_MECHANISM_INVALID on a key pair gen with CKM_RSA_X9_31_KEY_PAIR_GEN. Currently only the EP11 token supports CKM_RSA_X9_31_KEY_PAIR_GEN at all.