### PR TITLE
PKCSSLOTD: Remove the use of MD5

### DIFF
--- a/usr/sbin/pkcsslotd/pkcsslotd.h
+++ b/usr/sbin/pkcsslotd/pkcsslotd.h
@@ -42,11 +42,7 @@
 
 #endif                          /* DEV */
 
-#define HASH_SHA1   1
-#define HASH_MD5    2
-#define compute_md5(a,b,c)      compute_hash(HASH_MD5,b,a,c)
-
-int compute_hash(int hash_type, int buf_size, char *buf, char *digest);
+int compute_sha256(char *buf, int buf_size, char *digest);
 
 /********************
  * Global Variables *

--- a/usr/sbin/pkcsslotd/slotmgr.c
+++ b/usr/sbin/pkcsslotd/slotmgr.c
@@ -27,7 +27,7 @@
 #include "configuration.h"
 
 #define OBJ_DIR "TOK_OBJ"
-#define MD5_HASH_SIZE 16
+#define SHA256_HASH_SIZE 32
 
 #define DEF_MANUFID "IBM"
 
@@ -44,8 +44,8 @@
     #define DEF_SLOTDESC    "Linux"
 #endif
 
-typedef char md5_hash_entry[MD5_HASH_SIZE];
-md5_hash_entry tokname_hash_table[NUMBER_SLOTS_MANAGED];
+typedef char sha256_hash_entry[SHA256_HASH_SIZE];
+sha256_hash_entry tokname_hash_table[NUMBER_SLOTS_MANAGED];
 
 Slot_Mgr_Shr_t *shmp;           // pointer to the shared memory region.
 int shmid;
@@ -86,27 +86,19 @@ void DumpSharedMemory(void)
     }
 }
 
-int compute_hash(int hash_type, int buf_size, char *buf, char *digest)
+int compute_sha256(char *buf, int buf_size, char *digest)
 {
     EVP_MD_CTX *md_ctx = NULL;
     unsigned int result_size;
     int rc;
 
     md_ctx = EVP_MD_CTX_create();
-
-    switch (hash_type) {
-    case HASH_SHA1:
-        rc = EVP_DigestInit(md_ctx, EVP_sha1());
-        break;
-    case HASH_MD5:
-        rc = EVP_DigestInit(md_ctx, EVP_md5());
-        break;
-    default:
-        EVP_MD_CTX_destroy(md_ctx);
+    if (md_ctx == NULL) {
+        fprintf(stderr, "EVP_MD_CTX_create() failed\n");
         return -1;
-        break;
     }
 
+    rc = EVP_DigestInit(md_ctx, EVP_sha256());
     if (rc != 1) {
         fprintf(stderr, "EVP_DigestInit() failed: rc = %d\n", rc);
         return -1;
@@ -374,12 +366,12 @@ void run_sanity_checks(void)
     }
 }
 
-int is_duplicate(md5_hash_entry hash, md5_hash_entry *hash_table)
+int is_duplicate(sha256_hash_entry hash, sha256_hash_entry *hash_table)
 {
     int i;
 
     for (i = 0; i < NUMBER_SLOTS_MANAGED; i++) {
-        if (memcmp(hash_table[i], hash, sizeof(md5_hash_entry)) == 0)
+        if (memcmp(hash_table[i], hash, sizeof(sha256_hash_entry)) == 0)
             return 1;
     }
 
@@ -483,7 +475,7 @@ int chk_create_tokdir(Slot_Info_t_64 *psinfo)
     mode_t proc_umask;
     char *tokdir = psinfo->tokname;
     char *tokgroup = psinfo->usergroup;
-    char token_md5_hash[MD5_HASH_SIZE];
+    char token_sha256_hash[SHA256_HASH_SIZE];
 
     if (psinfo->present == FALSE)
         return 0;
@@ -517,26 +509,26 @@ int chk_create_tokdir(Slot_Info_t_64 *psinfo)
      */
     if (!tokdir || strlen(tokdir) == 0) {
         /*
-         * Build the md5 hash from the dll name prefixed with 'dll:' to
+         * Build the SHA256 hash from the dll name prefixed with 'dll:' to
          * check for duplicate tokens with no 'tokname'.
          */
         snprintf(tokendir, sizeof(tokendir), "dll:%s", psinfo->dll_location);
-        rc = compute_md5(tokendir, strlen(tokendir), token_md5_hash);
+        rc = compute_sha256(tokendir, strlen(tokendir), token_sha256_hash);
         if (rc) {
-            fprintf(stderr, "Error calculating MD5 of token name!\n");
+            fprintf(stderr, "Error calculating SHA256 of token name!\n");
             return -1;
         }
 
         /* check for duplicate token names */
-        if (is_duplicate(token_md5_hash, tokname_hash_table)) {
+        if (is_duplicate(token_sha256_hash, tokname_hash_table)) {
             fprintf(stderr, "Duplicate token in slot %llu!\n",
                     psinfo->slot_number);
             return -1;
         }
 
         /* add entry into hash table */
-        memcpy(tokname_hash_table[psinfo->slot_number], token_md5_hash,
-               MD5_HASH_SIZE);
+        memcpy(tokname_hash_table[psinfo->slot_number], token_sha256_hash,
+               SHA256_HASH_SIZE);
 
         return 0;
     }
@@ -549,21 +541,21 @@ int chk_create_tokdir(Slot_Info_t_64 *psinfo)
         return -1;
     }
 
-    /* calculate md5 hash from token name */
-    rc = compute_md5(tokdir, strlen(tokdir), token_md5_hash);
+    /* calculate SHA256 hash from token name */
+    rc = compute_sha256(tokdir, strlen(tokdir), token_sha256_hash);
     if (rc) {
-        fprintf(stderr, "Error calculating MD5 of token name!\n");
+        fprintf(stderr, "Error calculating SHA256 of token name!\n");
         return -1;
     }
     /* check for duplicate token names */
-    if (is_duplicate(token_md5_hash, tokname_hash_table)) {
+    if (is_duplicate(token_sha256_hash, tokname_hash_table)) {
         fprintf(stderr, "Duplicate token name '%s'!\n", tokdir);
         return -1;
     }
 
     /* add entry into hash table */
-    memcpy(tokname_hash_table[psinfo->slot_number], token_md5_hash,
-           MD5_HASH_SIZE);
+    memcpy(tokname_hash_table[psinfo->slot_number], token_sha256_hash,
+           SHA256_HASH_SIZE);
 
     /* Create token specific directory */
     /* sprintf checked above */


### PR DESCRIPTION
The pkcsslotd uses MD5 to calculate kind of a checksum of the token directory path, for easy checking if the same token directory has already been used by other tokens.

The use of MD5 for this is just historical, and has no security relevance at all. Still, OpenSSL running in FIPS mode might reject the use of MD5, so pkcsslotd will fail to start.

Change the code to use SHA256 instead.