### PR TITLE
COMMON: Fix decoding of DH private key

### DIFF
--- a/usr/lib/common/asn1.c
+++ b/usr/lib/common/asn1.c
@@ -3273,7 +3273,7 @@ CK_RV ber_decode_DHPrivateKey(CK_BYTE *data,
     }
     // extract the parameter data into ATTRIBUTES
     //
-    rc = ber_decode_SEQUENCE(alg + ber_idDSALen, &buf, &buf_len, &field_len);
+    rc = ber_decode_SEQUENCE(alg + ber_idDHLen, &buf, &buf_len, &field_len);
     if (rc != CKR_OK) {
         TRACE_DEVEL("ber_decode_SEQUENCE failed\n");
         return rc;


### PR DESCRIPTION
Use the correct object ID length as offset to the alg-id parameters.

Fixes: aa32d071cd46 ("EP11: Add key import for DH keys")