### PR TITLE
EP11: Fix concurrent MK change for Kyber-KEM using C_DeriveKey

### DIFF
--- a/usr/lib/ep11_stdll/ep11_specific.c
+++ b/usr/lib/ep11_stdll/ep11_specific.c
@@ -7531,6 +7531,11 @@ static CK_RV ep11tok_kyber_mech_pre_process(STDLL_TokData_t *tokdata,
     }
 
     if (kyber_params->hSecret != CK_INVALID_HANDLE) {
+        if (*secret_key_obj != NULL) {
+            object_put(tokdata, *secret_key_obj, TRUE);
+            *secret_key_obj = NULL;
+        }
+
         rc = h_opaque_2_blob(tokdata, kyber_params->hSecret,
                              &mech_ep11->params.pBlob,
                              &mech_ep11->params.ulBlobLen,


### PR DESCRIPTION
When the operation is repeated because of CKR_IBM_WKID_MISMATCH, then the secret key object has already been acquired and locked by the first try. Unlock the object first, before attempting to acquired and lock it again. Otherwise the object might get locked twice, but is unlocked only once, thus it stays locked after the derive processing has finished.

Fixes: 91ecd8214aafd585a26cd6a6b8ab38885911c004