### PR TITLE
CCA: Trim RSA public exponent when retrieved from CCA key tokens

### DIFF
--- a/usr/lib/cca_stdll/cca_specific.c
+++ b/usr/lib/cca_stdll/cca_specific.c
@@ -5382,6 +5382,7 @@ static CK_RV cca_rsa_inttok_privkeysec_get_n(CK_BYTE *sec, CK_ULONG *n_len, CK_B
 static CK_RV cca_rsa_inttok_pubkeysec_get_e(CK_BYTE *sec, CK_ULONG *e_len, CK_BYTE *e)
 {
     uint16_t e_length;
+    CK_BYTE *p;
 
     if (sec[0] != 0x04) {
         TRACE_ERROR("Invalid public key section identifier 0x%02hhx\n", sec[0]);
@@ -5395,8 +5396,9 @@ static CK_RV cca_rsa_inttok_pubkeysec_get_e(CK_BYTE *sec, CK_ULONG *e_len, CK_BY
         return CKR_FUNCTION_FAILED;
     }
 
-    memcpy(e, &sec[CCA_RSA_INTTOK_PUBKEY_E_OFFSET], (size_t) e_length);
-    *e_len = (CK_ULONG) e_length;
+    *e_len = e_length;
+    p = p11_bigint_trim(&sec[CCA_RSA_INTTOK_PUBKEY_E_OFFSET], e_len);
+    memcpy(e, p, *e_len);
 
     return CKR_OK;
 }
@@ -5435,6 +5437,7 @@ static CK_RV cca_rsa_exttok_pubkeysec_get_n(CK_BYTE *sec, CK_ULONG *n_len, CK_BY
 static CK_RV cca_rsa_exttok_pubkeysec_get_e(CK_BYTE *sec, CK_ULONG *e_len, CK_BYTE *e)
 {
     uint16_t e_length;
+    CK_BYTE *p;
 
     if (sec[0] != 0x04) {
         TRACE_ERROR("Invalid public key section identifier 0x%02hhx\n", sec[0]);
@@ -5448,8 +5451,9 @@ static CK_RV cca_rsa_exttok_pubkeysec_get_e(CK_BYTE *sec, CK_ULONG *e_len, CK_BY
         return CKR_FUNCTION_FAILED;
     }
 
-    memcpy(e, &sec[CCA_RSA_INTTOK_PUBKEY_E_OFFSET], (size_t) e_length);
-    *e_len = (CK_ULONG) e_length;
+    *e_len = e_length;
+    p = p11_bigint_trim(&sec[CCA_RSA_INTTOK_PUBKEY_E_OFFSET], e_len);
+    memcpy(e, p, *e_len);
 
     return CKR_OK;
 }


### PR DESCRIPTION
During RSA key generation as well as during RSA key blob import, the public key attributes CKA_MODULUS and CKA_PUBLIC_EXPONENT are populated by retrieving the respective values from the private or public secure key token section.

The key components inside a CCA private or public secure key token section might be padded with binary zeros on the left, and the length information contained in the key token includes this padding. This is especially the case for the public exponent.

Because the RSA key components are big endian integers, leading zeros do not change the numerical value. However attributes such as CKA_PUBLIC_EXPONENT should contain the numerical value without any leading zeros.

Trim the public exponent value to remove any leading zeros for the public exponent value. The modulus value and length is left as is, because the modulus length is always exactly the bit size of the RSA key. Even if the modulus value would ever contain leading zeros, the modulus length should be kept as is.