### PR TITLE
P11SAK/P11KMIP: Adjustments for OpenSSL v4.0.0 API changes and deprecations

### DIFF
--- a/usr/sbin/p11kmip/kmipclient/tls.c
+++ b/usr/sbin/p11kmip/kmipclient/tls.c
@@ -379,8 +379,14 @@ int kmip_connection_tls_init(struct kmip_connection *conn, bool debug)
 	if (conn->config.tls_verify_host) {
 		SSL_set_hostflags(conn->plain_tls.ssl,
 				  X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
+#if OPENSSL_VERSION_PREREQ(4, 0)
+		if (SSL_set1_ipaddr(conn->plain_tls.ssl, hostname) != 1 &&
+		    SSL_set1_dnsname(conn->plain_tls.ssl, hostname) != 1) {
+			kmip_debug(debug, "SSL_set1_ipaddr/dnsname failed");
+#else
 		if (SSL_set1_host(conn->plain_tls.ssl, hostname) != 1) {
 			kmip_debug(debug, "SSL_set1_host failed");
+#endif
 			if (debug)
 				ERR_print_errors_fp(stderr);
 			rc = -EIO;

--- a/usr/sbin/p11kmip/p11kmip.c
+++ b/usr/sbin/p11kmip/p11kmip.c
@@ -1193,8 +1193,12 @@ int p11kmip_check_certificate(const char *cert_file,
     *self_signed = (X509_NAME_cmp(X509_get_subject_name(cert),
                                   X509_get_issuer_name(cert)) == 0);
 
+#if OPENSSL_VERSION_PREREQ(4, 0)
+    *valid = X509_check_certificate_times(NULL, cert, NULL);
+#else
     *valid = (X509_cmp_current_time(X509_get0_notBefore(cert)) < 0 &&
               X509_cmp_current_time(X509_get0_notAfter(cert)) > 0);
+#endif
 
     X509_free(cert);
 

--- a/usr/sbin/p11sak/p11sak.c
+++ b/usr/sbin/p11sak/p11sak.c
@@ -6373,7 +6373,11 @@ static CK_RV p11sak_import_x509_attrs(const struct p11tool_objtype *certtype,
 {
     ASN1_INTEGER *serialno;
     unsigned char *serial_buf = NULL;
+#if OPENSSL_VERSION_PREREQ(4, 0)
+    const X509_NAME *name;
+#else
     X509_NAME *name;
+#endif
     const unsigned char *subj_name = NULL, *issuer_name = NULL;
     size_t subj_name_len, issuer_name_len;
     CK_BYTE *value_buf = NULL;
@@ -6505,7 +6509,11 @@ static CK_RV p11sak_extract_x509_pk(const struct p11tool_objtype *certtype,
     CK_ATTRIBUTE id_attr = { CKA_ID, NULL, 0 };
     const CK_BYTE *tmp_ptr;
     const unsigned char *subj_name = NULL;
+#if OPENSSL_VERSION_PREREQ(4, 0)
+    const X509_NAME *name = NULL;
+#else
     X509_NAME *name = NULL;
+#endif
     size_t subj_name_len;
     char *pubkey_label = NULL;
     X509 *x509 = NULL;


### PR DESCRIPTION
1. OpenSSL function `X509_get_subject_name()` now returns a const `X509_NAME` pointer starting with OpenSSL 4.0. Constify the receiving variable.
2. OpenSSL function `X509_cmp_current_time()` is deprecated with OpenSSL 4.0, use `X509_check_certificate_times()` instead.
3. OpenSSL function `SSL_set1_host()` is deprecated with OpenSSL 4.0, use `SSL_set1_ipaddr()` and `SSL_set1_dnsname()` instead.