### PR TITLE
CCA: Support additional RSA public exponent values

### DIFF
--- a/testcases/common/common.c
+++ b/testcases/common/common.c
@@ -2028,10 +2028,22 @@ int is_ep11_token(CK_SLOT_ID slot_id)
 int is_valid_cca_pubexp(CK_BYTE pubexp[], CK_ULONG pubexp_len)
 {
     CK_BYTE exp3[] = { 0x03 };  // 3
+    CK_BYTE exp5[] = { 0x05 };  // 5
+    CK_BYTE exp17[] = { 0x11 };  // 17
+    CK_BYTE exp257[] = { 0x01, 0x01 };  // 257
     CK_BYTE exp65537[] = { 0x01, 0x00, 0x01 };  // 65537
 
-    return (pubexp_len == 1 && (!memcmp(pubexp, exp3, 1)))
-        || (pubexp_len == 3 && (!memcmp(pubexp, exp65537, 3)));
+    // trim any leading zero bytes
+    while (pubexp_len > 1 && pubexp[0] == 0x00) {
+        pubexp++;
+        pubexp_len--;
+    }
+
+    return (pubexp_len == 1 && (!memcmp(pubexp, exp3, 1))) ||
+           (pubexp_len == 1 && (!memcmp(pubexp, exp5, 1))) ||
+           (pubexp_len == 1 && (!memcmp(pubexp, exp17, 1))) ||
+           (pubexp_len == 2 && (!memcmp(pubexp, exp257, 2))) ||
+           (pubexp_len == 3 && (!memcmp(pubexp, exp65537, 3)));
 }
 
 /** Returns true if pubexp is valid for Soft Tokens **/

--- a/testcases/crypto/rsa_func.c
+++ b/testcases/crypto/rsa_func.c
@@ -133,8 +133,7 @@ CK_RV do_EncryptDecryptRSA(struct GENERATED_TEST_SUITE_INFO *tsuite)
             }
         }
         // cca special cases:
-        // cca token can only use the following public exponents
-        // 0x03 or 0x010001 (65537)
+        // cca token can only use a few public exponents
         // so skip test if invalid public exponent is used
         if (is_cca_token(slot_id)) {
             if (!is_valid_cca_pubexp(tsuite->tv[i].publ_exp,
@@ -520,8 +519,7 @@ CK_RV do_EncryptDecryptImportRSA(struct PUBLISHED_TEST_SUITE_INFO *tsuite,
         }
 
         // cca special cases:
-        // cca token can only use the following public exponents
-        // 0x03 or 0x010001 (65537)
+        // cca token can only use a few public exponents
         // so skip test if invalid public exponent is used
         if (is_cca_token(slot_id)) {
             if (!is_valid_cca_pubexp(tsuite->tv[i].pub_exp,

--- a/usr/lib/cca_stdll/cca_specific.c
+++ b/usr/lib/cca_stdll/cca_specific.c
@@ -5813,9 +5813,12 @@ CK_RV token_specific_rsa_generate_keypair(STDLL_TokData_t * tokdata,
     rv = template_attribute_get_non_empty(publ_tmpl, CKA_PUBLIC_EXPONENT,
                                           &pub_exp);
     if (rv == CKR_OK) {
-        /* Per CCA manual, we really only support 3 values here:        *
+        /* Per CCA manual, we really only support 6 values here:        *
          * * 0 (generate random public exponent)                        *
          * * 3 or                                                       *
+         * * 5 (since CCA 5.2) or                                       *
+         * * 17 (since CCA 5.2) or                                      *
+         * * 257 (since CCA 5.2) or                                     *
          * * 65537                                                      *
          * Trim the P11 value so we can check what's comming our way    */
 
@@ -5823,8 +5826,10 @@ CK_RV token_specific_rsa_generate_keypair(STDLL_TokData_t * tokdata,
         ptr = p11_bigint_trim(pub_exp->pValue, &tmpsize);
         /* If we trimmed the number correctly, only 3 bytes are         *
          * sufficient to hold 65537 (0x010001)                          */
-        if (tmpsize > 3)
+        if (tmpsize > 3) {
+            TRACE_ERROR("Unsupported public exponent (too large)\n");
             return CKR_TEMPLATE_INCONSISTENT;
+        }
 
         /* make pValue into CK_ULONG so we can compare */
         tmpexp = 0;
@@ -5836,9 +5841,18 @@ CK_RV token_specific_rsa_generate_keypair(STDLL_TokData_t * tokdata,
             tmpexp = be32toh(tmpexp);
 
         /* Check for one of the three allowed values */
-        if ((tmpexp != 0) && (tmpexp != 3) && (tmpexp != 65537))
+        switch (tmpexp) {
+        case 0:
+        case 3:
+        case 5:
+        case 17:
+        case 257:
+        case 65537:
+            break;
+        default:
+            TRACE_ERROR("Unsupported public exponent\n");
             return CKR_TEMPLATE_INCONSISTENT;
-
+        }
 
         size_of_e = htobe16((uint16_t)tmpsize);
 


### PR DESCRIPTION
Since CCA v5.2 CCA supports public exponent values of 5, 17, or 257 in addition to 0 (random), 3 or 65537.

The CCA token requires CCA v7.1 or later at minimum, so those public exponent values can be assumed to be supported in any case.