### PR TITLE
SOFT: Ensure that a DH public key always has the size of the prime

### DIFF
--- a/usr/lib/soft_stdll/soft_specific.c
+++ b/usr/lib/soft_stdll/soft_specific.c
@@ -1227,9 +1227,14 @@ CK_RV token_specific_dh_pkcs_key_pair_gen(STDLL_TokData_t *tokdata,
     }
 #endif
 
-    temp_bn_len = BN_num_bytes(temp_bn);
-    temp_byte = malloc(temp_bn_len);
-    temp_bn_len = BN_bn2bin(temp_bn, temp_byte);
+    /* The public key is same size as the prime: pub_key = g^priv_key mod p */
+    temp_byte = malloc(prime_attr->ulValueLen);
+    temp_bn_len = BN_bn2binpad(temp_bn, temp_byte, prime_attr->ulValueLen);
+    if (temp_bn_len != prime_attr->ulValueLen) {
+        TRACE_ERROR("%s\n", ock_err(ERR_FUNCTION_FAILED));
+        rv = CKR_FUNCTION_FAILED;
+        goto done;
+    }
     // in bytes
     rv = build_attribute(CKA_VALUE, temp_byte, temp_bn_len, &temp_attr);
     if (rv != CKR_OK) {


### PR DESCRIPTION
The size of the DH public key value is the same as the size of the prime that was used to generated the key. The public key is calculated by

   pub_key = g^priv_key mod p

thus its size is the same as the modulus p (i.e the prime).

However, it can happen that for a specific key the number of significant bits of the public key is less than the number of prime bits, and thus the OpenSSL BIGNUM size is smaller than the prime, and this results in a CKA_VALUE attribute of the public key object with a smaller size, too.

This can lead to problems when the CKM_DH_PKCS_DERIVE mechanism is used with C_EncapsulateKey(). There an ephemeral DH key pair is generated internally, and the size of the public key determines the size of the cipher text buffer that must be supplied by the caller.

If on a size-query call of C_EncapsulateKey() with CKM_DH_PKCS_DERIVE a smaller public key is generated, then the cipher text buffer size returned to the caller is too mall, and might lead to CKR_BUFFER_TOO_SMALL on the next call to C_EncapsulateKey() with a too small buffer supplied by the caller.