### PR TITLE
Add unit and fuzzing tests for BER en-/decoding and object flatten/unflatten functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ testcases/unit/buffertest
 testcases/unit/uritest
 testcases/unit/pintest
 testcases/unit/asn1test
+testcases/unit/asn1fuzztest
 usr/sbin/p11sak/p11sak
 usr/sbin/p11kmip/p11kmip
 usr/sbin/pkcscca/pkcscca

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ testcases/unit/policytest
 testcases/unit/buffertest
 testcases/unit/uritest
 testcases/unit/pintest
+testcases/unit/asn1test
 usr/sbin/p11sak/p11sak
 usr/sbin/p11kmip/p11kmip
 usr/sbin/pkcscca/pkcscca

--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ testcases/unit/uritest
 testcases/unit/pintest
 testcases/unit/asn1test
 testcases/unit/asn1fuzztest
+testcases/unit/objectflattentest
 usr/sbin/p11sak/p11sak
 usr/sbin/p11kmip/p11kmip
 usr/sbin/pkcscca/pkcscca

--- a/testcases/unit/asn1fuzztest.c
+++ b/testcases/unit/asn1fuzztest.c
@@ -1,0 +1,886 @@
+/*
+ * COPYRIGHT (c) International Business Machines Corp. 2026
+ *
+ * This program is provided under the terms of the Common Public License,
+ * version 1.0 (CPL-1.0). Any use, reproduction or distribution for this
+ * software constitutes recipient's acceptance of CPL-1.0 terms which can be
+ * found in the file LICENSE file or at
+ * https://opensource.org/licenses/cpl1.0.php
+ */
+
+/*
+ * Fuzzing tests for BER encoding and decoding functions in asn1.c
+ *
+ * This test suite performs TRUE FUZZING on the BER encoding/decoding functions
+ * to identify potential crashes, memory leaks, and security vulnerabilities
+ * when processing completely random or specially crafted malformed inputs.
+ *
+ * NOTE: This complements asn1test.c which tests known valid/invalid cases.
+ * This file focuses on:
+ * - Random data generation and mutation
+ * - Stress testing with high iteration counts
+ * - Advanced malformation scenarios not covered in unit tests
+ * - Memory allocation stress
+ * - Deeply nested structures
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <stdint.h>
+
+#include "pkcs11types.h"
+#include "defs.h"
+#include "host_defs.h"
+#include "h_extern.h"
+
+/* Function prototypes from asn1.c */
+CK_ULONG ber_encode_INTEGER(CK_BBOOL length_only,
+                            CK_BYTE **ber_int,
+                            CK_ULONG *ber_int_len, CK_BYTE *data,
+                            CK_ULONG data_len);
+
+CK_RV ber_decode_INTEGER(CK_BYTE *ber_int, CK_ULONG ber_int_len,
+                         CK_BYTE **data, CK_ULONG *data_len,
+                         CK_ULONG *field_len);
+
+CK_RV ber_encode_OCTET_STRING(CK_BBOOL length_only,
+                              CK_BYTE **str,
+                              CK_ULONG *str_len, CK_BYTE *data,
+                              CK_ULONG data_len);
+
+CK_RV ber_decode_OCTET_STRING(CK_BYTE *str, CK_ULONG str_len,
+                              CK_BYTE **data,
+                              CK_ULONG *data_len, CK_ULONG *field_len);
+
+CK_ULONG ber_encode_BIT_STRING(CK_BBOOL length_only,
+                            CK_BYTE **ber_str,
+                            CK_ULONG *ber_str_len, CK_BYTE *data,
+                            CK_ULONG data_len,
+                            CK_BYTE unused_bits);
+
+CK_RV ber_decode_BIT_STRING(CK_BYTE *str, CK_ULONG str_len,
+                            CK_BYTE **data,
+                            CK_ULONG *data_len, CK_ULONG *field_len);
+
+CK_RV ber_encode_SEQUENCE(CK_BBOOL length_only,
+                          CK_BYTE **seq,
+                          CK_ULONG *seq_len, CK_BYTE *data, CK_ULONG data_len);
+
+CK_RV ber_decode_SEQUENCE(CK_BYTE *seq, CK_ULONG seq_len,
+                          CK_BYTE **data, CK_ULONG *data_len,
+                          CK_ULONG *field_len);
+
+CK_RV ber_encode_CHOICE(CK_BBOOL length_only,
+                        CK_BYTE option,
+                        CK_BYTE **str,
+                        CK_ULONG *str_len, CK_BYTE *data, CK_ULONG data_len,
+                        CK_BBOOL constructed);
+
+CK_RV ber_decode_CHOICE(CK_BYTE *choice, CK_ULONG choice_len,
+                        CK_BBOOL constructed,
+                        CK_BYTE **data,
+                        CK_ULONG *data_len, CK_ULONG *field_len,
+                        CK_ULONG *option);
+
+/* Test statistics */
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+static int crashes_prevented = 0;
+
+#define TEST_ASSERT(condition, msg) do { \
+    tests_run++; \
+    if (!(condition)) { \
+        printf("FAIL: %s (line %d): %s\n", __func__, __LINE__, msg); \
+        tests_failed++; \
+        return -1; \
+    } else { \
+        tests_passed++; \
+    } \
+} while(0)
+
+#define TEST_PASS() do { \
+    printf("PASS: %s\n", __func__); \
+    return 0; \
+} while(0)
+
+/* Helper function to generate random data */
+static void generate_random_data(CK_BYTE *buffer, CK_ULONG length)
+{
+    for (CK_ULONG i = 0; i < length; i++) {
+        buffer[i] = (CK_BYTE)(rand() % 256);
+    }
+}
+
+/* Helper to mutate existing data (bit flips, byte swaps, etc.) */
+static void mutate_data(CK_BYTE *data, CK_ULONG length, int mutation_type)
+{
+    if (length == 0)
+        return;
+
+    switch (mutation_type % 5) {
+        case 0: /* Bit flip */
+            data[rand() % length] ^= (1 << (rand() % 8));
+            break;
+        case 1: /* Byte swap */
+            if (length > 1) {
+                CK_ULONG pos1 = rand() % length;
+                CK_ULONG pos2 = rand() % length;
+                CK_BYTE tmp = data[pos1];
+                data[pos1] = data[pos2];
+                data[pos2] = tmp;
+            }
+            break;
+        case 2: /* Set to extreme value */
+            data[rand() % length] = (rand() % 2) ? 0x00 : 0xFF;
+            break;
+        case 3: /* Increment/decrement */
+            data[rand() % length] += (rand() % 2) ? 1 : -1;
+            break;
+        case 4: /* Set random byte */
+            data[rand() % length] = (CK_BYTE)(rand() % 256);
+            break;
+    }
+}
+
+/* Test 1: Pure random data fuzzing - All types */
+static int test_fuzz_decode_all_types_pure_random(void)
+{
+    CK_BYTE random_data[2048];
+    CK_BYTE *decoded_data;
+    CK_ULONG decoded_len, field_len, option;
+    int iterations = 2000; /* 2000 per type = 10000 total */
+
+    printf("Running: %s (%d iterations per type)\n", __func__, iterations);
+
+    for (int i = 0; i < iterations; i++) {
+        CK_ULONG data_len = (rand() % 2000) + 1;
+        generate_random_data(random_data, data_len);
+
+        /* Test all 5 types - should not crash with random data */
+        (void)ber_decode_INTEGER(random_data, data_len, &decoded_data,
+                                &decoded_len, &field_len);
+
+        (void)ber_decode_OCTET_STRING(random_data, data_len, &decoded_data,
+                                     &decoded_len, &field_len);
+
+        (void)ber_decode_BIT_STRING(random_data, data_len, &decoded_data,
+                                   &decoded_len, &field_len);
+
+        (void)ber_decode_SEQUENCE(random_data, data_len, &decoded_data,
+                                 &decoded_len, &field_len);
+
+        (void)ber_decode_CHOICE(random_data, data_len, (rand() % 2) ? TRUE : FALSE,
+                               &decoded_data, &decoded_len, &field_len, &option);
+    }
+
+    printf("  Tested all 5 BER types with random data\n");
+    TEST_ASSERT(1, "Completed without crashing");
+    TEST_PASS();
+}
+
+/* Test 2: Mutation-based fuzzing - all types */
+static int test_fuzz_mutation_based_all_types(void)
+{
+    CK_BYTE *decoded_data;
+    CK_ULONG decoded_len, field_len, option;
+    int iterations = 2000; /* 2000 per type = 10000 total */
+
+    printf("Running: %s (%d iterations per type)\n", __func__, iterations);
+
+    /* Test each type */
+    for (int type = 0; type < 5; type++) {
+        CK_BYTE *encoded_data = NULL;
+        CK_ULONG encoded_len;
+        CK_BYTE valid_data[100];
+        generate_random_data(valid_data, sizeof(valid_data));
+
+        /* Encode based on type */
+        CK_RV rv = CKR_FUNCTION_FAILED;
+        switch (type) {
+            case 0: /* INTEGER */
+                rv = ber_encode_INTEGER(FALSE, &encoded_data, &encoded_len,
+                                       valid_data, sizeof(valid_data));
+                break;
+            case 1: /* OCTET_STRING */
+                rv = ber_encode_OCTET_STRING(FALSE, &encoded_data, &encoded_len,
+                                            valid_data, sizeof(valid_data));
+                break;
+            case 2: /* BIT_STRING */
+                rv = ber_encode_BIT_STRING(FALSE, &encoded_data, &encoded_len,
+                                          valid_data, sizeof(valid_data), 0);
+                break;
+            case 3: /* SEQUENCE */
+                rv = ber_encode_SEQUENCE(FALSE, &encoded_data, &encoded_len,
+                                        valid_data, sizeof(valid_data));
+                break;
+            case 4: /* CHOICE */
+                rv = ber_encode_CHOICE(FALSE, (CK_BYTE)(rand() % 16), &encoded_data,
+                                      &encoded_len, valid_data, sizeof(valid_data), FALSE);
+                break;
+        }
+
+        if (rv == CKR_OK && encoded_data) {
+            /* Mutate and decode */
+            for (int i = 0; i < iterations; i++) {
+                CK_BYTE *mutated = malloc(encoded_len);
+                if (mutated) {
+                    memcpy(mutated, encoded_data, encoded_len);
+
+                    /* Apply mutations */
+                    for (int m = 0; m < (rand() % 5) + 1; m++) {
+                        mutate_data(mutated, encoded_len, rand());
+                    }
+
+                    /* Decode based on type */
+                    switch (type) {
+                        case 0:
+                            (void)ber_decode_INTEGER(mutated, encoded_len, &decoded_data,
+                                                    &decoded_len, &field_len);
+                            break;
+                        case 1:
+                            (void)ber_decode_OCTET_STRING(mutated, encoded_len, &decoded_data,
+                                                         &decoded_len, &field_len);
+                            break;
+                        case 2:
+                            (void)ber_decode_BIT_STRING(mutated, encoded_len, &decoded_data,
+                                                       &decoded_len, &field_len);
+                            break;
+                        case 3:
+                            (void)ber_decode_SEQUENCE(mutated, encoded_len, &decoded_data,
+                                                     &decoded_len, &field_len);
+                            break;
+                        case 4:
+                            (void)ber_decode_CHOICE(mutated, encoded_len, FALSE, &decoded_data,
+                                                   &decoded_len, &field_len, &option);
+                            break;
+                    }
+
+                    free(mutated);
+                }
+            }
+            free(encoded_data);
+        }
+    }
+
+    printf("  Tested mutation fuzzing on all 5 types\n");
+    TEST_ASSERT(1, "Mutation fuzzing completed");
+    TEST_PASS();
+}
+
+/* Test 3: Length field fuzzing - manipulate length fields specifically */
+static int test_fuzz_length_field_attacks(void)
+{
+    CK_BYTE *decoded_data;
+    CK_ULONG decoded_len, field_len;
+    CK_RV rv;
+    int attack_count = 0;
+
+    printf("Running: %s\n", __func__);
+
+    /* Attack 1: Length overflow - claim huge length with small data */
+    for (int i = 0; i < 1000; i++) {
+        CK_BYTE overflow_data[10];
+        overflow_data[0] = 0x02; /* INTEGER tag */
+        overflow_data[1] = 0x84; /* Long form, 4 octets */
+        overflow_data[2] = (rand() % 256);
+        overflow_data[3] = (rand() % 256);
+        overflow_data[4] = (rand() % 256);
+        overflow_data[5] = (rand() % 256);
+        /* Only 4 bytes of actual data */
+        overflow_data[6] = rand() % 256;
+        overflow_data[7] = rand() % 256;
+        overflow_data[8] = rand() % 256;
+        overflow_data[9] = rand() % 256;
+
+        rv = ber_decode_INTEGER(overflow_data, sizeof(overflow_data),
+                               &decoded_data, &decoded_len, &field_len);
+
+        if (rv == CKR_FUNCTION_FAILED) {
+            attack_count++;
+        }
+    }
+
+    /* Attack 2: Inconsistent length encoding */
+    for (int i = 0; i < 1000; i++) {
+        CK_BYTE inconsistent[20];
+        inconsistent[0] = 0x02; /* INTEGER tag */
+        inconsistent[1] = 0x80 | (rand() % 8); /* Random long form octets */
+        for (int j = 2; j < 20; j++) {
+            inconsistent[j] = rand() % 256;
+        }
+
+        rv = ber_decode_INTEGER(inconsistent, sizeof(inconsistent),
+                               &decoded_data, &decoded_len, &field_len);
+
+        if (rv == CKR_FUNCTION_FAILED) {
+            attack_count++;
+        }
+    }
+
+    printf("  Detected and rejected %d length field attacks\n", attack_count);
+    TEST_ASSERT(attack_count > 0, "Should detect length field attacks");
+    TEST_PASS();
+}
+
+/* Test 4: Deeply nested structure fuzzing */
+static int test_fuzz_deeply_nested_structures(void)
+{
+    CK_BYTE *decoded_data;
+    CK_ULONG decoded_len, field_len;
+    CK_RV rv;
+
+    printf("Running: %s\n", __func__);
+
+    /* Test various nesting depths */
+    for (int depth = 10; depth <= 200; depth += 10) {
+        CK_BYTE *nested = malloc(depth * 3);
+        if (!nested) continue;
+
+        CK_ULONG offset = 0;
+        CK_ULONG max_offset = (CK_ULONG)(depth * 3) - 2;
+
+        /* Create nested sequences */
+        for (int i = 0; i < depth && offset < max_offset; i++) {
+            nested[offset++] = 0x30; /* SEQUENCE tag */
+            nested[offset++] = (rand() % 2) ? 0x02 : 0x81; /* Random length form */
+            if (nested[offset-1] == 0x81) {
+                nested[offset++] = rand() % 128;
+            } else {
+                nested[offset-1] = rand() % 128;
+            }
+        }
+
+        rv = ber_decode_SEQUENCE(nested, offset, &decoded_data,
+                                &decoded_len, &field_len);
+
+        /* Should handle or reject gracefully, not crash */
+        if (rv != CKR_OK && rv != CKR_FUNCTION_FAILED) {
+            crashes_prevented++;
+        }
+
+        free(nested);
+    }
+
+    printf("  Tested nesting depths up to 200 levels\n");
+    TEST_ASSERT(1, "Deep nesting handled");
+    TEST_PASS();
+}
+
+/* Test 5: Memory allocation stress with rapid alloc/free */
+static int test_fuzz_memory_stress(void)
+{
+    CK_BYTE *encoded_data = NULL;
+    CK_ULONG encoded_len;
+    CK_RV rv;
+    int iterations = 2000;
+
+    printf("Running: %s (%d iterations)\n", __func__, iterations);
+
+    /* Rapidly allocate and free to stress memory management */
+    for (int i = 0; i < iterations; i++) {
+        CK_ULONG data_len = (rand() % 500) + 1;
+        CK_BYTE *data = malloc(data_len);
+
+        if (data) {
+            generate_random_data(data, data_len);
+
+            rv = ber_encode_INTEGER(FALSE, &encoded_data, &encoded_len,
+                                   data, data_len);
+
+            if (rv == CKR_OK && encoded_data) {
+                free(encoded_data);
+                encoded_data = NULL;
+            }
+
+            free(data);
+        }
+    }
+
+    printf("  Completed %d alloc/free cycles\n", iterations);
+    TEST_ASSERT(1, "Memory stress test completed");
+    TEST_PASS();
+}
+
+/* Test 6: Concurrent encode/decode operations simulation */
+static int test_fuzz_interleaved_operations(void)
+{
+    CK_BYTE *encoded_data[10] = {NULL};
+    CK_ULONG encoded_len[10];
+    CK_BYTE *decoded_data;
+    CK_ULONG decoded_len, field_len;
+
+    printf("Running: %s\n", __func__);
+
+    /* Interleave multiple encode/decode operations */
+    for (int round = 0; round < 100; round++) {
+        /* Encode phase - create multiple encoded buffers */
+        for (int i = 0; i < 10; i++) {
+            CK_ULONG data_len = (rand() % 200) + 1;
+            CK_BYTE *data = malloc(data_len);
+
+            if (data) {
+                generate_random_data(data, data_len);
+                (void)ber_encode_INTEGER(FALSE, &encoded_data[i], &encoded_len[i],
+                                        data, data_len);
+                free(data);
+            }
+        }
+
+        /* Decode phase - decode in random order */
+        for (int i = 0; i < 10; i++) {
+            int idx = rand() % 10;
+            if (encoded_data[idx]) {
+                (void)ber_decode_INTEGER(encoded_data[idx], encoded_len[idx],
+                                        &decoded_data, &decoded_len, &field_len);
+            }
+        }
+
+        /* Cleanup */
+        for (int i = 0; i < 10; i++) {
+            if (encoded_data[i]) {
+                free(encoded_data[i]);
+                encoded_data[i] = NULL;
+            }
+        }
+    }
+
+    printf("  Completed 100 rounds of interleaved operations\n");
+    TEST_ASSERT(1, "Interleaved operations completed");
+    TEST_PASS();
+}
+
+/* Test 7: Fuzzing all primitive types with random data */
+static int test_fuzz_all_primitives_random(void)
+{
+    CK_BYTE random_data[1024];
+    CK_BYTE *decoded_data;
+    CK_ULONG decoded_len, field_len;
+    int iterations = 2000;
+
+    printf("Running: %s (%d iterations per type)\n", __func__, iterations);
+
+    for (int i = 0; i < iterations; i++) {
+        CK_ULONG data_len = (rand() % 1000) + 1;
+        generate_random_data(random_data, data_len);
+
+        /* Test INTEGER */
+        (void)ber_decode_INTEGER(random_data, data_len, &decoded_data,
+                                &decoded_len, &field_len);
+
+        /* Test OCTET_STRING */
+        (void)ber_decode_OCTET_STRING(random_data, data_len, &decoded_data,
+                                      &decoded_len, &field_len);
+
+        /* Test BIT_STRING */
+        (void)ber_decode_BIT_STRING(random_data, data_len, &decoded_data,
+                                    &decoded_len, &field_len);
+
+        /* Test SEQUENCE */
+        (void)ber_decode_SEQUENCE(random_data, data_len, &decoded_data,
+                                 &decoded_len, &field_len);
+    }
+
+    printf("  Tested all primitive types with random data\n");
+    TEST_ASSERT(1, "All primitives tested");
+    TEST_PASS();
+}
+
+/* Test 8: Edge case combinations - all types */
+static int test_fuzz_edge_case_combinations_all_types(void)
+{
+    CK_BYTE *encoded_data = NULL;
+    CK_ULONG encoded_len;
+
+    printf("Running: %s\n", __func__);
+
+    /* Test various edge case combinations */
+    struct {
+        CK_ULONG size;
+        CK_BYTE fill;
+    } test_cases[] = {
+        {0, 0x00},      /* Zero length */
+        {1, 0x00},      /* Single byte, zero */
+        {1, 0xFF},      /* Single byte, all bits set */
+        {1, 0x80},      /* Single byte, MSB set */
+        {127, 0x00},    /* Boundary: last short form */
+        {127, 0xFF},    /* Boundary: last short form, all bits */
+        {128, 0x00},    /* Boundary: first long form */
+        {128, 0x80},    /* Boundary: first long form, MSB set */
+        {255, 0x00},    /* Boundary: 1-byte long form limit */
+        {256, 0x00},    /* Boundary: 2-byte long form start */
+    };
+
+    int test_count = 0;
+
+    /* Test each type with each edge case */
+    for (int type = 0; type < 5; type++) {
+        for (size_t i = 0; i < sizeof(test_cases) / sizeof(test_cases[0]); i++) {
+            CK_BYTE *data = malloc(test_cases[i].size > 0 ? test_cases[i].size : 1);
+            if (data) {
+                if (test_cases[i].size > 0) {
+                    memset(data, test_cases[i].fill, test_cases[i].size);
+                }
+
+                /* Encode based on type */
+                switch (type) {
+                    case 0: /* INTEGER */
+                        (void)ber_encode_INTEGER(FALSE, &encoded_data, &encoded_len,
+                                                data, test_cases[i].size);
+                        break;
+                    case 1: /* OCTET_STRING */
+                        (void)ber_encode_OCTET_STRING(FALSE, &encoded_data, &encoded_len,
+                                                     data, test_cases[i].size);
+                        break;
+                    case 2: /* BIT_STRING */
+                        (void)ber_encode_BIT_STRING(FALSE, &encoded_data, &encoded_len,
+                                                   data, test_cases[i].size, 0);
+                        break;
+                    case 3: /* SEQUENCE */
+                        (void)ber_encode_SEQUENCE(FALSE, &encoded_data, &encoded_len,
+                                                 data, test_cases[i].size);
+                        break;
+                    case 4: /* CHOICE */
+                        (void)ber_encode_CHOICE(FALSE, 0x01, &encoded_data, &encoded_len,
+                                               data, test_cases[i].size, FALSE);
+                        break;
+                }
+
+                if (encoded_data) {
+                    free(encoded_data);
+                    encoded_data = NULL;
+                }
+
+                free(data);
+                test_count++;
+            }
+        }
+    }
+
+    printf("  Tested %d edge case combinations across all 5 types\n", test_count);
+    TEST_ASSERT(test_count == 50, "All edge cases tested");
+    TEST_PASS();
+}
+
+/* Test 9: Fuzzing with specific attack patterns - all types */
+static int test_fuzz_attack_patterns_all_types(void)
+{
+    CK_BYTE *decoded_data;
+    CK_ULONG decoded_len, field_len, option;
+    int patterns_tested = 0;
+
+    printf("Running: %s\n", __func__);
+
+    /* Define attack patterns */
+    CK_BYTE zeros[100];
+    memset(zeros, 0x00, sizeof(zeros));
+
+    CK_BYTE ones[100];
+    memset(ones, 0xFF, sizeof(ones));
+
+    CK_BYTE alternating[100];
+    for (size_t i = 0; i < sizeof(alternating); i++) {
+        alternating[i] = (i % 2) ? 0xAA : 0x55;
+    }
+
+    CK_BYTE incrementing[256];
+    for (size_t i = 0; i < sizeof(incrementing); i++) {
+        incrementing[i] = (CK_BYTE)i;
+    }
+
+    CK_BYTE decrementing[256];
+    for (size_t i = 0; i < sizeof(decrementing); i++) {
+        decrementing[i] = (CK_BYTE)(255 - i);
+    }
+
+    /* Test each pattern with each type */
+    struct {
+        CK_BYTE *data;
+        CK_ULONG len;
+    } patterns[] = {
+        {zeros, sizeof(zeros)},
+        {ones, sizeof(ones)},
+        {alternating, sizeof(alternating)},
+        {incrementing, sizeof(incrementing)},
+        {decrementing, sizeof(decrementing)}
+    };
+
+    for (int type = 0; type < 5; type++) {
+        for (size_t p = 0; p < sizeof(patterns) / sizeof(patterns[0]); p++) {
+            /* Decode based on type */
+            switch (type) {
+                case 0: /* INTEGER */
+                    (void)ber_decode_INTEGER(patterns[p].data, patterns[p].len,
+                                            &decoded_data, &decoded_len, &field_len);
+                    break;
+                case 1: /* OCTET_STRING */
+                    (void)ber_decode_OCTET_STRING(patterns[p].data, patterns[p].len,
+                                                 &decoded_data, &decoded_len, &field_len);
+                    break;
+                case 2: /* BIT_STRING */
+                    (void)ber_decode_BIT_STRING(patterns[p].data, patterns[p].len,
+                                               &decoded_data, &decoded_len, &field_len);
+                    break;
+                case 3: /* SEQUENCE */
+                    (void)ber_decode_SEQUENCE(patterns[p].data, patterns[p].len,
+                                             &decoded_data, &decoded_len, &field_len);
+                    break;
+                case 4: /* CHOICE */
+                    (void)ber_decode_CHOICE(patterns[p].data, patterns[p].len, FALSE,
+                                           &decoded_data, &decoded_len, &field_len, &option);
+                    break;
+            }
+            patterns_tested++;
+        }
+    }
+
+    printf("  Tested %d attack patterns across all 5 types\n", patterns_tested);
+    TEST_ASSERT(patterns_tested == 25, "All attack patterns tested");
+    TEST_PASS();
+}
+
+/* Test 10: Fuzzing CHOICE with random options and data */
+static int test_fuzz_choice_random_options(void)
+{
+    CK_BYTE *encoded_data = NULL;
+    CK_ULONG encoded_len;
+    CK_BYTE *decoded_data;
+    CK_ULONG decoded_len, field_len, option;
+    CK_RV rv;
+    int iterations = 1000;
+
+    printf("Running: %s (%d iterations)\n", __func__, iterations);
+
+    /* Test with random options and data */
+    for (int i = 0; i < iterations; i++) {
+        CK_BYTE random_option = (CK_BYTE)(rand() % 32); /* Options 0-31 */
+        CK_BBOOL constructed = (rand() % 2) ? TRUE : FALSE;
+        CK_ULONG data_len = (rand() % 200) + 1;
+        CK_BYTE *data = malloc(data_len);
+
+        if (data) {
+            generate_random_data(data, data_len);
+
+            /* Encode */
+            rv = ber_encode_CHOICE(FALSE, random_option, &encoded_data,
+                                  &encoded_len, data, data_len, constructed);
+
+            if (rv == CKR_OK && encoded_data) {
+                /* Decode */
+                rv = ber_decode_CHOICE(encoded_data, encoded_len, constructed,
+                                      &decoded_data, &decoded_len, &field_len, &option);
+
+                free(encoded_data);
+                encoded_data = NULL;
+            }
+
+            free(data);
+        }
+    }
+
+    printf("  Tested %d random CHOICE encodings\n", iterations);
+    TEST_ASSERT(1, "CHOICE random options test completed");
+    TEST_PASS();
+}
+
+/* Test 11: Fuzzing CHOICE decoder with random data */
+static int test_fuzz_choice_decode_random(void)
+{
+    CK_BYTE random_data[1024];
+    CK_BYTE *decoded_data;
+    CK_ULONG decoded_len, field_len, option;
+    int iterations = 1000;
+
+    printf("Running: %s (%d iterations)\n", __func__, iterations);
+
+    /* Test both constructed and primitive with random data */
+    for (int i = 0; i < iterations; i++) {
+        CK_ULONG data_len = (rand() % 1000) + 1;
+        CK_BBOOL constructed = (rand() % 2) ? TRUE : FALSE;
+        generate_random_data(random_data, data_len);
+
+        /* Should not crash with random data */
+        (void)ber_decode_CHOICE(random_data, data_len, constructed,
+                               &decoded_data, &decoded_len, &field_len, &option);
+    }
+
+    printf("  Tested CHOICE decoder with random data\n");
+    TEST_ASSERT(1, "CHOICE random decode test completed");
+    TEST_PASS();
+}
+
+/* Test 12: Fuzzing CHOICE with option boundary values */
+static int test_fuzz_choice_option_boundaries(void)
+{
+    CK_BYTE *encoded_data = NULL;
+    CK_ULONG encoded_len;
+    int test_count = 0;
+
+    printf("Running: %s\n", __func__);
+
+    /* Test boundary option values */
+    CK_BYTE boundary_options[] = {0x00, 0x01, 0x1E, 0x1F, 0x20, 0x7F, 0x80, 0xFF};
+
+    for (size_t i = 0; i < sizeof(boundary_options); i++) {
+        for (int constructed = 0; constructed <= 1; constructed++) {
+            CK_BYTE test_data[50];
+            generate_random_data(test_data, sizeof(test_data));
+
+            (void)ber_encode_CHOICE(FALSE, boundary_options[i], &encoded_data,
+                                   &encoded_len, test_data, sizeof(test_data),
+                                   constructed ? TRUE : FALSE);
+
+            if (encoded_data) {
+                free(encoded_data);
+                encoded_data = NULL;
+            }
+            test_count++;
+        }
+    }
+
+    printf("  Tested %d CHOICE option boundary values\n", test_count);
+    TEST_ASSERT(test_count == 16, "All boundary options tested");
+    TEST_PASS();
+}
+
+/* Test 13: Fuzzing CHOICE with malformed constructed flag */
+static int test_fuzz_choice_constructed_mismatch(void)
+{
+    CK_BYTE *encoded_data = NULL;
+    CK_ULONG encoded_len;
+    CK_BYTE *decoded_data;
+    CK_ULONG decoded_len, field_len, option;
+    CK_RV rv;
+    int iterations = 1000;
+
+    printf("Running: %s (%d iterations)\n", __func__, iterations);
+
+    /* Encode with one constructed flag, decode with another */
+    for (int i = 0; i < iterations; i++) {
+        CK_BYTE random_option = (CK_BYTE)(rand() % 16);
+        CK_BBOOL encode_constructed = (rand() % 2) ? TRUE : FALSE;
+        CK_BBOOL decode_constructed = (rand() % 2) ? TRUE : FALSE;
+        CK_ULONG data_len = (rand() % 100) + 1;
+        CK_BYTE *data = malloc(data_len);
+
+        if (data) {
+            generate_random_data(data, data_len);
+
+            /* Encode with one flag */
+            rv = ber_encode_CHOICE(FALSE, random_option, &encoded_data,
+                                  &encoded_len, data, data_len, encode_constructed);
+
+            if (rv == CKR_OK && encoded_data) {
+                /* Decode with potentially different flag */
+                (void)ber_decode_CHOICE(encoded_data, encoded_len, decode_constructed,
+                                       &decoded_data, &decoded_len, &field_len, &option);
+
+                free(encoded_data);
+                encoded_data = NULL;
+            }
+
+            free(data);
+        }
+    }
+
+    printf("  Tested constructed flag mismatches\n");
+    TEST_ASSERT(1, "CHOICE constructed mismatch test completed");
+    TEST_PASS();
+}
+
+/* Test 14: Fuzzing CHOICE with mutation */
+static int test_fuzz_choice_mutation(void)
+{
+    CK_BYTE *encoded_data = NULL;
+    CK_ULONG encoded_len;
+    CK_BYTE *decoded_data;
+    CK_ULONG decoded_len, field_len, option;
+    CK_RV rv;
+    int iterations = 1000;
+
+    printf("Running: %s (%d iterations)\n", __func__, iterations);
+
+    for (int i = 0; i < iterations; i++) {
+        CK_BYTE random_option = (CK_BYTE)(rand() % 16);
+        CK_BBOOL constructed = (rand() % 2) ? TRUE : FALSE;
+        CK_BYTE test_data[100];
+        generate_random_data(test_data, sizeof(test_data));
+
+        /* Encode valid CHOICE */
+        rv = ber_encode_CHOICE(FALSE, random_option, &encoded_data,
+                              &encoded_len, test_data, sizeof(test_data), constructed);
+
+        if (rv == CKR_OK && encoded_data) {
+            /* Mutate the encoded data */
+            CK_BYTE *mutated = malloc(encoded_len);
+            if (mutated) {
+                memcpy(mutated, encoded_data, encoded_len);
+
+                /* Apply mutations */
+                for (int m = 0; m < (rand() % 3) + 1; m++) {
+                    mutate_data(mutated, encoded_len, rand());
+                }
+
+                /* Try to decode mutated data */
+                (void)ber_decode_CHOICE(mutated, encoded_len, constructed,
+                                       &decoded_data, &decoded_len, &field_len, &option);
+
+                free(mutated);
+            }
+
+            free(encoded_data);
+            encoded_data = NULL;
+        }
+    }
+
+    printf("  Tested CHOICE with mutations\n");
+    TEST_ASSERT(1, "CHOICE mutation test completed");
+    TEST_PASS();
+}
+
+/* Main test runner */
+int main(int argc __attribute__((unused)), char **argv __attribute__((unused)))
+{
+    int result = 0;
+
+    /* Initialize random seed */
+    srand((unsigned int)time(NULL));
+
+    printf("=== ASN.1 BER Encoding/Decoding FUZZING Tests ===\n");
+    printf("NOTE: These are TRUE fuzzing tests with random data\n");
+    printf("      Complementing the unit tests in asn1test.c\n\n");
+
+    /* Run all fuzzing tests */
+    result |= test_fuzz_decode_all_types_pure_random();
+    result |= test_fuzz_mutation_based_all_types();
+    result |= test_fuzz_length_field_attacks();
+    result |= test_fuzz_deeply_nested_structures();
+    result |= test_fuzz_memory_stress();
+    result |= test_fuzz_interleaved_operations();
+    result |= test_fuzz_all_primitives_random();
+    result |= test_fuzz_edge_case_combinations_all_types();
+    result |= test_fuzz_attack_patterns_all_types();
+    result |= test_fuzz_choice_random_options();
+    result |= test_fuzz_choice_decode_random();
+    result |= test_fuzz_choice_option_boundaries();
+    result |= test_fuzz_choice_constructed_mismatch();
+    result |= test_fuzz_choice_mutation();
+
+    /* Print summary */
+    printf("\n=== Fuzzing Test Summary ===\n");
+    printf("Total tests run: %d\n", tests_run);
+    printf("Tests passed: %d\n", tests_passed);
+    printf("Tests failed: %d\n", tests_failed);
+    printf("Crashes prevented: %d\n", crashes_prevented);
+
+    if (tests_failed == 0) {
+        printf("\nAll fuzzing tests PASSED!\n");
+        printf("The BER decoder handled random/malformed data gracefully.\n");
+        return 0;
+    } else {
+        printf("\nSome fuzzing tests FAILED!\n");
+        return 1;
+    }
+}

--- a/testcases/unit/asn1test.c
+++ b/testcases/unit/asn1test.c
@@ -1,0 +1,3394 @@
+/*
+ * COPYRIGHT (c) International Business Machines Corp. 2026
+ *
+ * This program is provided under the terms of the Common Public License,
+ * version 1.0 (CPL-1.0). Any use, reproduction or distribution for this
+ * software constitutes recipient's acceptance of CPL-1.0 terms which can be
+ * found in the file LICENSE file or at
+ * https://opensource.org/licenses/cpl1.0.php
+ */
+
+/*
+ * Unit tests for BER encoding and decoding functions in asn1.c
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "pkcs11types.h"
+#include "defs.h"
+#include "host_defs.h"
+#include "h_extern.h"
+#include "unittest.h"
+#include "asn1test_keys.h"
+#include "asn1test_pqckeys.h"
+
+/* Function prototypes from asn1.c */
+CK_ULONG ber_encode_INTEGER(CK_BBOOL length_only,
+                            CK_BYTE **ber_int,
+                            CK_ULONG *ber_int_len, CK_BYTE *data,
+                            CK_ULONG data_len);
+
+CK_RV ber_decode_INTEGER(CK_BYTE *ber_int, CK_ULONG ber_int_len,
+                         CK_BYTE **data, CK_ULONG *data_len,
+                         CK_ULONG *field_len);
+
+CK_RV ber_encode_OCTET_STRING(CK_BBOOL length_only,
+                              CK_BYTE **str,
+                              CK_ULONG *str_len, CK_BYTE *data,
+                              CK_ULONG data_len);
+
+CK_RV ber_decode_OCTET_STRING(CK_BYTE *str, CK_ULONG str_len,
+                              CK_BYTE **data,
+                              CK_ULONG *data_len, CK_ULONG *field_len);
+
+CK_ULONG ber_encode_BIT_STRING(CK_BBOOL length_only,
+                            CK_BYTE **ber_str,
+                            CK_ULONG *ber_str_len, CK_BYTE *data,
+                            CK_ULONG data_len,
+                            CK_BYTE unused_bits);
+
+CK_RV ber_decode_BIT_STRING(CK_BYTE *str, CK_ULONG str_len,
+                            CK_BYTE **data,
+                            CK_ULONG *data_len, CK_ULONG *field_len);
+
+CK_RV ber_encode_SEQUENCE(CK_BBOOL length_only,
+                          CK_BYTE **seq,
+                          CK_ULONG *seq_len, CK_BYTE *data, CK_ULONG data_len);
+
+CK_RV ber_decode_SEQUENCE(CK_BYTE *seq, CK_ULONG seq_len,
+                          CK_BYTE **data, CK_ULONG *data_len,
+                          CK_ULONG *field_len);
+
+CK_RV ber_encode_CHOICE(CK_BBOOL length_only,
+                        CK_BYTE option,
+                        CK_BYTE **str,
+                        CK_ULONG *str_len, CK_BYTE *data, CK_ULONG data_len,
+                        CK_BBOOL constructed);
+
+CK_RV ber_decode_CHOICE(CK_BYTE *choice, CK_ULONG choice_len,
+                        CK_BBOOL constructed,
+                        CK_BYTE **data,
+                        CK_ULONG *data_len, CK_ULONG *field_len,
+                        CK_ULONG *option);
+
+CK_RV ber_encode_PrivateKeyInfo(CK_BBOOL length_only,
+                                CK_BYTE **data,
+                                CK_ULONG *data_len,
+                                const CK_BYTE *algorithm_id,
+                                const CK_ULONG algorithm_id_len,
+                                CK_BYTE *priv_key, CK_ULONG priv_key_len);
+
+CK_RV ber_decode_PrivateKeyInfo(CK_BYTE *data, CK_ULONG data_len,
+                                CK_BYTE **algorithm, CK_ULONG *alg_len,
+                                CK_BYTE **priv_key, CK_ULONG *priv_key_len);
+
+CK_RV ber_decode_SPKI(CK_BYTE *spki, CK_ULONG spki_len,
+                      CK_BYTE **alg_oid, CK_ULONG *alg_oid_len,
+                      CK_BYTE **param, CK_ULONG *param_len,
+                      CK_BYTE **key, CK_ULONG *key_len);
+
+CK_RV ber_encode_RSAPrivateKey(CK_BBOOL length_only,
+                               CK_BYTE **data,
+                               CK_ULONG *data_len,
+                               CK_ATTRIBUTE *modulus,
+                               CK_ATTRIBUTE *publ_exp,
+                               CK_ATTRIBUTE *priv_exp,
+                               CK_ATTRIBUTE *prime1,
+                               CK_ATTRIBUTE *prime2,
+                               CK_ATTRIBUTE *exponent1,
+                               CK_ATTRIBUTE *exponent2,
+                               CK_ATTRIBUTE *coeff);
+
+CK_RV ber_decode_RSAPrivateKey(CK_BYTE *data,
+                               CK_ULONG data_len,
+                               CK_ATTRIBUTE **modulus,
+                               CK_ATTRIBUTE **publ_exp,
+                               CK_ATTRIBUTE **priv_exp,
+                               CK_ATTRIBUTE **prime1,
+                               CK_ATTRIBUTE **prime2,
+                               CK_ATTRIBUTE **exponent1,
+                               CK_ATTRIBUTE **exponent2,
+                               CK_ATTRIBUTE **coeff);
+
+CK_RV ber_encode_RSAPublicKey(CK_BBOOL length_only, CK_BYTE **data,
+                              CK_ULONG *data_len, CK_ATTRIBUTE *modulus,
+                              CK_ATTRIBUTE *publ_exp);
+
+CK_RV ber_decode_RSAPublicKey(CK_BYTE *data,
+                              CK_ULONG data_len,
+                              CK_ATTRIBUTE **modulus,
+                              CK_ATTRIBUTE **publ_exp);
+
+CK_RV ber_encode_DSAPrivateKey(CK_BBOOL length_only,
+                               CK_BYTE **data,
+                               CK_ULONG *data_len,
+                               CK_ATTRIBUTE *prime1,
+                               CK_ATTRIBUTE *prime2,
+                               CK_ATTRIBUTE *base,
+                               CK_ATTRIBUTE *priv_key);
+
+CK_RV ber_decode_DSAPrivateKey(CK_BYTE *data,
+                               CK_ULONG data_len,
+                               CK_ATTRIBUTE **prime,
+                               CK_ATTRIBUTE **subprime,
+                               CK_ATTRIBUTE **base,
+                               CK_ATTRIBUTE **priv_key);
+
+CK_RV ber_encode_DSAPublicKey(CK_BBOOL length_only,
+                              CK_BYTE **data,
+                              CK_ULONG *data_len,
+                              CK_ATTRIBUTE *prime,
+                              CK_ATTRIBUTE *subprime,
+                              CK_ATTRIBUTE *base,
+                              CK_ATTRIBUTE *value);
+
+CK_RV ber_decode_DSAPublicKey(CK_BYTE *data,
+                              CK_ULONG data_len,
+                              CK_ATTRIBUTE **prime,
+                              CK_ATTRIBUTE **subprime,
+                              CK_ATTRIBUTE **base,
+                              CK_ATTRIBUTE **value);
+
+/* DH key encoding/decoding function prototypes */
+CK_RV ber_encode_DHPrivateKey(CK_BBOOL length_only,
+                              CK_BYTE **data,
+                              CK_ULONG *data_len,
+                              CK_ATTRIBUTE *prime,
+                              CK_ATTRIBUTE *base,
+                              CK_ATTRIBUTE *priv_key);
+
+CK_RV ber_decode_DHPrivateKey(CK_BYTE *data,
+                              CK_ULONG data_len,
+                              CK_ATTRIBUTE **prime,
+                              CK_ATTRIBUTE **base,
+                              CK_ATTRIBUTE **priv_key);
+
+CK_RV ber_encode_DHPublicKey(CK_BBOOL length_only,
+                             CK_BYTE **data,
+                             CK_ULONG *data_len,
+                             CK_ATTRIBUTE *prime,
+                             CK_ATTRIBUTE *base,
+                             CK_ATTRIBUTE *value);
+
+CK_RV ber_decode_DHPublicKey(CK_BYTE *data,
+                             CK_ULONG data_len,
+                             CK_ATTRIBUTE **prime,
+                             CK_ATTRIBUTE **base,
+                             CK_ATTRIBUTE **value);
+
+/* EC key encoding/decoding function prototypes */
+CK_RV der_encode_ECPrivateKey(CK_BBOOL length_only,
+                              CK_BYTE **data,
+                              CK_ULONG *data_len,
+                              CK_ATTRIBUTE *params,
+                              CK_ATTRIBUTE *privkey,
+                              CK_ATTRIBUTE *pubkey,
+                              CK_KEY_TYPE key_type);
+
+CK_RV der_decode_ECPrivateKey(CK_BYTE *data,
+                              CK_ULONG data_len,
+                              CK_ATTRIBUTE **params,
+                              CK_ATTRIBUTE **pub_key,
+                              CK_ATTRIBUTE **priv_key,
+                              CK_KEY_TYPE key_type);
+
+CK_RV ber_encode_ECPublicKey(CK_BBOOL length_only,
+                             CK_BYTE **data,
+                             CK_ULONG *data_len,
+                             CK_ATTRIBUTE *params,
+                             CK_ATTRIBUTE *point,
+                             CK_KEY_TYPE key_type);
+
+CK_RV der_decode_ECPublicKey(CK_BYTE *data,
+                             CK_ULONG data_len,
+                             CK_ATTRIBUTE **ec_params,
+                             CK_ATTRIBUTE **ec_point,
+                             CK_KEY_TYPE key_type);
+
+
+/* Helper function to compare byte arrays */
+static int compare_bytes(const char *test_name, CK_BYTE *expected,
+                        CK_BYTE *actual, CK_ULONG len)
+{
+    if (memcmp(expected, actual, len) != 0) {
+        fprintf(stderr, "[FAIL] %s: Data mismatch\n", test_name);
+        fprintf(stderr, "  Expected: ");
+        for (CK_ULONG i = 0; i < len; i++)
+            fprintf(stderr, "%02X ", expected[i]);
+        fprintf(stderr, "\n  Actual:   ");
+        for (CK_ULONG i = 0; i < len; i++)
+            fprintf(stderr, "%02X ", actual[i]);
+        fprintf(stderr, "\n");
+        return 1;
+    }
+    return 0;
+}
+
+/* Test ber_encode_INTEGER with short form length (< 128 bytes) */
+static int test_encode_integer_short(void)
+{
+    CK_BYTE data[] = {0x01, 0x02, 0x03};
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* Expected: 0x02 (INTEGER tag), 0x03 (length), data */
+    CK_BYTE expected[] = {0x02, 0x03, 0x01, 0x02, 0x03};
+
+    rv = ber_encode_INTEGER(FALSE, &encoded, &encoded_len, data, sizeof(data));
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_integer_short: encode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    if (encoded_len != sizeof(expected)) {
+        fprintf(stderr, "[FAIL] test_encode_integer_short: length mismatch (expected %lu, got %lu)\n",
+                (unsigned long)sizeof(expected), encoded_len);
+        result = 1;
+    } else {
+        result = compare_bytes("test_encode_integer_short", expected, encoded, encoded_len);
+    }
+
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_encode_integer_short\n");
+    return result;
+}
+
+/* Test ber_encode_INTEGER with MSB set (requires padding) */
+static int test_encode_integer_padding(void)
+{
+    CK_BYTE data[] = {0x80, 0x01, 0x02};  /* MSB set, needs 0x00 padding */
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* Expected: 0x02 (INTEGER tag), 0x04 (length), 0x00 (padding), data */
+    CK_BYTE expected[] = {0x02, 0x04, 0x00, 0x80, 0x01, 0x02};
+
+    rv = ber_encode_INTEGER(FALSE, &encoded, &encoded_len, data, sizeof(data));
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_integer_padding: encode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    if (encoded_len != sizeof(expected)) {
+        fprintf(stderr, "[FAIL] test_encode_integer_padding: length mismatch (expected %lu, got %lu)\n",
+                (unsigned long)sizeof(expected), encoded_len);
+        result = 1;
+    } else {
+        result = compare_bytes("test_encode_integer_padding", expected, encoded, encoded_len);
+    }
+
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_encode_integer_padding\n");
+    return result;
+}
+
+/* Test ber_encode_INTEGER with long form length (128-255 bytes) */
+static int test_encode_integer_long_form(void)
+{
+    CK_BYTE data[200];
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* Fill with non-MSB-set data to avoid padding */
+    memset(data, 0x42, sizeof(data));
+
+    rv = ber_encode_INTEGER(FALSE, &encoded, &encoded_len, data, sizeof(data));
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_integer_long_form: encode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    /* Expected: 0x02 (INTEGER tag), 0x81 (long form, 1 byte length), 0xC8 (200), data */
+    if (encoded_len != 1 + 2 + 200) {
+        fprintf(stderr, "[FAIL] test_encode_integer_long_form: length mismatch (expected 203, got %lu)\n",
+                encoded_len);
+        result = 1;
+    } else if (encoded[0] != 0x02 || encoded[1] != 0x81 || encoded[2] != 200) {
+        fprintf(stderr, "[FAIL] test_encode_integer_long_form: header mismatch\n");
+        result = 1;
+    } else if (memcmp(&encoded[3], data, 200) != 0) {
+        fprintf(stderr, "[FAIL] test_encode_integer_long_form: data mismatch\n");
+        result = 1;
+    }
+
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_encode_integer_long_form\n");
+    return result;
+}
+
+/* Test ber_encode_INTEGER with 3-byte long form length (256-65535 bytes) */
+static int test_encode_integer_3byte_long_form(void)
+{
+    CK_BYTE *data = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+    const CK_ULONG data_size = 300;  /* 256+ bytes to trigger 3-byte long form */
+
+    /* Allocate and fill with non-MSB-set data to avoid padding */
+    data = malloc(data_size);
+    if (data == NULL) {
+        fprintf(stderr, "[FAIL] test_encode_integer_3byte_long_form: malloc failed\n");
+        return 1;
+    }
+    memset(data, 0x42, data_size);
+
+    rv = ber_encode_INTEGER(FALSE, &encoded, &encoded_len, data, data_size);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_integer_3byte_long_form: encode failed with rv=%lu\n", rv);
+        free(data);
+        return 1;
+    }
+
+    /* Expected: 0x02 (INTEGER tag), 0x82 (long form, 2 bytes length),
+     * 0x01 0x2C (300 in big-endian), data */
+    if (encoded_len != 1 + 3 + 300) {
+        fprintf(stderr, "[FAIL] test_encode_integer_3byte_long_form: length mismatch (expected 304, got %lu)\n",
+                encoded_len);
+        result = 1;
+    } else if (encoded[0] != 0x02 || encoded[1] != 0x82 ||
+               encoded[2] != 0x01 || encoded[3] != 0x2C) {
+        fprintf(stderr, "[FAIL] test_encode_integer_3byte_long_form: header mismatch\n");
+        fprintf(stderr, "  Expected: 02 82 01 2C\n");
+        fprintf(stderr, "  Got:      %02X %02X %02X %02X\n",
+                encoded[0], encoded[1], encoded[2], encoded[3]);
+        result = 1;
+    } else if (memcmp(&encoded[4], data, 300) != 0) {
+        fprintf(stderr, "[FAIL] test_encode_integer_3byte_long_form: data mismatch\n");
+        result = 1;
+    }
+
+    free(data);
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_encode_integer_3byte_long_form\n");
+    return result;
+}
+
+/* Test ber_encode_INTEGER with 4-byte long form length (65536+ bytes) */
+static int test_encode_integer_4byte_long_form(void)
+{
+    CK_BYTE *data = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+    const CK_ULONG data_size = 70000;  /* 65536+ bytes to trigger 4-byte long form */
+
+    /* Allocate and fill with non-MSB-set data to avoid padding */
+    data = malloc(data_size);
+    if (data == NULL) {
+        fprintf(stderr, "[FAIL] test_encode_integer_4byte_long_form: malloc failed\n");
+        return 1;
+    }
+    memset(data, 0x42, data_size);
+
+    rv = ber_encode_INTEGER(FALSE, &encoded, &encoded_len, data, data_size);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_integer_4byte_long_form: encode failed with rv=%lu\n", rv);
+        free(data);
+        return 1;
+    }
+
+    /* Expected: 0x02 (INTEGER tag), 0x83 (long form, 3 bytes length),
+     * 0x01 0x11 0x70 (70000 in big-endian), data */
+    if (encoded_len != 1 + 4 + 70000) {
+        fprintf(stderr, "[FAIL] test_encode_integer_4byte_long_form: length mismatch (expected 70005, got %lu)\n",
+                encoded_len);
+        result = 1;
+    } else if (encoded[0] != 0x02 || encoded[1] != 0x83 ||
+               encoded[2] != 0x01 || encoded[3] != 0x11 || encoded[4] != 0x70) {
+        fprintf(stderr, "[FAIL] test_encode_integer_4byte_long_form: header mismatch\n");
+        fprintf(stderr, "  Expected: 02 83 01 11 70\n");
+        fprintf(stderr, "  Got:      %02X %02X %02X %02X %02X\n",
+                encoded[0], encoded[1], encoded[2], encoded[3], encoded[4]);
+        result = 1;
+    } else if (memcmp(&encoded[5], data, 70000) != 0) {
+        fprintf(stderr, "[FAIL] test_encode_integer_4byte_long_form: data mismatch\n");
+        result = 1;
+    }
+
+    free(data);
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_encode_integer_4byte_long_form\n");
+    return result;
+}
+
+/* Test ber_encode_INTEGER length_only mode */
+static int test_encode_integer_length_only(void)
+{
+    CK_BYTE data[] = {0x01, 0x02, 0x03};
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+
+    rv = ber_encode_INTEGER(TRUE, &encoded, &encoded_len, data, sizeof(data));
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_integer_length_only: encode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    /* Expected length: 1 (tag) + 1 (length) + 3 (data) = 5 */
+    if (encoded_len != 5) {
+        fprintf(stderr, "[FAIL] test_encode_integer_length_only: length mismatch (expected 5, got %lu)\n",
+                encoded_len);
+        return 1;
+    }
+
+    if (encoded != NULL) {
+        fprintf(stderr, "[FAIL] test_encode_integer_length_only: encoded should be NULL in length_only mode\n");
+        return 1;
+    }
+
+    printf("[PASS] test_encode_integer_length_only\n");
+    return 0;
+}
+
+/* Test ber_encode_INTEGER with zero-length data */
+static int test_encode_integer_zero_length(void)
+{
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* Expected: 0x02 (INTEGER tag), 0x00 (length 0) */
+    CK_BYTE expected[] = {0x02, 0x00};
+
+    rv = ber_encode_INTEGER(FALSE, &encoded, &encoded_len, NULL, 0);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_integer_zero_length: encode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    if (encoded_len != sizeof(expected)) {
+        fprintf(stderr, "[FAIL] test_encode_integer_zero_length: length mismatch (expected %lu, got %lu)\n",
+                (unsigned long)sizeof(expected), encoded_len);
+        result = 1;
+    } else {
+        result = compare_bytes("test_encode_integer_zero_length", expected, encoded, encoded_len);
+    }
+
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_encode_integer_zero_length\n");
+    return result;
+}
+
+/* Test ber_encode_INTEGER at boundary (127 bytes - last short form) */
+static int test_encode_integer_boundary_127(void)
+{
+    CK_BYTE data[127];
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    memset(data, 0x42, sizeof(data));
+
+    rv = ber_encode_INTEGER(FALSE, &encoded, &encoded_len, data, sizeof(data));
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_integer_boundary_127: encode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    /* Should use short form: tag + length + data = 1 + 1 + 127 = 129 */
+    if (encoded_len != 129) {
+        fprintf(stderr, "[FAIL] test_encode_integer_boundary_127: length mismatch (expected 129, got %lu)\n",
+                encoded_len);
+        result = 1;
+    } else if (encoded[0] != 0x02 || encoded[1] != 127) {
+        fprintf(stderr, "[FAIL] test_encode_integer_boundary_127: header mismatch (got %02X %02X)\n",
+                encoded[0], encoded[1]);
+        result = 1;
+    }
+
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_encode_integer_boundary_127\n");
+    return result;
+}
+
+/* Test ber_encode_INTEGER at boundary (128 bytes - first long form) */
+static int test_encode_integer_boundary_128(void)
+{
+    CK_BYTE data[128];
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    memset(data, 0x42, sizeof(data));
+
+    rv = ber_encode_INTEGER(FALSE, &encoded, &encoded_len, data, sizeof(data));
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_integer_boundary_128: encode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    /* Should use long form: tag + 0x81 + length + data = 1 + 1 + 1 + 128 = 131 */
+    if (encoded_len != 131) {
+        fprintf(stderr, "[FAIL] test_encode_integer_boundary_128: length mismatch (expected 131, got %lu)\n",
+                encoded_len);
+        result = 1;
+    } else if (encoded[0] != 0x02 || encoded[1] != 0x81 || encoded[2] != 128) {
+        fprintf(stderr, "[FAIL] test_encode_integer_boundary_128: header mismatch (got %02X %02X %02X)\n",
+                encoded[0], encoded[1], encoded[2]);
+        result = 1;
+    }
+
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_encode_integer_boundary_128\n");
+    return result;
+}
+
+/* Test ber_decode_INTEGER with short form length */
+static int test_decode_integer_short(void)
+{
+    CK_BYTE encoded[] = {0x02, 0x03, 0x01, 0x02, 0x03};
+    CK_BYTE *data = NULL;
+    CK_ULONG data_len = 0;
+    CK_ULONG field_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    CK_BYTE expected[] = {0x01, 0x02, 0x03};
+
+    rv = ber_decode_INTEGER(encoded, sizeof(encoded), &data, &data_len, &field_len);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_integer_short: decode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    if (data_len != sizeof(expected)) {
+        fprintf(stderr, "[FAIL] test_decode_integer_short: length mismatch (expected %lu, got %lu)\n",
+                (unsigned long)sizeof(expected), data_len);
+        result = 1;
+    } else if (field_len != sizeof(encoded)) {
+        fprintf(stderr, "[FAIL] test_decode_integer_short: field_len mismatch (expected %lu, got %lu)\n",
+                (unsigned long)sizeof(encoded), field_len);
+        result = 1;
+    } else {
+        result = compare_bytes("test_decode_integer_short", expected, data, data_len);
+    }
+
+    if (result == 0)
+        printf("[PASS] test_decode_integer_short\n");
+    return result;
+}
+
+/* Test ber_decode_INTEGER with padding removal */
+static int test_decode_integer_padding(void)
+{
+    CK_BYTE encoded[] = {0x02, 0x04, 0x00, 0x80, 0x01, 0x02};
+    CK_BYTE *data = NULL;
+    CK_ULONG data_len = 0;
+    CK_ULONG field_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* Expected: padding byte removed */
+    CK_BYTE expected[] = {0x80, 0x01, 0x02};
+
+    rv = ber_decode_INTEGER(encoded, sizeof(encoded), &data, &data_len, &field_len);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_integer_padding: decode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    if (data_len != sizeof(expected)) {
+        fprintf(stderr, "[FAIL] test_decode_integer_padding: length mismatch (expected %lu, got %lu)\n",
+                (unsigned long)sizeof(expected), data_len);
+        result = 1;
+    } else {
+        result = compare_bytes("test_decode_integer_padding", expected, data, data_len);
+    }
+
+    if (result == 0)
+        printf("[PASS] test_decode_integer_padding\n");
+    return result;
+}
+
+/* Test ber_decode_INTEGER with 3-byte long form length (256-65535 bytes) */
+static int test_decode_integer_3byte_long_form(void)
+{
+    CK_BYTE *encoded = NULL;
+    CK_BYTE *data = NULL;
+    CK_ULONG data_len = 0;
+    CK_ULONG field_len = 0;
+    CK_RV rv;
+    int result = 0;
+    const CK_ULONG expected_data_size = 300;
+
+    /* Build encoded data: 0x02 (tag), 0x82 (long form 2 bytes), 0x01 0x2C (300), data */
+    encoded = malloc(1 + 3 + expected_data_size);
+    if (encoded == NULL) {
+        fprintf(stderr, "[FAIL] test_decode_integer_3byte_long_form: malloc failed\n");
+        return 1;
+    }
+
+    encoded[0] = 0x02;  /* INTEGER tag */
+    encoded[1] = 0x82;  /* Long form: 2 length bytes follow */
+    encoded[2] = 0x01;  /* Length high byte */
+    encoded[3] = 0x2C;  /* Length low byte (300 = 0x012C) */
+    memset(&encoded[4], 0x42, expected_data_size);
+
+    rv = ber_decode_INTEGER(encoded, 1 + 3 + expected_data_size, &data, &data_len, &field_len);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_integer_3byte_long_form: decode failed with rv=%lu\n", rv);
+        free(encoded);
+        return 1;
+    }
+
+    if (data_len != expected_data_size) {
+        fprintf(stderr, "[FAIL] test_decode_integer_3byte_long_form: data length mismatch (expected %lu, got %lu)\n",
+                expected_data_size, data_len);
+        result = 1;
+    } else if (field_len != 1 + 3 + expected_data_size) {
+        fprintf(stderr, "[FAIL] test_decode_integer_3byte_long_form: field_len mismatch (expected %lu, got %lu)\n",
+                (unsigned long)(1 + 3 + expected_data_size), field_len);
+        result = 1;
+    } else {
+        /* Verify data content */
+        for (CK_ULONG i = 0; i < expected_data_size; i++) {
+            if (data[i] != 0x42) {
+                fprintf(stderr, "[FAIL] test_decode_integer_3byte_long_form: data mismatch at byte %lu\n", i);
+                result = 1;
+                break;
+            }
+        }
+    }
+
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_decode_integer_3byte_long_form\n");
+    return result;
+}
+
+/* Test ber_decode_INTEGER with 4-byte long form length (65536+ bytes) */
+static int test_decode_integer_4byte_long_form(void)
+{
+    CK_BYTE *encoded = NULL;
+    CK_BYTE *data = NULL;
+    CK_ULONG data_len = 0;
+    CK_ULONG field_len = 0;
+    CK_RV rv;
+    int result = 0;
+    const CK_ULONG expected_data_size = 70000;
+
+    /* Build encoded data: 0x02 (tag), 0x83 (long form 3 bytes), 0x01 0x11 0x70 (70000), data */
+    encoded = malloc(1 + 4 + expected_data_size);
+    if (encoded == NULL) {
+        fprintf(stderr, "[FAIL] test_decode_integer_4byte_long_form: malloc failed\n");
+        return 1;
+    }
+
+    encoded[0] = 0x02;  /* INTEGER tag */
+    encoded[1] = 0x83;  /* Long form: 3 length bytes follow */
+    encoded[2] = 0x01;  /* Length high byte */
+    encoded[3] = 0x11;  /* Length middle byte */
+    encoded[4] = 0x70;  /* Length low byte (70000 = 0x011170) */
+    memset(&encoded[5], 0x42, expected_data_size);
+
+    rv = ber_decode_INTEGER(encoded, 1 + 4 + expected_data_size, &data, &data_len, &field_len);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_integer_4byte_long_form: decode failed with rv=%lu\n", rv);
+        free(encoded);
+        return 1;
+    }
+
+    if (data_len != expected_data_size) {
+        fprintf(stderr, "[FAIL] test_decode_integer_4byte_long_form: data length mismatch (expected %lu, got %lu)\n",
+                expected_data_size, data_len);
+        result = 1;
+    } else if (field_len != 1 + 4 + expected_data_size) {
+        fprintf(stderr, "[FAIL] test_decode_integer_4byte_long_form: field_len mismatch (expected %lu, got %lu)\n",
+                (unsigned long)(1 + 4 + expected_data_size), field_len);
+        result = 1;
+    } else {
+        /* Verify data content - check first and last bytes to avoid long loop */
+        if (data[0] != 0x42 || data[expected_data_size - 1] != 0x42) {
+            fprintf(stderr, "[FAIL] test_decode_integer_4byte_long_form: data mismatch\n");
+            result = 1;
+        }
+    }
+
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_decode_integer_4byte_long_form\n");
+    return result;
+}
+
+/* Test ber_decode_INTEGER with invalid tag */
+static int test_decode_integer_invalid_tag(void)
+{
+    CK_BYTE encoded[] = {0x04, 0x03, 0x01, 0x02, 0x03};  /* Wrong tag (OCTET STRING) */
+    CK_BYTE *data = NULL;
+    CK_ULONG data_len = 0;
+    CK_ULONG field_len = 0;
+    CK_RV rv;
+
+    rv = ber_decode_INTEGER(encoded, sizeof(encoded), &data, &data_len, &field_len);
+    if (rv == CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_integer_invalid_tag: should have failed\n");
+        return 1;
+    }
+
+    printf("[PASS] test_decode_integer_invalid_tag\n");
+    return 0;
+}
+
+/* Test ber_decode_INTEGER with truncated data */
+static int test_decode_integer_truncated(void)
+{
+    CK_BYTE encoded[] = {0x02, 0x05, 0x01, 0x02};  /* Says length 5 but only 2 bytes follow */
+    CK_BYTE *data = NULL;
+    CK_ULONG data_len = 0;
+    CK_ULONG field_len = 0;
+    CK_RV rv;
+
+    rv = ber_decode_INTEGER(encoded, sizeof(encoded), &data, &data_len, &field_len);
+    if (rv == CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_integer_truncated: should have failed on truncated data\n");
+        return 1;
+    }
+
+    printf("[PASS] test_decode_integer_truncated\n");
+    return 0;
+}
+
+/* Test ber_decode_INTEGER with NULL input */
+static int test_decode_integer_null_input(void)
+{
+    CK_BYTE *data = NULL;
+    CK_ULONG data_len = 0;
+    CK_ULONG field_len = 0;
+    CK_RV rv;
+
+    rv = ber_decode_INTEGER(NULL, 10, &data, &data_len, &field_len);
+    if (rv == CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_integer_null_input: should have failed on NULL input\n");
+        return 1;
+    }
+
+    printf("[PASS] test_decode_integer_null_input\n");
+    return 0;
+}
+
+/* Test ber_decode_INTEGER with too short buffer */
+static int test_decode_integer_too_short(void)
+{
+    CK_BYTE encoded[] = {0x02};  /* Only tag, no length */
+    CK_BYTE *data = NULL;
+    CK_ULONG data_len = 0;
+    CK_ULONG field_len = 0;
+    CK_RV rv;
+
+    rv = ber_decode_INTEGER(encoded, sizeof(encoded), &data, &data_len, &field_len);
+    if (rv == CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_integer_too_short: should have failed on too short buffer\n");
+        return 1;
+    }
+
+    printf("[PASS] test_decode_integer_too_short\n");
+    return 0;
+}
+
+/* Test round-trip: encode then decode INTEGER */
+static int test_roundtrip_integer(void)
+{
+    CK_BYTE original[] = {0x12, 0x34, 0x56, 0x78, 0x9A};
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_BYTE *decoded = NULL;
+    CK_ULONG decoded_len = 0;
+    CK_ULONG field_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* Encode */
+    rv = ber_encode_INTEGER(FALSE, &encoded, &encoded_len, original, sizeof(original));
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_integer: encode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    /* Decode */
+    rv = ber_decode_INTEGER(encoded, encoded_len, &decoded, &decoded_len, &field_len);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_integer: decode failed with rv=%lu\n", rv);
+        free(encoded);
+        return 1;
+    }
+
+    /* Compare */
+    if (decoded_len != sizeof(original)) {
+        fprintf(stderr, "[FAIL] test_roundtrip_integer: length mismatch (expected %lu, got %lu)\n",
+                (unsigned long)sizeof(original), decoded_len);
+        result = 1;
+    } else {
+        result = compare_bytes("test_roundtrip_integer", original, decoded, decoded_len);
+    }
+
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_roundtrip_integer\n");
+    return result;
+}
+
+/* Test ber_encode_OCTET_STRING with short form length */
+static int test_encode_octet_string_short(void)
+{
+    CK_BYTE data[] = {0x48, 0x65, 0x6C, 0x6C, 0x6F};  /* "Hello" */
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* Expected: 0x04 (OCTET STRING tag), 0x05 (length), data */
+    CK_BYTE expected[] = {0x04, 0x05, 0x48, 0x65, 0x6C, 0x6C, 0x6F};
+
+    rv = ber_encode_OCTET_STRING(FALSE, &encoded, &encoded_len, data, sizeof(data));
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_octet_string_short: encode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    if (encoded_len != sizeof(expected)) {
+        fprintf(stderr, "[FAIL] test_encode_octet_string_short: length mismatch (expected %lu, got %lu)\n",
+                (unsigned long)sizeof(expected), encoded_len);
+        result = 1;
+    } else {
+        result = compare_bytes("test_encode_octet_string_short", expected, encoded, encoded_len);
+    }
+
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_encode_octet_string_short\n");
+    return result;
+}
+
+/* Test ber_encode_OCTET_STRING with long form length */
+static int test_encode_octet_string_long_form(void)
+{
+    CK_BYTE data[150];
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    memset(data, 0x55, sizeof(data));
+
+    rv = ber_encode_OCTET_STRING(FALSE, &encoded, &encoded_len, data, sizeof(data));
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_octet_string_long_form: encode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    /* Expected: 0x04 (OCTET STRING tag), 0x81 (long form, 1 byte), 0x96 (150), data */
+    if (encoded_len != 1 + 2 + 150) {
+        fprintf(stderr, "[FAIL] test_encode_octet_string_long_form: length mismatch (expected 153, got %lu)\n",
+                encoded_len);
+        result = 1;
+    } else if (encoded[0] != 0x04 || encoded[1] != 0x81 || encoded[2] != 150) {
+        fprintf(stderr, "[FAIL] test_encode_octet_string_long_form: header mismatch\n");
+        result = 1;
+    } else if (memcmp(&encoded[3], data, 150) != 0) {
+        fprintf(stderr, "[FAIL] test_encode_octet_string_long_form: data mismatch\n");
+        result = 1;
+    }
+
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_encode_octet_string_long_form\n");
+    return result;
+}
+
+/* Test ber_encode_OCTET_STRING with 3-byte long form length (256-65535 bytes) */
+static int test_encode_octet_string_3byte_long_form(void)
+{
+    CK_BYTE *data = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+    const CK_ULONG data_size = 400;  /* 256+ bytes to trigger 3-byte long form */
+
+    /* Allocate and fill data */
+    data = malloc(data_size);
+    if (data == NULL) {
+        fprintf(stderr, "[FAIL] test_encode_octet_string_3byte_long_form: malloc failed\n");
+        return 1;
+    }
+    memset(data, 0x55, data_size);
+
+    rv = ber_encode_OCTET_STRING(FALSE, &encoded, &encoded_len, data, data_size);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_octet_string_3byte_long_form: encode failed with rv=%lu\n", rv);
+        free(data);
+        return 1;
+    }
+
+    /* Expected: 0x04 (OCTET STRING tag), 0x82 (long form, 2 bytes length),
+     * 0x01 0x90 (400 in big-endian), data */
+    if (encoded_len != 1 + 3 + 400) {
+        fprintf(stderr, "[FAIL] test_encode_octet_string_3byte_long_form: length mismatch (expected 404, got %lu)\n",
+                encoded_len);
+        result = 1;
+    } else if (encoded[0] != 0x04 || encoded[1] != 0x82 ||
+               encoded[2] != 0x01 || encoded[3] != 0x90) {
+        fprintf(stderr, "[FAIL] test_encode_octet_string_3byte_long_form: header mismatch\n");
+        fprintf(stderr, "  Expected: 04 82 01 90\n");
+        fprintf(stderr, "  Got:      %02X %02X %02X %02X\n",
+                encoded[0], encoded[1], encoded[2], encoded[3]);
+        result = 1;
+    } else if (memcmp(&encoded[4], data, 400) != 0) {
+        fprintf(stderr, "[FAIL] test_encode_octet_string_3byte_long_form: data mismatch\n");
+        result = 1;
+    }
+
+    free(data);
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_encode_octet_string_3byte_long_form\n");
+    return result;
+}
+
+/* Test ber_encode_OCTET_STRING with 4-byte long form length (65536+ bytes) */
+static int test_encode_octet_string_4byte_long_form(void)
+{
+    CK_BYTE *data = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+    const CK_ULONG data_size = 80000;  /* 65536+ bytes to trigger 4-byte long form */
+
+    /* Allocate and fill data */
+    data = malloc(data_size);
+    if (data == NULL) {
+        fprintf(stderr, "[FAIL] test_encode_octet_string_4byte_long_form: malloc failed\n");
+        return 1;
+    }
+    memset(data, 0x55, data_size);
+
+    rv = ber_encode_OCTET_STRING(FALSE, &encoded, &encoded_len, data, data_size);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_octet_string_4byte_long_form: encode failed with rv=%lu\n", rv);
+        free(data);
+        return 1;
+    }
+
+    /* Expected: 0x04 (OCTET STRING tag), 0x83 (long form, 3 bytes length),
+     * 0x01 0x38 0x80 (80000 in big-endian), data */
+    if (encoded_len != 1 + 4 + 80000) {
+        fprintf(stderr, "[FAIL] test_encode_octet_string_4byte_long_form: length mismatch (expected 80005, got %lu)\n",
+                encoded_len);
+        result = 1;
+    } else if (encoded[0] != 0x04 || encoded[1] != 0x83 ||
+               encoded[2] != 0x01 || encoded[3] != 0x38 || encoded[4] != 0x80) {
+        fprintf(stderr, "[FAIL] test_encode_octet_string_4byte_long_form: header mismatch\n");
+        fprintf(stderr, "  Expected: 04 83 01 38 80\n");
+        fprintf(stderr, "  Got:      %02X %02X %02X %02X %02X\n",
+                encoded[0], encoded[1], encoded[2], encoded[3], encoded[4]);
+        result = 1;
+    } else if (memcmp(&encoded[5], data, 80000) != 0) {
+        fprintf(stderr, "[FAIL] test_encode_octet_string_4byte_long_form: data mismatch\n");
+        result = 1;
+    }
+
+    free(data);
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_encode_octet_string_4byte_long_form\n");
+    return result;
+}
+
+/* Test ber_encode_OCTET_STRING with single byte */
+static int test_encode_octet_string_single_byte(void)
+{
+    CK_BYTE data[] = {0xFF};
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* Expected: 0x04 (OCTET STRING tag), 0x01 (length), data */
+    CK_BYTE expected[] = {0x04, 0x01, 0xFF};
+
+    rv = ber_encode_OCTET_STRING(FALSE, &encoded, &encoded_len, data, sizeof(data));
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_octet_string_single_byte: encode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    if (encoded_len != sizeof(expected)) {
+        fprintf(stderr, "[FAIL] test_encode_octet_string_single_byte: length mismatch (expected %lu, got %lu)\n",
+                (unsigned long)sizeof(expected), encoded_len);
+        result = 1;
+    } else {
+        result = compare_bytes("test_encode_octet_string_single_byte", expected, encoded, encoded_len);
+    }
+
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_encode_octet_string_single_byte\n");
+    return result;
+}
+
+/* Test ber_encode_OCTET_STRING with all zeros */
+static int test_encode_octet_string_all_zeros(void)
+{
+    CK_BYTE data[10] = {0};
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    rv = ber_encode_OCTET_STRING(FALSE, &encoded, &encoded_len, data, sizeof(data));
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_octet_string_all_zeros: encode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    /* Verify encoding and that all data bytes are zero */
+    if (encoded_len != 12) {  /* 1 + 1 + 10 */
+        fprintf(stderr, "[FAIL] test_encode_octet_string_all_zeros: length mismatch (expected 12, got %lu)\n",
+                encoded_len);
+        result = 1;
+    } else if (encoded[0] != 0x04 || encoded[1] != 10) {
+        fprintf(stderr, "[FAIL] test_encode_octet_string_all_zeros: header mismatch\n");
+        result = 1;
+    } else {
+        for (int i = 2; i < 12; i++) {
+            if (encoded[i] != 0x00) {
+                fprintf(stderr, "[FAIL] test_encode_octet_string_all_zeros: data not all zeros\n");
+                result = 1;
+                break;
+            }
+        }
+    }
+
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_encode_octet_string_all_zeros\n");
+    return result;
+}
+
+/* Test ber_decode_OCTET_STRING with short form length */
+static int test_decode_octet_string_short(void)
+{
+    CK_BYTE encoded[] = {0x04, 0x05, 0x48, 0x65, 0x6C, 0x6C, 0x6F};
+    CK_BYTE *data = NULL;
+    CK_ULONG data_len = 0;
+    CK_ULONG field_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    CK_BYTE expected[] = {0x48, 0x65, 0x6C, 0x6C, 0x6F};
+
+    rv = ber_decode_OCTET_STRING(encoded, sizeof(encoded), &data, &data_len, &field_len);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_octet_string_short: decode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    if (data_len != sizeof(expected)) {
+        fprintf(stderr, "[FAIL] test_decode_octet_string_short: length mismatch (expected %lu, got %lu)\n",
+                (unsigned long)sizeof(expected), data_len);
+        result = 1;
+    } else if (field_len != sizeof(encoded)) {
+        fprintf(stderr, "[FAIL] test_decode_octet_string_short: field_len mismatch (expected %lu, got %lu)\n",
+                (unsigned long)sizeof(encoded), field_len);
+        result = 1;
+    } else {
+        result = compare_bytes("test_decode_octet_string_short", expected, data, data_len);
+    }
+
+    if (result == 0)
+        printf("[PASS] test_decode_octet_string_short\n");
+    return result;
+}
+
+/* Test ber_decode_OCTET_STRING with 3-byte long form length (256-65535 bytes) */
+static int test_decode_octet_string_3byte_long_form(void)
+{
+    CK_BYTE *encoded = NULL;
+    CK_BYTE *data = NULL;
+    CK_ULONG data_len = 0;
+    CK_ULONG field_len = 0;
+    CK_RV rv;
+    int result = 0;
+    const CK_ULONG expected_data_size = 400;
+
+    /* Build encoded data: 0x04 (tag), 0x82 (long form 2 bytes), 0x01 0x90 (400), data */
+    encoded = malloc(1 + 3 + expected_data_size);
+    if (encoded == NULL) {
+        fprintf(stderr, "[FAIL] test_decode_octet_string_3byte_long_form: malloc failed\n");
+        return 1;
+    }
+
+    encoded[0] = 0x04;  /* OCTET STRING tag */
+    encoded[1] = 0x82;  /* Long form: 2 length bytes follow */
+    encoded[2] = 0x01;  /* Length high byte */
+    encoded[3] = 0x90;  /* Length low byte (400 = 0x0190) */
+    memset(&encoded[4], 0x55, expected_data_size);
+
+    rv = ber_decode_OCTET_STRING(encoded, 1 + 3 + expected_data_size, &data, &data_len, &field_len);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_octet_string_3byte_long_form: decode failed with rv=%lu\n", rv);
+        free(encoded);
+        return 1;
+    }
+
+    if (data_len != expected_data_size) {
+        fprintf(stderr, "[FAIL] test_decode_octet_string_3byte_long_form: data length mismatch (expected %lu, got %lu)\n",
+                expected_data_size, data_len);
+        result = 1;
+    } else if (field_len != 1 + 3 + expected_data_size) {
+        fprintf(stderr, "[FAIL] test_decode_octet_string_3byte_long_form: field_len mismatch (expected %lu, got %lu)\n",
+                (unsigned long)(1 + 3 + expected_data_size), field_len);
+        result = 1;
+    } else {
+        /* Verify data content */
+        for (CK_ULONG i = 0; i < expected_data_size; i++) {
+            if (data[i] != 0x55) {
+                fprintf(stderr, "[FAIL] test_decode_octet_string_3byte_long_form: data mismatch at byte %lu\n", i);
+                result = 1;
+                break;
+            }
+        }
+    }
+
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_decode_octet_string_3byte_long_form\n");
+    return result;
+}
+
+/* Test ber_decode_OCTET_STRING with 4-byte long form length (65536+ bytes) */
+static int test_decode_octet_string_4byte_long_form(void)
+{
+    CK_BYTE *encoded = NULL;
+    CK_BYTE *data = NULL;
+    CK_ULONG data_len = 0;
+    CK_ULONG field_len = 0;
+    CK_RV rv;
+    int result = 0;
+    const CK_ULONG expected_data_size = 80000;
+
+    /* Build encoded data: 0x04 (tag), 0x83 (long form 3 bytes), 0x01 0x38 0x80 (80000), data */
+    encoded = malloc(1 + 4 + expected_data_size);
+    if (encoded == NULL) {
+        fprintf(stderr, "[FAIL] test_decode_octet_string_4byte_long_form: malloc failed\n");
+        return 1;
+    }
+
+    encoded[0] = 0x04;  /* OCTET STRING tag */
+    encoded[1] = 0x83;  /* Long form: 3 length bytes follow */
+    encoded[2] = 0x01;  /* Length high byte */
+    encoded[3] = 0x38;  /* Length middle byte */
+    encoded[4] = 0x80;  /* Length low byte (80000 = 0x013880) */
+    memset(&encoded[5], 0x55, expected_data_size);
+
+    rv = ber_decode_OCTET_STRING(encoded, 1 + 4 + expected_data_size, &data, &data_len, &field_len);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_octet_string_4byte_long_form: decode failed with rv=%lu\n", rv);
+        free(encoded);
+        return 1;
+    }
+
+    if (data_len != expected_data_size) {
+        fprintf(stderr, "[FAIL] test_decode_octet_string_4byte_long_form: data length mismatch (expected %lu, got %lu)\n",
+                expected_data_size, data_len);
+        result = 1;
+    } else if (field_len != 1 + 4 + expected_data_size) {
+        fprintf(stderr, "[FAIL] test_decode_octet_string_4byte_long_form: field_len mismatch (expected %lu, got %lu)\n",
+                (unsigned long)(1 + 4 + expected_data_size), field_len);
+        result = 1;
+    } else {
+        /* Verify data content - check first and last bytes */
+        if (data[0] != 0x55 || data[expected_data_size - 1] != 0x55) {
+            fprintf(stderr, "[FAIL] test_decode_octet_string_4byte_long_form: data mismatch\n");
+            result = 1;
+        }
+    }
+
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_decode_octet_string_4byte_long_form\n");
+    return result;
+}
+
+/* Test ber_decode_OCTET_STRING with invalid tag */
+static int test_decode_octet_string_invalid_tag(void)
+{
+    CK_BYTE encoded[] = {0x02, 0x05, 0x48, 0x65, 0x6C, 0x6C, 0x6F};  /* Wrong tag (INTEGER) */
+    CK_BYTE *data = NULL;
+    CK_ULONG data_len = 0;
+    CK_ULONG field_len = 0;
+    CK_RV rv;
+
+    rv = ber_decode_OCTET_STRING(encoded, sizeof(encoded), &data, &data_len, &field_len);
+    if (rv == CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_octet_string_invalid_tag: should have failed\n");
+        return 1;
+    }
+
+    printf("[PASS] test_decode_octet_string_invalid_tag\n");
+    return 0;
+}
+
+/* Test ber_decode_OCTET_STRING with NULL input */
+static int test_decode_octet_string_null_input(void)
+{
+    CK_BYTE *data = NULL;
+    CK_ULONG data_len = 0;
+    CK_ULONG field_len = 0;
+    CK_RV rv;
+
+    rv = ber_decode_OCTET_STRING(NULL, 10, &data, &data_len, &field_len);
+    if (rv == CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_octet_string_null_input: should have failed on NULL input\n");
+        return 1;
+    }
+
+    printf("[PASS] test_decode_octet_string_null_input\n");
+    return 0;
+}
+
+/* Test round-trip: encode then decode OCTET_STRING */
+static int test_roundtrip_octet_string(void)
+{
+    CK_BYTE original[] = "Test data for round-trip encoding";
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_BYTE *decoded = NULL;
+    CK_ULONG decoded_len = 0;
+    CK_ULONG field_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* Encode */
+    rv = ber_encode_OCTET_STRING(FALSE, &encoded, &encoded_len, original, sizeof(original) - 1);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_octet_string: encode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    /* Decode */
+    rv = ber_decode_OCTET_STRING(encoded, encoded_len, &decoded, &decoded_len, &field_len);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_octet_string: decode failed with rv=%lu\n", rv);
+        free(encoded);
+        return 1;
+    }
+
+    /* Compare */
+    if (decoded_len != sizeof(original) - 1) {
+        fprintf(stderr, "[FAIL] test_roundtrip_octet_string: length mismatch (expected %lu, got %lu)\n",
+                (unsigned long)(sizeof(original) - 1), decoded_len);
+        result = 1;
+    } else {
+        result = compare_bytes("test_roundtrip_octet_string", original, decoded, decoded_len);
+    }
+
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_roundtrip_octet_string\n");
+    return result;
+}
+
+/* Test ber_encode_BIT_STRING with short form length */
+static int test_encode_bit_string_short(void)
+{
+    CK_BYTE data[] = {0x01, 0x02, 0x03};
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+    CK_BYTE unused_bits = 0x00;
+
+    /* Expected: 0x03 (BIT STRING tag), 0x04 (length = data + unused_bits byte),
+     * 0x00 (unused bits), data */
+    CK_BYTE expected[] = {0x03, 0x04, 0x00, 0x01, 0x02, 0x03};
+
+    rv = ber_encode_BIT_STRING(FALSE, &encoded, &encoded_len, data, sizeof(data), unused_bits);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_bit_string_short: encode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    if (encoded_len != sizeof(expected)) {
+        fprintf(stderr, "[FAIL] test_encode_bit_string_short: length mismatch (expected %lu, got %lu)\n",
+                (unsigned long)sizeof(expected), encoded_len);
+        result = 1;
+    } else {
+        result = compare_bytes("test_encode_bit_string_short", expected, encoded, encoded_len);
+    }
+
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_encode_bit_string_short\n");
+    return result;
+}
+
+/* Test ber_encode_BIT_STRING with long form length (128-255 bytes) */
+static int test_encode_bit_string_long_form(void)
+{
+    CK_BYTE data[150];
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+    CK_BYTE unused_bits = 0x03;  /* 3 unused bits */
+
+    /* Fill with test data */
+    memset(data, 0x55, sizeof(data));
+
+    rv = ber_encode_BIT_STRING(FALSE, &encoded, &encoded_len, data, sizeof(data), unused_bits);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_bit_string_long_form: encode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    /* Expected: 0x03 (BIT STRING tag), 0x81 (long form, 1 byte length),
+     * 0x97 (151 = 150 + 1), 0x03 (unused bits), data */
+    if (encoded_len != 1 + 2 + 1 + 150) {
+        fprintf(stderr, "[FAIL] test_encode_bit_string_long_form: length mismatch (expected 154, got %lu)\n",
+                encoded_len);
+        result = 1;
+    } else if (encoded[0] != 0x03 || encoded[1] != 0x81 || encoded[2] != 151 || encoded[3] != 0x03) {
+        fprintf(stderr, "[FAIL] test_encode_bit_string_long_form: header mismatch\n");
+        result = 1;
+    } else if (memcmp(&encoded[4], data, 150) != 0) {
+        fprintf(stderr, "[FAIL] test_encode_bit_string_long_form: data mismatch\n");
+        result = 1;
+    }
+
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_encode_bit_string_long_form\n");
+    return result;
+}
+
+/* Test ber_encode_BIT_STRING with 3-byte long form length (256-65535 bytes) */
+static int test_encode_bit_string_3byte_long_form(void)
+{
+    CK_BYTE *data = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+    const CK_ULONG data_size = 300;
+    CK_BYTE unused_bits = 0x05;  /* 5 unused bits */
+
+    /* Allocate and fill with test data */
+    data = malloc(data_size);
+    if (data == NULL) {
+        fprintf(stderr, "[FAIL] test_encode_bit_string_3byte_long_form: malloc failed\n");
+        return 1;
+    }
+    memset(data, 0xAA, data_size);
+
+    rv = ber_encode_BIT_STRING(FALSE, &encoded, &encoded_len, data, data_size, unused_bits);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_bit_string_3byte_long_form: encode failed with rv=%lu\n", rv);
+        free(data);
+        return 1;
+    }
+
+    /* Expected: 0x03 (BIT STRING tag), 0x82 (long form, 2 bytes length),
+     * 0x01 0x2D (301 = 300 + 1 in big-endian), 0x05 (unused bits), data */
+    if (encoded_len != 1 + 3 + 1 + 300) {
+        fprintf(stderr, "[FAIL] test_encode_bit_string_3byte_long_form: length mismatch (expected 305, got %lu)\n",
+                encoded_len);
+        result = 1;
+    } else if (encoded[0] != 0x03 || encoded[1] != 0x82 ||
+               encoded[2] != 0x01 || encoded[3] != 0x2D || encoded[4] != 0x05) {
+        fprintf(stderr, "[FAIL] test_encode_bit_string_3byte_long_form: header mismatch\n");
+        fprintf(stderr, "  Expected: 03 82 01 2D 05\n");
+        fprintf(stderr, "  Got:      %02X %02X %02X %02X %02X\n",
+                encoded[0], encoded[1], encoded[2], encoded[3], encoded[4]);
+        result = 1;
+    } else if (memcmp(&encoded[5], data, 300) != 0) {
+        fprintf(stderr, "[FAIL] test_encode_bit_string_3byte_long_form: data mismatch\n");
+        result = 1;
+    }
+
+    free(data);
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_encode_bit_string_3byte_long_form\n");
+    return result;
+}
+
+/* Test ber_encode_BIT_STRING with 4-byte long form length (65536+ bytes) */
+static int test_encode_bit_string_4byte_long_form(void)
+{
+    CK_BYTE *data = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+    const CK_ULONG data_size = 70000;
+    CK_BYTE unused_bits = 0x07;  /* 7 unused bits */
+
+    /* Allocate and fill with test data */
+    data = malloc(data_size);
+    if (data == NULL) {
+        fprintf(stderr, "[FAIL] test_encode_bit_string_4byte_long_form: malloc failed\n");
+        return 1;
+    }
+    memset(data, 0xCC, data_size);
+
+    rv = ber_encode_BIT_STRING(FALSE, &encoded, &encoded_len, data, data_size, unused_bits);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_bit_string_4byte_long_form: encode failed with rv=%lu\n", rv);
+        free(data);
+        return 1;
+    }
+
+    /* Expected: 0x03 (BIT STRING tag), 0x83 (long form, 3 bytes length),
+     * 0x01 0x11 0x71 (70001 = 70000 + 1 in big-endian), 0x07 (unused bits), data */
+    if (encoded_len != 1 + 4 + 1 + 70000) {
+        fprintf(stderr, "[FAIL] test_encode_bit_string_4byte_long_form: length mismatch (expected 70006, got %lu)\n",
+                encoded_len);
+        result = 1;
+    } else if (encoded[0] != 0x03 || encoded[1] != 0x83 ||
+               encoded[2] != 0x01 || encoded[3] != 0x11 || encoded[4] != 0x71 || encoded[5] != 0x07) {
+        fprintf(stderr, "[FAIL] test_encode_bit_string_4byte_long_form: header mismatch\n");
+        fprintf(stderr, "  Expected: 03 83 01 11 71 07\n");
+        fprintf(stderr, "  Got:      %02X %02X %02X %02X %02X %02X\n",
+                encoded[0], encoded[1], encoded[2], encoded[3], encoded[4], encoded[5]);
+        result = 1;
+    } else if (encoded[6] != 0xCC || encoded[encoded_len - 1] != 0xCC) {
+        fprintf(stderr, "[FAIL] test_encode_bit_string_4byte_long_form: data mismatch\n");
+        result = 1;
+    }
+
+    free(data);
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_encode_bit_string_4byte_long_form\n");
+    return result;
+}
+
+/* Test ber_encode_BIT_STRING with length_only mode */
+static int test_encode_bit_string_length_only(void)
+{
+    CK_BYTE data[] = {0x01, 0x02, 0x03};
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    CK_BYTE unused_bits = 0x00;
+
+    rv = ber_encode_BIT_STRING(TRUE, &encoded, &encoded_len, data, sizeof(data), unused_bits);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_bit_string_length_only: encode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    /* Expected length: tag (1) + length (1) + unused_bits (1) + data (3) = 6 */
+    if (encoded_len != 6) {
+        fprintf(stderr, "[FAIL] test_encode_bit_string_length_only: length mismatch (expected 6, got %lu)\n",
+                encoded_len);
+        return 1;
+    }
+
+    if (encoded != NULL) {
+        fprintf(stderr, "[FAIL] test_encode_bit_string_length_only: encoded should be NULL in length_only mode\n");
+        return 1;
+    }
+
+    printf("[PASS] test_encode_bit_string_length_only\n");
+    return 0;
+}
+
+/* Test ber_encode_BIT_STRING with various unused_bits values */
+static int test_encode_bit_string_unused_bits(void)
+{
+    CK_BYTE data[] = {0xFF};
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+    CK_BYTE unused_bits = 0x04;  /* 4 unused bits */
+
+    /* Expected: 0x03 (BIT STRING tag), 0x02 (length), 0x04 (unused bits), 0xFF (data) */
+    CK_BYTE expected[] = {0x03, 0x02, 0x04, 0xFF};
+
+    rv = ber_encode_BIT_STRING(FALSE, &encoded, &encoded_len, data, sizeof(data), unused_bits);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_bit_string_unused_bits: encode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    if (encoded_len != sizeof(expected)) {
+        fprintf(stderr, "[FAIL] test_encode_bit_string_unused_bits: length mismatch (expected %lu, got %lu)\n",
+                (unsigned long)sizeof(expected), encoded_len);
+        result = 1;
+    } else {
+        result = compare_bytes("test_encode_bit_string_unused_bits", expected, encoded, encoded_len);
+    }
+
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_encode_bit_string_unused_bits\n");
+    return result;
+}
+
+/* Test ber_decode_BIT_STRING with short form length */
+static int test_decode_bit_string_short(void)
+{
+    /* BIT STRING with unused bits byte (0x00) followed by data */
+    CK_BYTE encoded[] = {0x03, 0x04, 0x00, 0x01, 0x02, 0x03};
+    CK_BYTE *data = NULL;
+    CK_ULONG data_len = 0;
+    CK_ULONG field_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* Expected: includes unused bits byte */
+    CK_BYTE expected[] = {0x00, 0x01, 0x02, 0x03};
+
+    rv = ber_decode_BIT_STRING(encoded, sizeof(encoded), &data, &data_len, &field_len);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_bit_string_short: decode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    if (data_len != sizeof(expected)) {
+        fprintf(stderr, "[FAIL] test_decode_bit_string_short: length mismatch (expected %lu, got %lu)\n",
+                (unsigned long)sizeof(expected), data_len);
+        result = 1;
+    } else if (field_len != sizeof(encoded)) {
+        fprintf(stderr, "[FAIL] test_decode_bit_string_short: field_len mismatch (expected %lu, got %lu)\n",
+                (unsigned long)sizeof(encoded), field_len);
+        result = 1;
+    } else {
+        result = compare_bytes("test_decode_bit_string_short", expected, data, data_len);
+    }
+
+    if (result == 0)
+        printf("[PASS] test_decode_bit_string_short\n");
+    return result;
+}
+
+/* Test ber_decode_BIT_STRING with invalid tag */
+static int test_decode_bit_string_invalid_tag(void)
+{
+    CK_BYTE encoded[] = {0x04, 0x04, 0x00, 0x01, 0x02, 0x03};  /* Wrong tag (OCTET STRING) */
+    CK_BYTE *data = NULL;
+    CK_ULONG data_len = 0;
+    CK_ULONG field_len = 0;
+    CK_RV rv;
+
+    rv = ber_decode_BIT_STRING(encoded, sizeof(encoded), &data, &data_len, &field_len);
+    if (rv == CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_bit_string_invalid_tag: should have failed\n");
+        return 1;
+    }
+
+    printf("[PASS] test_decode_bit_string_invalid_tag\n");
+    return 0;
+}
+
+/* Test ber_decode_BIT_STRING with NULL input */
+static int test_decode_bit_string_null_input(void)
+{
+    CK_BYTE *data = NULL;
+    CK_ULONG data_len = 0;
+    CK_ULONG field_len = 0;
+    CK_RV rv;
+
+    rv = ber_decode_BIT_STRING(NULL, 10, &data, &data_len, &field_len);
+    if (rv == CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_bit_string_null_input: should have failed on NULL input\n");
+        return 1;
+    }
+
+    printf("[PASS] test_decode_bit_string_null_input\n");
+    return 0;
+}
+
+/* Test ber_decode_BIT_STRING with too short length (no unused bits byte) */
+static int test_decode_bit_string_no_unused_byte(void)
+{
+    CK_BYTE encoded[] = {0x03, 0x00};  /* BIT STRING with length 0 - invalid */
+    CK_BYTE *data = NULL;
+    CK_ULONG data_len = 0;
+    CK_ULONG field_len = 0;
+    CK_RV rv;
+
+    rv = ber_decode_BIT_STRING(encoded, sizeof(encoded), &data, &data_len, &field_len);
+    if (rv == CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_bit_string_no_unused_byte: should have failed (no unused bits byte)\n");
+        return 1;
+    }
+
+    printf("[PASS] test_decode_bit_string_no_unused_byte\n");
+    return 0;
+}
+
+/* Test ber_encode_BIT_STRING roundtrip */
+static int test_roundtrip_bit_string(void)
+{
+    CK_BYTE original[] = {0x01, 0x02, 0x03, 0x04, 0x05};
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_BYTE *decoded = NULL;
+    CK_ULONG decoded_len = 0;
+    CK_ULONG field_len = 0;
+    CK_RV rv;
+    int result = 0;
+    CK_BYTE unused_bits = 0x02;  /* 2 unused bits */
+
+    /* Encode */
+    rv = ber_encode_BIT_STRING(FALSE, &encoded, &encoded_len, original, sizeof(original), unused_bits);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_bit_string: encode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    /* Decode */
+    rv = ber_decode_BIT_STRING(encoded, encoded_len, &decoded, &decoded_len, &field_len);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_bit_string: decode failed with rv=%lu\n", rv);
+        free(encoded);
+        return 1;
+    }
+
+    /* Verify: decoded includes unused_bits byte + original data */
+    if (decoded_len != sizeof(original) + 1) {
+        fprintf(stderr, "[FAIL] test_roundtrip_bit_string: decoded length mismatch (expected %lu, got %lu)\n",
+                (unsigned long)(sizeof(original) + 1), decoded_len);
+        result = 1;
+    } else if (decoded[0] != unused_bits) {
+        fprintf(stderr, "[FAIL] test_roundtrip_bit_string: unused_bits mismatch (expected 0x%02X, got 0x%02X)\n",
+                unused_bits, decoded[0]);
+        result = 1;
+    } else if (memcmp(&decoded[1], original, sizeof(original)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_bit_string: data mismatch\n");
+        result = 1;
+    }
+
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_roundtrip_bit_string\n");
+    return result;
+}
+
+/* Test ber_encode_SEQUENCE with short form length */
+static int test_encode_sequence_short(void)
+{
+    CK_BYTE data[] = {0x02, 0x01, 0x05};  /* INTEGER 5 */
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* Expected: 0x30 (SEQUENCE tag), 0x03 (length), data */
+    CK_BYTE expected[] = {0x30, 0x03, 0x02, 0x01, 0x05};
+
+    rv = ber_encode_SEQUENCE(FALSE, &encoded, &encoded_len, data, sizeof(data));
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_sequence_short: encode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    if (encoded_len != sizeof(expected)) {
+        fprintf(stderr, "[FAIL] test_encode_sequence_short: length mismatch (expected %lu, got %lu)\n",
+                (unsigned long)sizeof(expected), encoded_len);
+        result = 1;
+    } else {
+        result = compare_bytes("test_encode_sequence_short", expected, encoded, encoded_len);
+    }
+
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_encode_sequence_short\n");
+    return result;
+}
+
+/* Test ber_encode_SEQUENCE with long form length */
+static int test_encode_sequence_long_form(void)
+{
+    CK_BYTE data[200];
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    memset(data, 0x42, sizeof(data));
+
+    rv = ber_encode_SEQUENCE(FALSE, &encoded, &encoded_len, data, sizeof(data));
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_sequence_long_form: encode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    /* Expected: 0x30 (SEQUENCE tag), 0x81 (long form, 1 byte), 0xC8 (200), data */
+    if (encoded_len != 1 + 2 + 200) {
+        fprintf(stderr, "[FAIL] test_encode_sequence_long_form: length mismatch (expected 203, got %lu)\n",
+                encoded_len);
+        result = 1;
+    } else if (encoded[0] != 0x30 || encoded[1] != 0x81 || encoded[2] != 200) {
+        fprintf(stderr, "[FAIL] test_encode_sequence_long_form: header mismatch\n");
+        result = 1;
+    } else if (memcmp(&encoded[3], data, 200) != 0) {
+        fprintf(stderr, "[FAIL] test_encode_sequence_long_form: data mismatch\n");
+        result = 1;
+    }
+
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_encode_sequence_long_form\n");
+    return result;
+}
+
+/* Test ber_encode_SEQUENCE with 3-byte long form length (256-65535 bytes) */
+static int test_encode_sequence_3byte_long_form(void)
+{
+    CK_BYTE *data = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+    const CK_ULONG data_size = 350;  /* 256+ bytes to trigger 3-byte long form */
+
+    /* Allocate and fill data */
+    data = malloc(data_size);
+    if (data == NULL) {
+        fprintf(stderr, "[FAIL] test_encode_sequence_3byte_long_form: malloc failed\n");
+        return 1;
+    }
+    memset(data, 0x33, data_size);
+
+    rv = ber_encode_SEQUENCE(FALSE, &encoded, &encoded_len, data, data_size);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_sequence_3byte_long_form: encode failed with rv=%lu\n", rv);
+        free(data);
+        return 1;
+    }
+
+    /* Expected: 0x30 (SEQUENCE tag), 0x82 (long form, 2 bytes length),
+     * 0x01 0x5E (350 in big-endian), data */
+    if (encoded_len != 1 + 3 + 350) {
+        fprintf(stderr, "[FAIL] test_encode_sequence_3byte_long_form: length mismatch (expected 354, got %lu)\n",
+                encoded_len);
+        result = 1;
+    } else if (encoded[0] != 0x30 || encoded[1] != 0x82 ||
+               encoded[2] != 0x01 || encoded[3] != 0x5E) {
+        fprintf(stderr, "[FAIL] test_encode_sequence_3byte_long_form: header mismatch\n");
+        fprintf(stderr, "  Expected: 30 82 01 5E\n");
+        fprintf(stderr, "  Got:      %02X %02X %02X %02X\n",
+                encoded[0], encoded[1], encoded[2], encoded[3]);
+        result = 1;
+    } else if (memcmp(&encoded[4], data, 350) != 0) {
+        fprintf(stderr, "[FAIL] test_encode_sequence_3byte_long_form: data mismatch\n");
+        result = 1;
+    }
+
+    free(data);
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_encode_sequence_3byte_long_form\n");
+    return result;
+}
+
+/* Test ber_encode_SEQUENCE with 4-byte long form length (65536+ bytes) */
+static int test_encode_sequence_4byte_long_form(void)
+{
+    CK_BYTE *data = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+    const CK_ULONG data_size = 90000;  /* 65536+ bytes to trigger 4-byte long form */
+
+    /* Allocate and fill data */
+    data = malloc(data_size);
+    if (data == NULL) {
+        fprintf(stderr, "[FAIL] test_encode_sequence_4byte_long_form: malloc failed\n");
+        return 1;
+    }
+    memset(data, 0x33, data_size);
+
+    rv = ber_encode_SEQUENCE(FALSE, &encoded, &encoded_len, data, data_size);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_sequence_4byte_long_form: encode failed with rv=%lu\n", rv);
+        free(data);
+        return 1;
+    }
+
+    /* Expected: 0x30 (SEQUENCE tag), 0x83 (long form, 3 bytes length),
+     * 0x01 0x5F 0x90 (90000 in big-endian), data */
+    if (encoded_len != 1 + 4 + 90000) {
+        fprintf(stderr, "[FAIL] test_encode_sequence_4byte_long_form: length mismatch (expected 90005, got %lu)\n",
+                encoded_len);
+        result = 1;
+    } else if (encoded[0] != 0x30 || encoded[1] != 0x83 ||
+               encoded[2] != 0x01 || encoded[3] != 0x5F || encoded[4] != 0x90) {
+        fprintf(stderr, "[FAIL] test_encode_sequence_4byte_long_form: header mismatch\n");
+        fprintf(stderr, "  Expected: 30 83 01 5F 90\n");
+        fprintf(stderr, "  Got:      %02X %02X %02X %02X %02X\n",
+                encoded[0], encoded[1], encoded[2], encoded[3], encoded[4]);
+        result = 1;
+    } else if (memcmp(&encoded[5], data, 90000) != 0) {
+        fprintf(stderr, "[FAIL] test_encode_sequence_4byte_long_form: data mismatch\n");
+        result = 1;
+    }
+
+    free(data);
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_encode_sequence_4byte_long_form\n");
+    return result;
+}
+
+/* Test ber_decode_SEQUENCE with short form length */
+static int test_decode_sequence_short(void)
+{
+    CK_BYTE encoded[] = {0x30, 0x03, 0x02, 0x01, 0x05};
+    CK_BYTE *data = NULL;
+    CK_ULONG data_len = 0;
+    CK_ULONG field_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    CK_BYTE expected[] = {0x02, 0x01, 0x05};
+
+    rv = ber_decode_SEQUENCE(encoded, sizeof(encoded), &data, &data_len, &field_len);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_sequence_short: decode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    if (data_len != sizeof(expected)) {
+        fprintf(stderr, "[FAIL] test_decode_sequence_short: length mismatch (expected %lu, got %lu)\n",
+                (unsigned long)sizeof(expected), data_len);
+        result = 1;
+    } else if (field_len != sizeof(encoded)) {
+        fprintf(stderr, "[FAIL] test_decode_sequence_short: field_len mismatch (expected %lu, got %lu)\n",
+                (unsigned long)sizeof(encoded), field_len);
+        result = 1;
+    } else {
+        result = compare_bytes("test_decode_sequence_short", expected, data, data_len);
+    }
+
+    if (result == 0)
+        printf("[PASS] test_decode_sequence_short\n");
+    return result;
+}
+
+/* Test ber_decode_SEQUENCE with 3-byte long form length (256-65535 bytes) */
+static int test_decode_sequence_3byte_long_form(void)
+{
+    CK_BYTE *encoded = NULL;
+    CK_BYTE *data = NULL;
+    CK_ULONG data_len = 0;
+    CK_ULONG field_len = 0;
+    CK_RV rv;
+    int result = 0;
+    const CK_ULONG expected_data_size = 350;
+
+    /* Build encoded data: 0x30 (tag), 0x82 (long form 2 bytes), 0x01 0x5E (350), data */
+    encoded = malloc(1 + 3 + expected_data_size);
+    if (encoded == NULL) {
+        fprintf(stderr, "[FAIL] test_decode_sequence_3byte_long_form: malloc failed\n");
+        return 1;
+    }
+
+    encoded[0] = 0x30;  /* SEQUENCE tag */
+    encoded[1] = 0x82;  /* Long form: 2 length bytes follow */
+    encoded[2] = 0x01;  /* Length high byte */
+    encoded[3] = 0x5E;  /* Length low byte (350 = 0x015E) */
+    memset(&encoded[4], 0x33, expected_data_size);
+
+    rv = ber_decode_SEQUENCE(encoded, 1 + 3 + expected_data_size, &data, &data_len, &field_len);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_sequence_3byte_long_form: decode failed with rv=%lu\n", rv);
+        free(encoded);
+        return 1;
+    }
+
+    if (data_len != expected_data_size) {
+        fprintf(stderr, "[FAIL] test_decode_sequence_3byte_long_form: data length mismatch (expected %lu, got %lu)\n",
+                expected_data_size, data_len);
+        result = 1;
+    } else if (field_len != 1 + 3 + expected_data_size) {
+        fprintf(stderr, "[FAIL] test_decode_sequence_3byte_long_form: field_len mismatch (expected %lu, got %lu)\n",
+                (unsigned long)(1 + 3 + expected_data_size), field_len);
+        result = 1;
+    } else {
+        /* Verify data content */
+        for (CK_ULONG i = 0; i < expected_data_size; i++) {
+            if (data[i] != 0x33) {
+                fprintf(stderr, "[FAIL] test_decode_sequence_3byte_long_form: data mismatch at byte %lu\n", i);
+                result = 1;
+                break;
+            }
+        }
+    }
+
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_decode_sequence_3byte_long_form\n");
+    return result;
+}
+
+/* Test ber_decode_SEQUENCE with 4-byte long form length (65536+ bytes) */
+static int test_decode_sequence_4byte_long_form(void)
+{
+    CK_BYTE *encoded = NULL;
+    CK_BYTE *data = NULL;
+    CK_ULONG data_len = 0;
+    CK_ULONG field_len = 0;
+    CK_RV rv;
+    int result = 0;
+    const CK_ULONG expected_data_size = 90000;
+
+    /* Build encoded data: 0x30 (tag), 0x83 (long form 3 bytes), 0x01 0x5F 0x90 (90000), data */
+    encoded = malloc(1 + 4 + expected_data_size);
+    if (encoded == NULL) {
+        fprintf(stderr, "[FAIL] test_decode_sequence_4byte_long_form: malloc failed\n");
+        return 1;
+    }
+
+    encoded[0] = 0x30;  /* SEQUENCE tag */
+    encoded[1] = 0x83;  /* Long form: 3 length bytes follow */
+    encoded[2] = 0x01;  /* Length high byte */
+    encoded[3] = 0x5F;  /* Length middle byte */
+    encoded[4] = 0x90;  /* Length low byte (90000 = 0x015F90) */
+    memset(&encoded[5], 0x33, expected_data_size);
+
+    rv = ber_decode_SEQUENCE(encoded, 1 + 4 + expected_data_size, &data, &data_len, &field_len);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_sequence_4byte_long_form: decode failed with rv=%lu\n", rv);
+        free(encoded);
+        return 1;
+    }
+
+    if (data_len != expected_data_size) {
+        fprintf(stderr, "[FAIL] test_decode_sequence_4byte_long_form: data length mismatch (expected %lu, got %lu)\n",
+                expected_data_size, data_len);
+        result = 1;
+    } else if (field_len != 1 + 4 + expected_data_size) {
+        fprintf(stderr, "[FAIL] test_decode_sequence_4byte_long_form: field_len mismatch (expected %lu, got %lu)\n",
+                (unsigned long)(1 + 4 + expected_data_size), field_len);
+        result = 1;
+    } else {
+        /* Verify data content - check first and last bytes */
+        if (data[0] != 0x33 || data[expected_data_size - 1] != 0x33) {
+            fprintf(stderr, "[FAIL] test_decode_sequence_4byte_long_form: data mismatch\n");
+            result = 1;
+        }
+    }
+
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_decode_sequence_4byte_long_form\n");
+    return result;
+}
+
+/* Test ber_decode_SEQUENCE with invalid tag */
+static int test_decode_sequence_invalid_tag(void)
+{
+    CK_BYTE encoded[] = {0x04, 0x03, 0x02, 0x01, 0x05};  /* Wrong tag (OCTET STRING) */
+    CK_BYTE *data = NULL;
+    CK_ULONG data_len = 0;
+    CK_ULONG field_len = 0;
+    CK_RV rv;
+
+    rv = ber_decode_SEQUENCE(encoded, sizeof(encoded), &data, &data_len, &field_len);
+    if (rv == CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_sequence_invalid_tag: should have failed\n");
+        return 1;
+    }
+
+    printf("[PASS] test_decode_sequence_invalid_tag\n");
+    return 0;
+}
+
+/* Test ber_decode_SEQUENCE with empty sequence */
+static int test_decode_sequence_empty(void)
+{
+    CK_BYTE encoded[] = {0x30, 0x00};  /* Empty SEQUENCE */
+    CK_BYTE *data = NULL;
+    CK_ULONG data_len = 0;
+    CK_ULONG field_len = 0;
+    CK_RV rv;
+
+    rv = ber_decode_SEQUENCE(encoded, sizeof(encoded), &data, &data_len, &field_len);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_sequence_empty: decode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    if (data_len != 0) {
+        fprintf(stderr, "[FAIL] test_decode_sequence_empty: expected empty data, got %lu bytes\n", data_len);
+        return 1;
+    }
+
+    if (field_len != 2) {
+        fprintf(stderr, "[FAIL] test_decode_sequence_empty: field_len mismatch (expected 2, got %lu)\n", field_len);
+        return 1;
+    }
+
+    printf("[PASS] test_decode_sequence_empty\n");
+    return 0;
+}
+
+/* Test ber_decode_SEQUENCE with NULL input */
+static int test_decode_sequence_null_input(void)
+{
+    CK_BYTE *data = NULL;
+    CK_ULONG data_len = 0;
+    CK_ULONG field_len = 0;
+    CK_RV rv;
+
+    rv = ber_decode_SEQUENCE(NULL, 10, &data, &data_len, &field_len);
+    if (rv == CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_sequence_null_input: should have failed on NULL input\n");
+        return 1;
+    }
+
+    printf("[PASS] test_decode_sequence_null_input\n");
+    return 0;
+}
+
+/* Test round-trip: encode then decode SEQUENCE */
+static int test_roundtrip_sequence(void)
+{
+    CK_BYTE original[] = {0x02, 0x01, 0x05, 0x04, 0x03, 0x61, 0x62, 0x63};
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_BYTE *decoded = NULL;
+    CK_ULONG decoded_len = 0;
+    CK_ULONG field_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* Encode */
+    rv = ber_encode_SEQUENCE(FALSE, &encoded, &encoded_len, original, sizeof(original));
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_sequence: encode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    /* Decode */
+    rv = ber_decode_SEQUENCE(encoded, encoded_len, &decoded, &decoded_len, &field_len);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_sequence: decode failed with rv=%lu\n", rv);
+        free(encoded);
+        return 1;
+    }
+
+    /* Compare */
+    if (decoded_len != sizeof(original)) {
+        fprintf(stderr, "[FAIL] test_roundtrip_sequence: length mismatch (expected %lu, got %lu)\n",
+                (unsigned long)sizeof(original), decoded_len);
+        result = 1;
+    } else {
+        result = compare_bytes("test_roundtrip_sequence", original, decoded, decoded_len);
+    }
+
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_roundtrip_sequence\n");
+    return result;
+}
+
+/* Test ber_encode_CHOICE with primitive (non-constructed) short form */
+static int test_encode_choice_primitive_short(void)
+{
+    CK_BYTE data[] = {0x01, 0x02, 0x03};
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_BYTE option = 0x05;  /* Option/tag number */
+    CK_RV rv;
+    int result = 0;
+
+    /* Expected: 0x85 (context-specific, primitive, tag 5), 0x03 (length), data */
+    CK_BYTE expected[] = {0x85, 0x03, 0x01, 0x02, 0x03};
+
+    rv = ber_encode_CHOICE(FALSE, option, &encoded, &encoded_len, data, sizeof(data), FALSE);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_choice_primitive_short: encode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    if (encoded_len != sizeof(expected)) {
+        fprintf(stderr, "[FAIL] test_encode_choice_primitive_short: length mismatch (expected %lu, got %lu)\n",
+                (unsigned long)sizeof(expected), encoded_len);
+        result = 1;
+    } else {
+        result = compare_bytes("test_encode_choice_primitive_short", expected, encoded, encoded_len);
+    }
+
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_encode_choice_primitive_short\n");
+    return result;
+}
+
+/* Test ber_encode_CHOICE with constructed short form */
+static int test_encode_choice_constructed_short(void)
+{
+    CK_BYTE data[] = {0x02, 0x01, 0x05};  /* INTEGER 5 */
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_BYTE option = 0x00;  /* Option/tag number 0 */
+    CK_RV rv;
+    int result = 0;
+
+    /* Expected: 0xA0 (context-specific, constructed, tag 0), 0x03 (length), data */
+    CK_BYTE expected[] = {0xA0, 0x03, 0x02, 0x01, 0x05};
+
+    rv = ber_encode_CHOICE(FALSE, option, &encoded, &encoded_len, data, sizeof(data), TRUE);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_choice_constructed_short: encode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    if (encoded_len != sizeof(expected)) {
+        fprintf(stderr, "[FAIL] test_encode_choice_constructed_short: length mismatch (expected %lu, got %lu)\n",
+                (unsigned long)sizeof(expected), encoded_len);
+        result = 1;
+    } else {
+        result = compare_bytes("test_encode_choice_constructed_short", expected, encoded, encoded_len);
+    }
+
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_encode_choice_constructed_short\n");
+    return result;
+}
+
+/* Test ber_encode_CHOICE with long form length */
+static int test_encode_choice_long_form(void)
+{
+    CK_BYTE data[150];
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_BYTE option = 0x03;
+    CK_RV rv;
+    int result = 0;
+
+    memset(data, 0x42, sizeof(data));
+
+    rv = ber_encode_CHOICE(FALSE, option, &encoded, &encoded_len, data, sizeof(data), FALSE);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_choice_long_form: encode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    /* Expected: 0x83 (context-specific, primitive, tag 3), 0x81 (long form, 1 byte), 0x96 (150), data */
+    if (encoded_len != 1 + 2 + 150) {
+        fprintf(stderr, "[FAIL] test_encode_choice_long_form: length mismatch (expected 153, got %lu)\n",
+                encoded_len);
+        result = 1;
+    } else if (encoded[0] != 0x83 || encoded[1] != 0x81 || encoded[2] != 150) {
+        fprintf(stderr, "[FAIL] test_encode_choice_long_form: header mismatch (got %02X %02X %02X)\n",
+                encoded[0], encoded[1], encoded[2]);
+        result = 1;
+    } else if (memcmp(&encoded[3], data, 150) != 0) {
+        fprintf(stderr, "[FAIL] test_encode_choice_long_form: data mismatch\n");
+        result = 1;
+    }
+
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_encode_choice_long_form\n");
+    return result;
+}
+
+/* Test ber_encode_CHOICE with 3-byte long form length (256-65535 bytes) */
+static int test_encode_choice_3byte_long_form(void)
+{
+    CK_BYTE *data = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+    const CK_ULONG data_size = 500;  /* 256+ bytes to trigger 3-byte long form */
+
+    /* Allocate and fill data */
+    data = malloc(data_size);
+    if (data == NULL) {
+        fprintf(stderr, "[FAIL] test_encode_choice_3byte_long_form: malloc failed\n");
+        return 1;
+    }
+    memset(data, 0x42, data_size);
+
+    /* Encode with option 3, constructed=FALSE */
+    rv = ber_encode_CHOICE(FALSE, 0x03, &encoded, &encoded_len, data, data_size, FALSE);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_choice_3byte_long_form: encode failed with rv=%lu\n", rv);
+        free(data);
+        return 1;
+    }
+
+    /* Expected: 0x83 (option 3, primitive), 0x82 (long form, 2 bytes length),
+     * 0x01 0xF4 (500 in big-endian), data */
+    if (encoded_len != 1 + 3 + 500) {
+        fprintf(stderr, "[FAIL] test_encode_choice_3byte_long_form: length mismatch (expected 504, got %lu)\n",
+                encoded_len);
+        result = 1;
+    } else if (encoded[0] != 0x83 || encoded[1] != 0x82 ||
+               encoded[2] != 0x01 || encoded[3] != 0xF4) {
+        fprintf(stderr, "[FAIL] test_encode_choice_3byte_long_form: header mismatch\n");
+        fprintf(stderr, "  Expected: 83 82 01 F4\n");
+        fprintf(stderr, "  Got:      %02X %02X %02X %02X\n",
+                encoded[0], encoded[1], encoded[2], encoded[3]);
+        result = 1;
+    } else if (memcmp(&encoded[4], data, 500) != 0) {
+        fprintf(stderr, "[FAIL] test_encode_choice_3byte_long_form: data mismatch\n");
+        result = 1;
+    }
+
+    free(data);
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_encode_choice_3byte_long_form\n");
+    return result;
+}
+
+/* Test ber_encode_CHOICE with 4-byte long form length (65536+ bytes) */
+static int test_encode_choice_4byte_long_form(void)
+{
+    CK_BYTE *data = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+    const CK_ULONG data_size = 100000;  /* 65536+ bytes to trigger 4-byte long form */
+
+    /* Allocate and fill data */
+    data = malloc(data_size);
+    if (data == NULL) {
+        fprintf(stderr, "[FAIL] test_encode_choice_4byte_long_form: malloc failed\n");
+        return 1;
+    }
+    memset(data, 0x42, data_size);
+
+    /* Encode with option 3, constructed=FALSE */
+    rv = ber_encode_CHOICE(FALSE, 0x03, &encoded, &encoded_len, data, data_size, FALSE);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_choice_4byte_long_form: encode failed with rv=%lu\n", rv);
+        free(data);
+        return 1;
+    }
+
+    /* Expected: 0x83 (option 3, primitive), 0x83 (long form, 3 bytes length),
+     * 0x01 0x86 0xA0 (100000 in big-endian), data */
+    if (encoded_len != 1 + 4 + 100000) {
+        fprintf(stderr, "[FAIL] test_encode_choice_4byte_long_form: length mismatch (expected 100005, got %lu)\n",
+                encoded_len);
+        result = 1;
+    } else if (encoded[0] != 0x83 || encoded[1] != 0x83 ||
+               encoded[2] != 0x01 || encoded[3] != 0x86 || encoded[4] != 0xA0) {
+        fprintf(stderr, "[FAIL] test_encode_choice_4byte_long_form: header mismatch\n");
+        fprintf(stderr, "  Expected: 83 83 01 86 A0\n");
+        fprintf(stderr, "  Got:      %02X %02X %02X %02X %02X\n",
+                encoded[0], encoded[1], encoded[2], encoded[3], encoded[4]);
+        result = 1;
+    } else if (memcmp(&encoded[5], data, 100000) != 0) {
+        fprintf(stderr, "[FAIL] test_encode_choice_4byte_long_form: data mismatch\n");
+        result = 1;
+    }
+
+    free(data);
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_encode_choice_4byte_long_form\n");
+    return result;
+}
+
+/* Test ber_encode_CHOICE length_only mode */
+static int test_encode_choice_length_only(void)
+{
+    CK_BYTE data[] = {0x01, 0x02, 0x03};
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_BYTE option = 0x05;
+    CK_RV rv;
+
+    rv = ber_encode_CHOICE(TRUE, option, &encoded, &encoded_len, data, sizeof(data), FALSE);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_choice_length_only: encode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    /* Expected length: 1 (tag) + 1 (length) + 3 (data) = 5 */
+    if (encoded_len != 5) {
+        fprintf(stderr, "[FAIL] test_encode_choice_length_only: length mismatch (expected 5, got %lu)\n",
+                encoded_len);
+        return 1;
+    }
+
+    if (encoded != NULL) {
+        fprintf(stderr, "[FAIL] test_encode_choice_length_only: encoded should be NULL in length_only mode\n");
+        return 1;
+    }
+
+    printf("[PASS] test_encode_choice_length_only\n");
+    return 0;
+}
+
+/* Test ber_encode_CHOICE with maximum option value (0x1F) */
+static int test_encode_choice_max_option(void)
+{
+    CK_BYTE data[] = {0x01, 0x02};
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_BYTE option = 0x1F;  /* Maximum 5-bit value */
+    CK_RV rv;
+    int result = 0;
+
+    rv = ber_encode_CHOICE(FALSE, option, &encoded, &encoded_len, data, sizeof(data), FALSE);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_choice_max_option: encode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    /* Expected: 0x9F (context-specific, primitive, tag 31), length, data */
+    if (encoded[0] != 0x9F) {
+        fprintf(stderr, "[FAIL] test_encode_choice_max_option: tag mismatch (expected 0x9F, got %02X)\n",
+                encoded[0]);
+        result = 1;
+    }
+
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_encode_choice_max_option\n");
+    return result;
+}
+
+/* Test ber_decode_CHOICE with primitive short form */
+static int test_decode_choice_primitive_short(void)
+{
+    CK_BYTE encoded[] = {0x85, 0x03, 0x01, 0x02, 0x03};
+    CK_BYTE *data = NULL;
+    CK_ULONG data_len = 0;
+    CK_ULONG field_len = 0;
+    CK_ULONG option = 0;
+    CK_RV rv;
+    int result = 0;
+
+    CK_BYTE expected[] = {0x01, 0x02, 0x03};
+
+    rv = ber_decode_CHOICE(encoded, sizeof(encoded), FALSE, &data, &data_len, &field_len, &option);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_choice_primitive_short: decode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    if (option != 0x05) {
+        fprintf(stderr, "[FAIL] test_decode_choice_primitive_short: option mismatch (expected 5, got %lu)\n",
+                option);
+        result = 1;
+    } else if (data_len != sizeof(expected)) {
+        fprintf(stderr, "[FAIL] test_decode_choice_primitive_short: length mismatch (expected %lu, got %lu)\n",
+                (unsigned long)sizeof(expected), data_len);
+        result = 1;
+    } else if (field_len != sizeof(encoded)) {
+        fprintf(stderr, "[FAIL] test_decode_choice_primitive_short: field_len mismatch (expected %lu, got %lu)\n",
+                (unsigned long)sizeof(encoded), field_len);
+        result = 1;
+    } else {
+        result = compare_bytes("test_decode_choice_primitive_short", expected, data, data_len);
+    }
+
+    if (result == 0)
+        printf("[PASS] test_decode_choice_primitive_short\n");
+    return result;
+}
+
+/* Test ber_decode_CHOICE with constructed short form */
+static int test_decode_choice_constructed_short(void)
+{
+    CK_BYTE encoded[] = {0xA0, 0x03, 0x02, 0x01, 0x05};
+    CK_BYTE *data = NULL;
+    CK_ULONG data_len = 0;
+    CK_ULONG field_len = 0;
+    CK_ULONG option = 0;
+    CK_RV rv;
+    int result = 0;
+
+    CK_BYTE expected[] = {0x02, 0x01, 0x05};
+
+    rv = ber_decode_CHOICE(encoded, sizeof(encoded), TRUE, &data, &data_len, &field_len, &option);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_choice_constructed_short: decode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    if (option != 0x00) {
+        fprintf(stderr, "[FAIL] test_decode_choice_constructed_short: option mismatch (expected 0, got %lu)\n",
+                option);
+        result = 1;
+    } else if (data_len != sizeof(expected)) {
+        fprintf(stderr, "[FAIL] test_decode_choice_constructed_short: length mismatch (expected %lu, got %lu)\n",
+                (unsigned long)sizeof(expected), data_len);
+        result = 1;
+    } else if (field_len != sizeof(encoded)) {
+        fprintf(stderr, "[FAIL] test_decode_choice_constructed_short: field_len mismatch (expected %lu, got %lu)\n",
+                (unsigned long)sizeof(encoded), field_len);
+        result = 1;
+    } else {
+        result = compare_bytes("test_decode_choice_constructed_short", expected, data, data_len);
+    }
+
+    if (result == 0)
+        printf("[PASS] test_decode_choice_constructed_short\n");
+    return result;
+}
+
+/* Test ber_decode_CHOICE with invalid constructed flag */
+static int test_decode_choice_invalid_constructed(void)
+{
+    CK_BYTE encoded[] = {0xA0, 0x03, 0x02, 0x01, 0x05};  /* Constructed tag */
+    CK_BYTE *data = NULL;
+    CK_ULONG data_len = 0;
+    CK_ULONG field_len = 0;
+    CK_ULONG option = 0;
+    CK_RV rv;
+
+    /* Try to decode as primitive - should fail */
+    rv = ber_decode_CHOICE(encoded, sizeof(encoded), FALSE, &data, &data_len, &field_len, &option);
+    if (rv == CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_choice_invalid_constructed: should have failed\n");
+        return 1;
+    }
+
+    printf("[PASS] test_decode_choice_invalid_constructed\n");
+    return 0;
+}
+
+/* Test ber_decode_CHOICE with long form length */
+static int test_decode_choice_long_form(void)
+{
+    CK_BYTE encoded[153];
+    CK_BYTE *data = NULL;
+    CK_ULONG data_len = 0;
+    CK_ULONG field_len = 0;
+    CK_ULONG option = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* Build encoded data: tag, long form length, data */
+    encoded[0] = 0x83;  /* context-specific, primitive, tag 3 */
+    encoded[1] = 0x81;  /* long form, 1 byte length */
+    encoded[2] = 150;   /* length = 150 */
+    memset(&encoded[3], 0x42, 150);
+
+    rv = ber_decode_CHOICE(encoded, sizeof(encoded), FALSE, &data, &data_len, &field_len, &option);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_choice_long_form: decode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    if (option != 0x03) {
+        fprintf(stderr, "[FAIL] test_decode_choice_long_form: option mismatch (expected 3, got %lu)\n",
+                option);
+        result = 1;
+    } else if (data_len != 150) {
+        fprintf(stderr, "[FAIL] test_decode_choice_long_form: length mismatch (expected 150, got %lu)\n",
+                data_len);
+        result = 1;
+    } else if (field_len != 153) {
+        fprintf(stderr, "[FAIL] test_decode_choice_long_form: field_len mismatch (expected 153, got %lu)\n",
+                field_len);
+        result = 1;
+    } else {
+        /* Verify data content */
+        for (CK_ULONG i = 0; i < 150; i++) {
+            if (data[i] != 0x42) {
+                fprintf(stderr, "[FAIL] test_decode_choice_long_form: data mismatch at position %lu\n", i);
+                result = 1;
+                break;
+            }
+        }
+    }
+
+    if (result == 0)
+        printf("[PASS] test_decode_choice_long_form\n");
+    return result;
+}
+
+/* Test ber_decode_CHOICE with 3-byte long form length (256-65535 bytes) */
+static int test_decode_choice_3byte_long_form(void)
+{
+    CK_BYTE *encoded = NULL;
+    CK_BYTE *data = NULL;
+    CK_ULONG data_len = 0;
+    CK_ULONG field_len = 0;
+    CK_ULONG option = 0;
+    CK_RV rv;
+    int result = 0;
+    const CK_ULONG expected_data_size = 500;
+
+    /* Build encoded data: 0x83 (option 3, primitive), 0x82 (long form 2 bytes),
+     * 0x01 0xF4 (500), data */
+    encoded = malloc(1 + 3 + expected_data_size);
+    if (encoded == NULL) {
+        fprintf(stderr, "[FAIL] test_decode_choice_3byte_long_form: malloc failed\n");
+        return 1;
+    }
+
+    encoded[0] = 0x83;  /* Option 3, primitive */
+    encoded[1] = 0x82;  /* Long form: 2 length bytes follow */
+    encoded[2] = 0x01;  /* Length high byte */
+    encoded[3] = 0xF4;  /* Length low byte (500 = 0x01F4) */
+    memset(&encoded[4], 0x42, expected_data_size);
+
+    rv = ber_decode_CHOICE(encoded, 1 + 3 + expected_data_size, FALSE,
+                           &data, &data_len, &field_len, &option);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_choice_3byte_long_form: decode failed with rv=%lu\n", rv);
+        free(encoded);
+        return 1;
+    }
+
+    if (option != 0x03) {
+        fprintf(stderr, "[FAIL] test_decode_choice_3byte_long_form: option mismatch (expected 3, got %lu)\n",
+                option);
+        result = 1;
+    } else if (data_len != expected_data_size) {
+        fprintf(stderr, "[FAIL] test_decode_choice_3byte_long_form: data length mismatch (expected %lu, got %lu)\n",
+                expected_data_size, data_len);
+        result = 1;
+    } else if (field_len != 1 + 3 + expected_data_size) {
+        fprintf(stderr, "[FAIL] test_decode_choice_3byte_long_form: field_len mismatch (expected %lu, got %lu)\n",
+                (unsigned long)(1 + 3 + expected_data_size), field_len);
+        result = 1;
+    } else {
+        /* Verify data content */
+        for (CK_ULONG i = 0; i < expected_data_size; i++) {
+            if (data[i] != 0x42) {
+                fprintf(stderr, "[FAIL] test_decode_choice_3byte_long_form: data mismatch at byte %lu\n", i);
+                result = 1;
+                break;
+            }
+        }
+    }
+
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_decode_choice_3byte_long_form\n");
+    return result;
+}
+
+/* Test ber_decode_CHOICE with 4-byte long form length (65536+ bytes) */
+static int test_decode_choice_4byte_long_form(void)
+{
+    CK_BYTE *encoded = NULL;
+    CK_BYTE *data = NULL;
+    CK_ULONG data_len = 0;
+    CK_ULONG field_len = 0;
+    CK_ULONG option = 0;
+    CK_RV rv;
+    int result = 0;
+    const CK_ULONG expected_data_size = 100000;
+
+    /* Build encoded data: 0x83 (option 3, primitive), 0x83 (long form 3 bytes),
+     * 0x01 0x86 0xA0 (100000), data */
+    encoded = malloc(1 + 4 + expected_data_size);
+    if (encoded == NULL) {
+        fprintf(stderr, "[FAIL] test_decode_choice_4byte_long_form: malloc failed\n");
+        return 1;
+    }
+
+    encoded[0] = 0x83;  /* Option 3, primitive */
+    encoded[1] = 0x83;  /* Long form: 3 length bytes follow */
+    encoded[2] = 0x01;  /* Length high byte */
+    encoded[3] = 0x86;  /* Length middle byte */
+    encoded[4] = 0xA0;  /* Length low byte (100000 = 0x0186A0) */
+    memset(&encoded[5], 0x42, expected_data_size);
+
+    rv = ber_decode_CHOICE(encoded, 1 + 4 + expected_data_size, FALSE,
+                           &data, &data_len, &field_len, &option);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_choice_4byte_long_form: decode failed with rv=%lu\n", rv);
+        free(encoded);
+        return 1;
+    }
+
+    if (option != 0x03) {
+        fprintf(stderr, "[FAIL] test_decode_choice_4byte_long_form: option mismatch (expected 3, got %lu)\n",
+                option);
+        result = 1;
+    } else if (data_len != expected_data_size) {
+        fprintf(stderr, "[FAIL] test_decode_choice_4byte_long_form: data length mismatch (expected %lu, got %lu)\n",
+                expected_data_size, data_len);
+        result = 1;
+    } else if (field_len != 1 + 4 + expected_data_size) {
+        fprintf(stderr, "[FAIL] test_decode_choice_4byte_long_form: field_len mismatch (expected %lu, got %lu)\n",
+                (unsigned long)(1 + 4 + expected_data_size), field_len);
+        result = 1;
+    } else {
+        /* Verify data content - check first and last bytes */
+        if (data[0] != 0x42 || data[expected_data_size - 1] != 0x42) {
+            fprintf(stderr, "[FAIL] test_decode_choice_4byte_long_form: data mismatch\n");
+            result = 1;
+        }
+    }
+
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_decode_choice_4byte_long_form\n");
+    return result;
+}
+
+/* Test ber_decode_CHOICE with NULL input */
+static int test_decode_choice_null_input(void)
+{
+    CK_BYTE *data = NULL;
+    CK_ULONG data_len = 0;
+    CK_ULONG field_len = 0;
+    CK_ULONG option = 0;
+    CK_RV rv;
+
+    rv = ber_decode_CHOICE(NULL, 10, FALSE, &data, &data_len, &field_len, &option);
+    if (rv == CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_choice_null_input: should have failed on NULL input\n");
+        return 1;
+    }
+
+    printf("[PASS] test_decode_choice_null_input\n");
+    return 0;
+}
+
+/* Test ber_decode_CHOICE with too short buffer */
+static int test_decode_choice_too_short(void)
+{
+    CK_BYTE encoded[] = {0xA0};  /* Only tag, no length */
+    CK_BYTE *data = NULL;
+    CK_ULONG data_len = 0;
+    CK_ULONG field_len = 0;
+    CK_ULONG option = 0;
+    CK_RV rv;
+
+    rv = ber_decode_CHOICE(encoded, sizeof(encoded), TRUE, &data, &data_len, &field_len, &option);
+    if (rv == CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_choice_too_short: should have failed on too short buffer\n");
+        return 1;
+    }
+
+    printf("[PASS] test_decode_choice_too_short\n");
+    return 0;
+}
+
+/* Test round-trip: encode then decode CHOICE */
+static int test_roundtrip_choice(void)
+{
+    CK_BYTE original[] = {0x02, 0x01, 0x05, 0x04, 0x03, 0x61, 0x62, 0x63};
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_BYTE *decoded = NULL;
+    CK_ULONG decoded_len = 0;
+    CK_ULONG field_len = 0;
+    CK_ULONG option = 0;
+    CK_BYTE test_option = 0x07;
+    CK_RV rv;
+    int result = 0;
+
+    /* Encode as constructed CHOICE */
+    rv = ber_encode_CHOICE(FALSE, test_option, &encoded, &encoded_len, original, sizeof(original), TRUE);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_choice: encode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    /* Decode */
+    rv = ber_decode_CHOICE(encoded, encoded_len, TRUE, &decoded, &decoded_len, &field_len, &option);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_choice: decode failed with rv=%lu\n", rv);
+        free(encoded);
+        return 1;
+    }
+
+    /* Compare */
+    if (option != test_option) {
+        fprintf(stderr, "[FAIL] test_roundtrip_choice: option mismatch (expected %u, got %lu)\n",
+                test_option, option);
+        result = 1;
+    } else if (decoded_len != sizeof(original)) {
+        fprintf(stderr, "[FAIL] test_roundtrip_choice: length mismatch (expected %lu, got %lu)\n",
+                (unsigned long)sizeof(original), decoded_len);
+        result = 1;
+    } else {
+        result = compare_bytes("test_roundtrip_choice", original, decoded, decoded_len);
+    }
+
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_roundtrip_choice\n");
+    return result;
+}
+
+/* Test ber_encode_PrivateKeyInfo with basic data */
+static int test_encode_privatekeyinfo_basic(void)
+{
+    /* Simple algorithm ID (SEQUENCE with OID) */
+    CK_BYTE algorithm_id[] = {0x30, 0x0D, 0x06, 0x09, 0x2A, 0x86, 0x48, 0x86,
+                              0xF7, 0x0D, 0x01, 0x01, 0x01, 0x05, 0x00};
+    CK_BYTE priv_key[] = {0x01, 0x02, 0x03, 0x04, 0x05};
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    rv = ber_encode_PrivateKeyInfo(FALSE, &encoded, &encoded_len,
+                                   algorithm_id, sizeof(algorithm_id),
+                                   priv_key, sizeof(priv_key));
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_privatekeyinfo_basic: encode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    /* Verify it's a SEQUENCE */
+    if (encoded[0] != 0x30) {
+        fprintf(stderr, "[FAIL] test_encode_privatekeyinfo_basic: not a SEQUENCE (got %02X)\n",
+                encoded[0]);
+        result = 1;
+    }
+
+    /* Verify non-zero length */
+    if (encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_privatekeyinfo_basic: zero length\n");
+        result = 1;
+    }
+
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_encode_privatekeyinfo_basic\n");
+    return result;
+}
+
+/* Test ber_encode_PrivateKeyInfo length_only mode */
+static int test_encode_privatekeyinfo_length_only(void)
+{
+    CK_BYTE algorithm_id[] = {0x30, 0x0D, 0x06, 0x09, 0x2A, 0x86, 0x48, 0x86,
+                              0xF7, 0x0D, 0x01, 0x01, 0x01, 0x05, 0x00};
+    CK_BYTE priv_key[] = {0x01, 0x02, 0x03, 0x04, 0x05};
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+
+    rv = ber_encode_PrivateKeyInfo(TRUE, &encoded, &encoded_len,
+                                   algorithm_id, sizeof(algorithm_id),
+                                   priv_key, sizeof(priv_key));
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_privatekeyinfo_length_only: encode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    if (encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_privatekeyinfo_length_only: zero length returned\n");
+        return 1;
+    }
+
+    if (encoded != NULL) {
+        fprintf(stderr, "[FAIL] test_encode_privatekeyinfo_length_only: encoded should be NULL\n");
+        return 1;
+    }
+
+    printf("[PASS] test_encode_privatekeyinfo_length_only\n");
+    return 0;
+}
+
+/* Test ber_decode_PrivateKeyInfo with valid data */
+static int test_decode_privatekeyinfo_valid(void)
+{
+    /* Manually constructed PrivateKeyInfo:
+     * SEQUENCE {
+     *   INTEGER 0 (version)
+     *   SEQUENCE { OID, NULL } (algorithm)
+     *   OCTET STRING (private key)
+     * }
+     */
+    CK_BYTE encoded[] = {
+        0x30, 0x1C,  /* SEQUENCE, length 28 (contents after this header) */
+        0x02, 0x01, 0x00,  /* INTEGER 0 (version) - 3 bytes */
+        0x30, 0x0D,  /* SEQUENCE (algorithm ID) - 15 bytes total (2 + 13) */
+        0x06, 0x09, 0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x01, 0x01,  /* OID - 11 bytes */
+        0x05, 0x00,  /* NULL - 2 bytes */
+        0x04, 0x08,  /* OCTET STRING, length 8 - 10 bytes total (2 + 8) */
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08  /* private key data - 8 bytes */
+    };
+    CK_BYTE *algorithm = NULL;
+    CK_ULONG alg_len = 0;
+    CK_BYTE *priv_key = NULL;
+    CK_ULONG priv_key_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    rv = ber_decode_PrivateKeyInfo(encoded, sizeof(encoded),
+                                   &algorithm, &alg_len,
+                                   &priv_key, &priv_key_len);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_privatekeyinfo_valid: decode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    /* Verify algorithm length (OID + NULL = 13 bytes, the SEQUENCE contents) */
+    if (alg_len != 13) {
+        fprintf(stderr, "[FAIL] test_decode_privatekeyinfo_valid: algorithm length mismatch (expected 13, got %lu)\n",
+                alg_len);
+        result = 1;
+    }
+
+    /* Verify private key length */
+    if (priv_key_len != 8) {
+        fprintf(stderr, "[FAIL] test_decode_privatekeyinfo_valid: private key length mismatch (expected 8, got %lu)\n",
+                priv_key_len);
+        result = 1;
+    }
+
+    /* Verify private key data */
+    CK_BYTE expected_key[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+    if (priv_key_len == 8 && memcmp(priv_key, expected_key, 8) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_privatekeyinfo_valid: private key data mismatch\n");
+        result = 1;
+    }
+
+    if (result == 0)
+        printf("[PASS] test_decode_privatekeyinfo_valid\n");
+    return result;
+}
+
+/* Test ber_decode_PrivateKeyInfo with NULL input */
+static int test_decode_privatekeyinfo_null_input(void)
+{
+    CK_BYTE *algorithm = NULL;
+    CK_ULONG alg_len = 0;
+    CK_BYTE *priv_key = NULL;
+    CK_ULONG priv_key_len = 0;
+    CK_RV rv;
+
+    rv = ber_decode_PrivateKeyInfo(NULL, 10, &algorithm, &alg_len,
+                                   &priv_key, &priv_key_len);
+    if (rv == CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_privatekeyinfo_null_input: should have failed\n");
+        return 1;
+    }
+
+    printf("[PASS] test_decode_privatekeyinfo_null_input\n");
+    return 0;
+}
+
+/* Test ber_decode_PrivateKeyInfo with zero length */
+static int test_decode_privatekeyinfo_zero_length(void)
+{
+    CK_BYTE encoded[] = {0x30, 0x00};
+    CK_BYTE *algorithm = NULL;
+    CK_ULONG alg_len = 0;
+    CK_BYTE *priv_key = NULL;
+    CK_ULONG priv_key_len = 0;
+    CK_RV rv;
+
+    rv = ber_decode_PrivateKeyInfo(encoded, 0, &algorithm, &alg_len,
+                                   &priv_key, &priv_key_len);
+    if (rv == CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_privatekeyinfo_zero_length: should have failed\n");
+        return 1;
+    }
+
+    printf("[PASS] test_decode_privatekeyinfo_zero_length\n");
+    return 0;
+}
+
+/* Test round-trip: encode then decode PrivateKeyInfo */
+static int test_roundtrip_privatekeyinfo(void)
+{
+    /* Full AlgorithmIdentifier SEQUENCE for encoding */
+    CK_BYTE algorithm_id[] = {0x30, 0x0D, 0x06, 0x09, 0x2A, 0x86, 0x48, 0x86,
+                              0xF7, 0x0D, 0x01, 0x01, 0x01, 0x05, 0x00};
+    /* Expected contents (13 bytes: OID + NULL, the SEQUENCE contents) after decoding */
+    CK_BYTE expected_alg_contents[] = {0x06, 0x09, 0x2A, 0x86, 0x48, 0x86,
+                                       0xF7, 0x0D, 0x01, 0x01, 0x01, 0x05, 0x00};
+    CK_BYTE original_key[] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88};
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_BYTE *decoded_alg = NULL;
+    CK_ULONG decoded_alg_len = 0;
+    CK_BYTE *decoded_key = NULL;
+    CK_ULONG decoded_key_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* Encode */
+    rv = ber_encode_PrivateKeyInfo(FALSE, &encoded, &encoded_len,
+                                   algorithm_id, sizeof(algorithm_id),
+                                   original_key, sizeof(original_key));
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_privatekeyinfo: encode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    /* Decode */
+    rv = ber_decode_PrivateKeyInfo(encoded, encoded_len,
+                                   &decoded_alg, &decoded_alg_len,
+                                   &decoded_key, &decoded_key_len);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_privatekeyinfo: decode failed with rv=%lu\n", rv);
+        free(encoded);
+        return 1;
+    }
+
+    /* Verify algorithm - decode returns contents without SEQUENCE wrapper */
+    if (decoded_alg_len != sizeof(expected_alg_contents)) {
+        fprintf(stderr, "[FAIL] test_roundtrip_privatekeyinfo: algorithm length mismatch (expected %lu, got %lu)\n",
+                (unsigned long)sizeof(expected_alg_contents), decoded_alg_len);
+        result = 1;
+    } else if (memcmp(decoded_alg, expected_alg_contents, sizeof(expected_alg_contents)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_privatekeyinfo: algorithm data mismatch\n");
+        result = 1;
+    }
+
+    /* Verify private key */
+    if (decoded_key_len != sizeof(original_key)) {
+        fprintf(stderr, "[FAIL] test_roundtrip_privatekeyinfo: key length mismatch (expected %lu, got %lu)\n",
+                (unsigned long)sizeof(original_key), decoded_key_len);
+        result = 1;
+    } else {
+        result = compare_bytes("test_roundtrip_privatekeyinfo", original_key, decoded_key, decoded_key_len);
+    }
+
+    free(encoded);
+    if (result == 0)
+        printf("[PASS] test_roundtrip_privatekeyinfo\n");
+    return result;
+}
+
+/* Test ber_decode_SPKI with valid data */
+static int test_decode_spki_valid(void)
+{
+    /* Manually constructed SPKI:
+     * SEQUENCE {
+     *   SEQUENCE {  // AlgorithmIdentifier
+     *     OID
+     *     NULL (parameters)
+     *   }
+     *   BIT STRING (public key)
+     * }
+     */
+    CK_BYTE spki[] = {
+        0x30, 0x22,  /* SEQUENCE, length 34 */
+        0x30, 0x0D,  /* SEQUENCE (AlgorithmIdentifier) */
+        0x06, 0x09, 0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x01, 0x01,  /* OID (RSA) */
+        0x05, 0x00,  /* NULL */
+        0x03, 0x11,  /* BIT STRING, length 17 */
+        0x00,  /* unused bits */
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,  /* key data */
+        0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10
+    };
+    CK_BYTE *alg_oid = NULL;
+    CK_ULONG alg_oid_len = 0;
+    CK_BYTE *param = NULL;
+    CK_ULONG param_len = 0;
+    CK_BYTE *key = NULL;
+    CK_ULONG key_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    rv = ber_decode_SPKI(spki, sizeof(spki),
+                         &alg_oid, &alg_oid_len,
+                         &param, &param_len,
+                         &key, &key_len);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_spki_valid: decode failed with rv=%lu\n", rv);
+        return 1;
+    }
+
+    /* Verify OID length (tag + length + 9 bytes = 11) */
+    if (alg_oid_len != 11) {
+        fprintf(stderr, "[FAIL] test_decode_spki_valid: OID length mismatch (expected 11, got %lu)\n",
+                alg_oid_len);
+        result = 1;
+    }
+
+    /* Verify parameters length (NULL = 2 bytes) */
+    if (param_len != 2) {
+        fprintf(stderr, "[FAIL] test_decode_spki_valid: param length mismatch (expected 2, got %lu)\n",
+                param_len);
+        result = 1;
+    }
+
+    /* Verify key length (16 bytes, unused bits byte removed) */
+    if (key_len != 16) {
+        fprintf(stderr, "[FAIL] test_decode_spki_valid: key length mismatch (expected 16, got %lu)\n",
+                key_len);
+        result = 1;
+    }
+
+    /* Verify key data */
+    CK_BYTE expected_key[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+                              0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10};
+    if (key_len == 16 && memcmp(key, expected_key, 16) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_spki_valid: key data mismatch\n");
+        result = 1;
+    }
+
+    if (result == 0)
+        printf("[PASS] test_decode_spki_valid\n");
+    return result;
+}
+
+/* Test ber_decode_SPKI with invalid/truncated data */
+static int test_decode_spki_truncated(void)
+{
+    CK_BYTE spki[] = {0x30, 0x05, 0x30, 0x03};  /* Incomplete SPKI */
+    CK_BYTE *alg_oid = NULL;
+    CK_ULONG alg_oid_len = 0;
+    CK_BYTE *param = NULL;
+    CK_ULONG param_len = 0;
+    CK_BYTE *key = NULL;
+    CK_ULONG key_len = 0;
+    CK_RV rv;
+
+    rv = ber_decode_SPKI(spki, sizeof(spki),
+                         &alg_oid, &alg_oid_len,
+                         &param, &param_len,
+                         &key, &key_len);
+    if (rv == CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_spki_truncated: should have failed on truncated data\n");
+        return 1;
+    }
+
+    printf("[PASS] test_decode_spki_truncated\n");
+    return 0;
+}
+
+/* Test ber_decode_SPKI with too short AlgorithmIdentifier */
+static int test_decode_spki_short_algid(void)
+{
+    /* SPKI with AlgorithmIdentifier that's too short (< 2 bytes) */
+    CK_BYTE spki[] = {
+        0x30, 0x10,  /* SEQUENCE */
+        0x30, 0x01,  /* SEQUENCE (AlgorithmIdentifier) - too short */
+        0x06,  /* OID tag but no length/data */
+        0x03, 0x0A,  /* BIT STRING */
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08
+    };
+    CK_BYTE *alg_oid = NULL;
+    CK_ULONG alg_oid_len = 0;
+    CK_BYTE *param = NULL;
+    CK_ULONG param_len = 0;
+    CK_BYTE *key = NULL;
+    CK_ULONG key_len = 0;
+    CK_RV rv;
+
+    rv = ber_decode_SPKI(spki, sizeof(spki),
+                         &alg_oid, &alg_oid_len,
+                         &param, &param_len,
+                         &key, &key_len);
+    if (rv == CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_spki_short_algid: should have failed on short AlgorithmIdentifier\n");
+        return 1;
+    }
+
+    printf("[PASS] test_decode_spki_short_algid\n");
+    return 0;
+}
+
+int main(void)
+{
+    int failed = 0;
+
+    printf("=== BER Encoding/Decoding Unit Tests ===\n\n");
+
+    /* INTEGER tests */
+    printf("--- INTEGER Tests ---\n");
+    failed += test_encode_integer_short();
+    failed += test_encode_integer_padding();
+    failed += test_encode_integer_long_form();
+    failed += test_encode_integer_3byte_long_form();
+    failed += test_encode_integer_4byte_long_form();
+    failed += test_encode_integer_length_only();
+    failed += test_encode_integer_zero_length();
+    failed += test_encode_integer_boundary_127();
+    failed += test_encode_integer_boundary_128();
+    failed += test_decode_integer_short();
+    failed += test_decode_integer_padding();
+    failed += test_decode_integer_3byte_long_form();
+    failed += test_decode_integer_4byte_long_form();
+    failed += test_decode_integer_invalid_tag();
+    failed += test_decode_integer_truncated();
+    failed += test_decode_integer_null_input();
+    failed += test_decode_integer_too_short();
+    failed += test_roundtrip_integer();
+
+    /* OCTET_STRING tests */
+    printf("\n--- OCTET_STRING Tests ---\n");
+    failed += test_encode_octet_string_short();
+    failed += test_encode_octet_string_long_form();
+    failed += test_encode_octet_string_3byte_long_form();
+    failed += test_encode_octet_string_4byte_long_form();
+    failed += test_encode_octet_string_single_byte();
+    failed += test_encode_octet_string_all_zeros();
+    failed += test_decode_octet_string_short();
+    failed += test_decode_octet_string_3byte_long_form();
+    failed += test_decode_octet_string_4byte_long_form();
+    failed += test_decode_octet_string_invalid_tag();
+    failed += test_decode_octet_string_null_input();
+    failed += test_roundtrip_octet_string();
+
+    /* BIT_STRING tests */
+    printf("\n--- BIT_STRING Tests ---\n");
+    failed += test_encode_bit_string_short();
+    failed += test_encode_bit_string_long_form();
+    failed += test_encode_bit_string_3byte_long_form();
+    failed += test_encode_bit_string_4byte_long_form();
+    failed += test_encode_bit_string_length_only();
+    failed += test_encode_bit_string_unused_bits();
+    failed += test_decode_bit_string_short();
+    failed += test_decode_bit_string_invalid_tag();
+    failed += test_decode_bit_string_null_input();
+    failed += test_decode_bit_string_no_unused_byte();
+    failed += test_roundtrip_bit_string();
+
+    /* SEQUENCE tests */
+    printf("\n--- SEQUENCE Tests ---\n");
+    failed += test_encode_sequence_short();
+    failed += test_encode_sequence_long_form();
+    failed += test_encode_sequence_3byte_long_form();
+    failed += test_encode_sequence_4byte_long_form();
+    failed += test_decode_sequence_short();
+    failed += test_decode_sequence_3byte_long_form();
+    failed += test_decode_sequence_4byte_long_form();
+    failed += test_decode_sequence_invalid_tag();
+    failed += test_decode_sequence_empty();
+    failed += test_decode_sequence_null_input();
+    failed += test_roundtrip_sequence();
+
+    /* CHOICE tests */
+    printf("\n--- CHOICE Tests ---\n");
+    failed += test_encode_choice_primitive_short();
+    failed += test_encode_choice_constructed_short();
+    failed += test_encode_choice_long_form();
+    failed += test_encode_choice_3byte_long_form();
+    failed += test_encode_choice_4byte_long_form();
+    failed += test_encode_choice_length_only();
+    failed += test_encode_choice_max_option();
+    failed += test_decode_choice_primitive_short();
+    failed += test_decode_choice_constructed_short();
+    failed += test_decode_choice_invalid_constructed();
+    failed += test_decode_choice_long_form();
+    failed += test_decode_choice_3byte_long_form();
+    failed += test_decode_choice_4byte_long_form();
+    failed += test_decode_choice_null_input();
+    failed += test_decode_choice_too_short();
+    failed += test_roundtrip_choice();
+
+    /* PrivateKeyInfo tests */
+    printf("\n--- PrivateKeyInfo Tests ---\n");
+    failed += test_encode_privatekeyinfo_basic();
+    failed += test_encode_privatekeyinfo_length_only();
+    failed += test_decode_privatekeyinfo_valid();
+    failed += test_decode_privatekeyinfo_null_input();
+    failed += test_decode_privatekeyinfo_zero_length();
+    failed += test_roundtrip_privatekeyinfo();
+
+    /* SPKI tests */
+    printf("\n--- SPKI Tests ---\n");
+    failed += test_decode_spki_valid();
+    failed += test_decode_spki_truncated();
+    failed += test_decode_spki_short_algid();
+
+    /* RSA Private Key tests */
+    printf("\n--- RSA Private Key Tests ---\n");
+    failed += test_encode_rsa_private_key_basic();
+    failed += test_encode_rsa_private_key_length_only();
+    failed += test_decode_rsa_private_key_valid();
+    failed += test_decode_rsa_private_key_invalid_alg();
+    failed += test_roundtrip_rsa_private_key();
+
+    /* RSA Public Key tests */
+    printf("\n--- RSA Public Key Tests ---\n");
+    failed += test_encode_rsa_public_key_basic();
+    failed += test_decode_rsa_public_key_valid();
+    failed += test_decode_rsa_public_key_invalid_alg();
+    failed += test_roundtrip_rsa_public_key();
+
+    /* DSA Private Key tests */
+    printf("\n--- DSA Private Key Tests ---\n");
+    failed += test_encode_dsa_private_key_basic();
+    failed += test_encode_dsa_private_key_length_only();
+    failed += test_decode_dsa_private_key_valid();
+    failed += test_roundtrip_dsa_private_key();
+
+    /* DSA Public Key tests */
+    printf("\n--- DSA Public Key Tests ---\n");
+    failed += test_encode_dsa_public_key_basic();
+    failed += test_decode_dsa_public_key_valid();
+    failed += test_roundtrip_dsa_public_key();
+
+    /* DH Private Key tests */
+    printf("\n--- DH Private Key Tests ---\n");
+    failed += test_encode_dh_private_key_basic();
+    failed += test_encode_dh_private_key_length_only();
+    failed += test_decode_dh_private_key_valid();
+    failed += test_roundtrip_dh_private_key();
+
+    /* DH Public Key tests */
+    printf("\n--- DH Public Key Tests ---\n");
+    failed += test_encode_dh_public_key_basic();
+    failed += test_decode_dh_public_key_valid();
+    failed += test_roundtrip_dh_public_key();
+
+    /* EC Private Key tests */
+    printf("\n--- EC Private Key Tests ---\n");
+    failed += test_encode_ec_private_key_basic();
+    failed += test_encode_ec_private_key_length_only();
+    failed += test_decode_ec_private_key_valid();
+    failed += test_roundtrip_ec_private_key();
+
+    /* EC Public Key tests */
+    printf("\n--- EC Public Key Tests ---\n");
+    failed += test_encode_ec_public_key_basic();
+    failed += test_decode_ec_public_key_valid();
+    failed += test_roundtrip_ec_public_key();
+
+    /* Edwards Curve Private Key tests */
+    printf("\n--- Edwards Curve Private Key Tests ---\n");
+    failed += test_encode_edwards_private_key_basic();
+    failed += test_roundtrip_edwards_private_key();
+
+    /* Edwards Curve Public Key tests */
+    printf("\n--- Edwards Curve Public Key Tests ---\n");
+    failed += test_encode_edwards_public_key_basic();
+    failed += test_roundtrip_edwards_public_key();
+
+    /* Montgomery Curve Private Key tests */
+    printf("\n--- Montgomery Curve Private Key Tests ---\n");
+    failed += test_encode_montgomery_private_key_basic();
+    failed += test_roundtrip_montgomery_private_key();
+
+    /* Montgomery Curve Public Key tests */
+    printf("\n--- Montgomery Curve Public Key Tests ---\n");
+    failed += test_encode_montgomery_public_key_basic();
+    failed += test_roundtrip_montgomery_public_key();
+
+    /* IBM ML-DSA Private Key tests */
+    printf("\n--- IBM ML-DSA Private Key Tests ---\n");
+    failed += test_encode_ibm_ml_dsa_private_key_basic();
+    failed += test_encode_ibm_ml_dsa_private_key_length_only();
+    failed += test_decode_ibm_ml_dsa_private_key_valid();
+    failed += test_roundtrip_ibm_ml_dsa_private_key();
+
+    /* IBM ML-DSA Public Key tests */
+    printf("\n--- IBM ML-DSA Public Key Tests ---\n");
+    failed += test_encode_ibm_ml_dsa_public_key_basic();
+    failed += test_decode_ibm_ml_dsa_public_key_valid();
+    failed += test_roundtrip_ibm_ml_dsa_public_key();
+
+    /* IBM ML-KEM Private Key tests */
+    printf("\n--- IBM ML-KEM Private Key Tests ---\n");
+    failed += test_encode_ibm_ml_kem_private_key_basic();
+    failed += test_encode_ibm_ml_kem_private_key_length_only();
+    failed += test_decode_ibm_ml_kem_private_key_valid();
+    failed += test_roundtrip_ibm_ml_kem_private_key();
+
+    /* IBM ML-KEM Public Key tests */
+    printf("\n--- IBM ML-KEM Public Key Tests ---\n");
+    failed += test_encode_ibm_ml_kem_public_key_basic();
+    failed += test_decode_ibm_ml_kem_public_key_valid();
+    failed += test_roundtrip_ibm_ml_kem_public_key();
+
+    /* IBM Dilithium Tests */
+    printf("\n--- IBM Dilithium Private Key Tests ---\n");
+    failed += test_encode_ibm_dilithium_private_key_basic();
+    failed += test_decode_ibm_dilithium_private_key_basic();
+    failed += test_roundtrip_ibm_dilithium_private_key();
+    failed += test_ibm_dilithium_private_key_null_optional();
+
+    printf("\n--- IBM Dilithium Public Key Tests ---\n");
+    failed += test_encode_ibm_dilithium_public_key_basic();
+    failed += test_decode_ibm_dilithium_public_key_basic();
+    failed += test_roundtrip_ibm_dilithium_public_key();
+
+    /* IBM Kyber Tests */
+    printf("\n--- IBM Kyber Private Key Tests ---\n");
+    failed += test_encode_ibm_kyber_private_key_basic();
+    failed += test_decode_ibm_kyber_private_key_basic();
+    failed += test_roundtrip_ibm_kyber_private_key();
+    failed += test_ibm_kyber_private_key_null_optional();
+
+    printf("\n--- IBM Kyber Public Key Tests ---\n");
+    failed += test_encode_ibm_kyber_public_key_basic();
+    failed += test_decode_ibm_kyber_public_key_basic();
+    failed += test_roundtrip_ibm_kyber_public_key();
+
+    printf("\n--- ML-DSA Public Key Tests ---\n");
+    failed += test_encode_ml_dsa_public_key_basic();
+    failed += test_decode_ml_dsa_public_key_valid();
+    failed += test_roundtrip_ml_dsa_public_key();
+
+    printf("\n--- ML-DSA Private Key Tests ---\n");
+    failed += test_encode_ml_dsa_private_key_basic();
+    failed += test_encode_ml_dsa_private_key_length_only();
+    failed += test_decode_ml_dsa_private_key_valid();
+    failed += test_roundtrip_ml_dsa_private_key();
+
+    printf("\n--- ML-DSA Private Key Tests with Seed ---\n");
+    failed += test_encode_ml_dsa_private_key_with_seed();
+    failed += test_encode_ml_dsa_private_key_with_seed_length_only();
+    failed += test_decode_ml_dsa_private_key_with_seed();
+    failed += test_roundtrip_ml_dsa_private_key_with_seed();
+
+    printf("\n--- ML-DSA Private Key Tests with Seed-Only ---\n");
+    failed += test_encode_ml_dsa_private_key_seed_only();
+    failed += test_encode_ml_dsa_private_key_seed_only_length_only();
+    failed += test_decode_ml_dsa_private_key_seed_only();
+    failed += test_roundtrip_ml_dsa_private_key_seed_only();
+
+    printf("\n--- ML-KEM Public Key Tests ---\n");
+    failed += test_encode_ml_kem_public_key_basic();
+    failed += test_decode_ml_kem_public_key_valid();
+    failed += test_roundtrip_ml_kem_public_key();
+
+    printf("\n--- ML-KEM Private Key Tests ---\n");
+    failed += test_encode_ml_kem_private_key_basic();
+    failed += test_encode_ml_kem_private_key_length_only();
+    failed += test_decode_ml_kem_private_key_valid();
+    failed += test_roundtrip_ml_kem_private_key();
+
+    printf("\n--- ML-KEM Private Key Tests with Seed ---\n");
+    failed += test_encode_ml_kem_private_key_with_seed();
+    failed += test_encode_ml_kem_private_key_with_seed_length_only();
+    failed += test_decode_ml_kem_private_key_with_seed();
+    failed += test_roundtrip_ml_kem_private_key_with_seed();
+
+    printf("\n--- ML-KEM Private Key Tests with Seed-Only ---\n");
+    failed += test_encode_ml_kem_private_key_seed_only();
+    failed += test_encode_ml_kem_private_key_seed_only_length_only();
+    failed += test_decode_ml_kem_private_key_seed_only();
+    failed += test_roundtrip_ml_kem_private_key_seed_only();
+
+    printf("\n=== Test Summary ===\n");
+    if (failed == 0) {
+        printf("All tests passed!\n");
+        return TEST_PASS;
+    } else {
+        printf("%d test(s) failed.\n", failed);
+        return TEST_FAIL;
+    }
+}

--- a/testcases/unit/asn1test_keys.c
+++ b/testcases/unit/asn1test_keys.c
@@ -1,0 +1,2973 @@
+/*
+ * COPYRIGHT (c) International Business Machines Corp. 2026
+ *
+ * This program is provided under the terms of the Common Public License,
+ * version 1.0 (CPL-1.0). Any use, reproduction or distribution for this
+ * software constitutes recipient's acceptance of CPL-1.0 terms which can be
+ * found in the file LICENSE file or at
+ * https://opensource.org/licenses/cpl1.0.php
+ */
+
+/*
+ * Cryptographic key encoding/decoding unit tests
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "pkcs11types.h"
+#include "defs.h"
+#include "host_defs.h"
+#include "h_extern.h"
+#include "unittest.h"
+#include "asn1test_keys.h"
+
+
+/* Helper function to create a CK_ATTRIBUTE with data */
+CK_ATTRIBUTE *create_attribute(CK_ATTRIBUTE_TYPE type, CK_BYTE *data, CK_ULONG data_len);
+
+/* Function prototypes from asn1.c */
+CK_RV ber_encode_RSAPrivateKey(CK_BBOOL length_only,
+                               CK_BYTE **data,
+                               CK_ULONG *data_len,
+                               CK_ATTRIBUTE *modulus,
+                               CK_ATTRIBUTE *publ_exp,
+                               CK_ATTRIBUTE *priv_exp,
+                               CK_ATTRIBUTE *prime1,
+                               CK_ATTRIBUTE *prime2,
+                               CK_ATTRIBUTE *exponent1,
+                               CK_ATTRIBUTE *exponent2,
+                               CK_ATTRIBUTE *coeff);
+
+CK_RV ber_decode_RSAPrivateKey(CK_BYTE *data,
+                               CK_ULONG data_len,
+                               CK_ATTRIBUTE **modulus,
+                               CK_ATTRIBUTE **publ_exp,
+                               CK_ATTRIBUTE **priv_exp,
+                               CK_ATTRIBUTE **prime1,
+                               CK_ATTRIBUTE **prime2,
+                               CK_ATTRIBUTE **exponent1,
+                               CK_ATTRIBUTE **exponent2,
+                               CK_ATTRIBUTE **coeff);
+
+CK_RV ber_encode_RSAPublicKey(CK_BBOOL length_only, CK_BYTE **data,
+                              CK_ULONG *data_len, CK_ATTRIBUTE *modulus,
+                              CK_ATTRIBUTE *publ_exp);
+
+CK_RV ber_decode_RSAPublicKey(CK_BYTE *data,
+                              CK_ULONG data_len,
+                              CK_ATTRIBUTE **modulus,
+                              CK_ATTRIBUTE **publ_exp);
+
+CK_RV ber_encode_DSAPrivateKey(CK_BBOOL length_only,
+                               CK_BYTE **data,
+                               CK_ULONG *data_len,
+                               CK_ATTRIBUTE *prime1,
+                               CK_ATTRIBUTE *prime2,
+                               CK_ATTRIBUTE *base,
+                               CK_ATTRIBUTE *priv_key);
+
+CK_RV ber_decode_DSAPrivateKey(CK_BYTE *data,
+                               CK_ULONG data_len,
+                               CK_ATTRIBUTE **prime,
+                               CK_ATTRIBUTE **subprime,
+                               CK_ATTRIBUTE **base,
+                               CK_ATTRIBUTE **priv_key);
+
+CK_RV ber_encode_DSAPublicKey(CK_BBOOL length_only,
+                              CK_BYTE **data,
+                              CK_ULONG *data_len,
+                              CK_ATTRIBUTE *prime,
+                              CK_ATTRIBUTE *subprime,
+                              CK_ATTRIBUTE *base,
+                              CK_ATTRIBUTE *value);
+
+CK_RV ber_decode_DSAPublicKey(CK_BYTE *data,
+                              CK_ULONG data_len,
+                              CK_ATTRIBUTE **prime,
+                              CK_ATTRIBUTE **subprime,
+                              CK_ATTRIBUTE **base,
+                              CK_ATTRIBUTE **value);
+
+/* DH key encoding/decoding function prototypes */
+CK_RV ber_encode_DHPrivateKey(CK_BBOOL length_only,
+                              CK_BYTE **data,
+                              CK_ULONG *data_len,
+                              CK_ATTRIBUTE *prime,
+                              CK_ATTRIBUTE *base,
+                              CK_ATTRIBUTE *priv_key);
+
+CK_RV ber_decode_DHPrivateKey(CK_BYTE *data,
+                              CK_ULONG data_len,
+                              CK_ATTRIBUTE **prime,
+                              CK_ATTRIBUTE **base,
+                              CK_ATTRIBUTE **priv_key);
+
+CK_RV ber_encode_DHPublicKey(CK_BBOOL length_only,
+                             CK_BYTE **data,
+                             CK_ULONG *data_len,
+                             CK_ATTRIBUTE *prime,
+                             CK_ATTRIBUTE *base,
+                             CK_ATTRIBUTE *value);
+
+CK_RV ber_decode_DHPublicKey(CK_BYTE *data,
+                             CK_ULONG data_len,
+                             CK_ATTRIBUTE **prime,
+                             CK_ATTRIBUTE **base,
+                             CK_ATTRIBUTE **value);
+
+/* EC key encoding/decoding function prototypes */
+CK_RV der_encode_ECPrivateKey(CK_BBOOL length_only,
+                              CK_BYTE **data,
+                              CK_ULONG *data_len,
+                              CK_ATTRIBUTE *params,
+                              CK_ATTRIBUTE *privkey,
+                              CK_ATTRIBUTE *pubkey,
+                              CK_KEY_TYPE key_type);
+
+CK_RV der_decode_ECPrivateKey(CK_BYTE *data,
+                              CK_ULONG data_len,
+                              CK_ATTRIBUTE **params,
+                              CK_ATTRIBUTE **pub_key,
+                              CK_ATTRIBUTE **priv_key,
+                              CK_KEY_TYPE key_type);
+
+CK_RV ber_encode_ECPublicKey(CK_BBOOL length_only,
+                             CK_BYTE **data,
+                             CK_ULONG *data_len,
+                             CK_ATTRIBUTE *params,
+                             CK_ATTRIBUTE *point,
+                             CK_KEY_TYPE key_type);
+
+CK_RV der_decode_ECPublicKey(CK_BYTE *data,
+                             CK_ULONG data_len,
+                             CK_ATTRIBUTE **ec_params,
+                             CK_ATTRIBUTE **ec_point,
+                             CK_KEY_TYPE key_type);
+
+/* ML-DSA key encoding/decoding function prototypes */
+CK_RV ber_encode_IBM_ML_DSA_PublicKey(CK_MECHANISM_TYPE mech,
+                                      CK_BBOOL length_only,
+                                      CK_BYTE **data, CK_ULONG *data_len,
+                                      const CK_BYTE *oid, CK_ULONG oid_len,
+                                      CK_ATTRIBUTE *rho, CK_ATTRIBUTE *t1);
+
+CK_RV ber_decode_IBM_ML_DSA_PublicKey(CK_MECHANISM_TYPE mech,
+                                      CK_BYTE *data,
+                                      CK_ULONG data_len,
+                                      CK_ATTRIBUTE **rho_attr,
+                                      CK_ATTRIBUTE **t1_attr,
+                                      CK_ATTRIBUTE **value_attr,
+                                      const struct pqc_oid **oid);
+
+CK_RV ber_encode_IBM_ML_DSA_PrivateKey(CK_MECHANISM_TYPE mech,
+                                       CK_BBOOL length_only,
+                                       CK_BYTE **data,
+                                       CK_ULONG *data_len,
+                                       const CK_BYTE *oid, CK_ULONG oid_len,
+                                       CK_ATTRIBUTE *rho,
+                                       CK_ATTRIBUTE *seed,
+                                       CK_ATTRIBUTE *tr,
+                                       CK_ATTRIBUTE *s1,
+                                       CK_ATTRIBUTE *s2,
+                                       CK_ATTRIBUTE *t0,
+                                       CK_ATTRIBUTE *t1,
+                                       CK_ATTRIBUTE *priv_seed);
+
+CK_RV ber_decode_IBM_ML_DSA_PrivateKey(CK_MECHANISM_TYPE mech,
+                                       CK_BYTE *data,
+                                       CK_ULONG data_len,
+                                       CK_ATTRIBUTE **rho,
+                                       CK_ATTRIBUTE **seed,
+                                       CK_ATTRIBUTE **tr,
+                                       CK_ATTRIBUTE **s1,
+                                       CK_ATTRIBUTE **s2,
+                                       CK_ATTRIBUTE **t0,
+                                       CK_ATTRIBUTE **t1,
+                                       CK_ATTRIBUTE **priv_seed,
+                                       CK_ATTRIBUTE **value,
+                                       const struct pqc_oid **oid);
+
+/* ML-KEM key encoding/decoding function prototypes */
+CK_RV ber_encode_IBM_ML_KEM_PublicKey(CK_MECHANISM_TYPE mech,
+                                      CK_BBOOL length_only,
+                                      CK_BYTE **data, CK_ULONG *data_len,
+                                      const CK_BYTE *oid, CK_ULONG oid_len,
+                                      CK_ATTRIBUTE *pk);
+
+CK_RV ber_decode_IBM_ML_KEM_PublicKey(CK_MECHANISM_TYPE mech,
+                                      CK_BYTE *data,
+                                      CK_ULONG data_len,
+                                      CK_ATTRIBUTE **pk_attr,
+                                      CK_ATTRIBUTE **value_attr,
+                                      const struct pqc_oid **oid);
+
+CK_RV ber_encode_IBM_ML_KEM_PrivateKey(CK_MECHANISM_TYPE mech,
+                                       CK_BBOOL length_only,
+                                       CK_BYTE **data,
+                                       CK_ULONG *data_len,
+                                       const CK_BYTE *oid, CK_ULONG oid_len,
+                                       CK_ATTRIBUTE *sk,
+                                       CK_ATTRIBUTE *pk,
+                                       CK_ATTRIBUTE *priv_seed);
+
+CK_RV ber_decode_IBM_ML_KEM_PrivateKey(CK_MECHANISM_TYPE mech,
+                                       CK_BYTE *data,
+                                       CK_ULONG data_len,
+                                       CK_ATTRIBUTE **sk,
+                                       CK_ATTRIBUTE **pk,
+                                       CK_ATTRIBUTE **priv_seed,
+                                       CK_ATTRIBUTE **value,
+                                       const struct pqc_oid **oid);
+
+
+/* Helper function to free attributes */
+static void free_attributes(CK_ATTRIBUTE **attrs, int count)
+{
+    for (int i = 0; i < count; i++) {
+        if (attrs[i])
+            free(attrs[i]);
+    }
+}
+
+
+/* ============================================================================
+ * RSA Private Key Tests
+ * ============================================================================ */
+
+/* Test ber_encode_RSAPrivateKey with basic RSA key components */
+int test_encode_rsa_private_key_basic(void)
+{
+    /* Small RSA key components for testing - no leading zeros to avoid BER padding issues */
+    CK_BYTE modulus_data[] = {0xC5, 0x3A, 0x7F, 0x8E, 0x9B, 0x2C, 0x1D, 0x0A};
+    CK_BYTE pub_exp_data[] = {0x01, 0x00, 0x01};  /* 65537 */
+    CK_BYTE priv_exp_data[] = {0x5A, 0x3B, 0x7C, 0x8D, 0x9E, 0x2F, 0x1A, 0x0B};
+    CK_BYTE prime1_data[] = {0xE7, 0x9A, 0x3B, 0x5C, 0x1F};
+    CK_BYTE prime2_data[] = {0xD9, 0x8C, 0x4E, 0x6F, 0x2A};
+    CK_BYTE exp1_data[] = {0x7B, 0x4C, 0x8D, 0x9E};
+    CK_BYTE exp2_data[] = {0x6A, 0x3B, 0x7C, 0x8D};
+    CK_BYTE coeff_data[] = {0x5C, 0x2D, 0x9E, 0x7F};
+
+    CK_ATTRIBUTE *modulus = NULL, *pub_exp = NULL, *priv_exp = NULL;
+    CK_ATTRIBUTE *prime1 = NULL, *prime2 = NULL, *exp1 = NULL, *exp2 = NULL, *coeff = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* Create attributes */
+    modulus = create_attribute(CKA_MODULUS, modulus_data, sizeof(modulus_data));
+    pub_exp = create_attribute(CKA_PUBLIC_EXPONENT, pub_exp_data, sizeof(pub_exp_data));
+    priv_exp = create_attribute(CKA_PRIVATE_EXPONENT, priv_exp_data, sizeof(priv_exp_data));
+    prime1 = create_attribute(CKA_PRIME_1, prime1_data, sizeof(prime1_data));
+    prime2 = create_attribute(CKA_PRIME_2, prime2_data, sizeof(prime2_data));
+    exp1 = create_attribute(CKA_EXPONENT_1, exp1_data, sizeof(exp1_data));
+    exp2 = create_attribute(CKA_EXPONENT_2, exp2_data, sizeof(exp2_data));
+    coeff = create_attribute(CKA_COEFFICIENT, coeff_data, sizeof(coeff_data));
+
+    if (!modulus || !pub_exp || !priv_exp || !prime1 || !prime2 || !exp1 || !exp2 || !coeff) {
+        fprintf(stderr, "[FAIL] test_encode_rsa_private_key_basic: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = ber_encode_RSAPrivateKey(FALSE, &encoded, &encoded_len, modulus, pub_exp,
+                                  priv_exp, prime1, prime2, exp1, exp2, coeff);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_rsa_private_key_basic: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify we got some encoded data */
+    if (encoded == NULL || encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_rsa_private_key_basic: no encoded data\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Basic sanity check: should start with SEQUENCE tag (0x30) for PrivateKeyInfo */
+    if (encoded[0] != 0x30) {
+        fprintf(stderr, "[FAIL] test_encode_rsa_private_key_basic: invalid tag (expected 0x30, got 0x%02X)\n",
+                encoded[0]);
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_encode_rsa_private_key_basic\n");
+
+cleanup:
+    {
+        CK_ATTRIBUTE *attrs[] = {modulus, pub_exp, priv_exp, prime1, prime2, exp1, exp2, coeff};
+        free_attributes(attrs, 8);
+    }
+    if (encoded)
+        free(encoded);
+    return result;
+}
+
+/* Test ber_encode_RSAPrivateKey in length_only mode */
+int test_encode_rsa_private_key_length_only(void)
+{
+    CK_BYTE modulus_data[] = {0xC5, 0x3A, 0x7F, 0x8E, 0x9B, 0x2C, 0x1D, 0x0A};
+    CK_BYTE pub_exp_data[] = {0x01, 0x00, 0x01};
+    CK_BYTE priv_exp_data[] = {0x5A, 0x3B, 0x7C, 0x8D, 0x9E, 0x2F, 0x1A, 0x0B};
+    CK_BYTE prime1_data[] = {0xE7, 0x9A, 0x3B, 0x5C, 0x1F};
+    CK_BYTE prime2_data[] = {0xD9, 0x8C, 0x4E, 0x6F, 0x2A};
+    CK_BYTE exp1_data[] = {0x7B, 0x4C, 0x8D, 0x9E};
+    CK_BYTE exp2_data[] = {0x6A, 0x3B, 0x7C, 0x8D};
+    CK_BYTE coeff_data[] = {0x5C, 0x2D, 0x9E, 0x7F};
+
+    CK_ATTRIBUTE *modulus = NULL, *pub_exp = NULL, *priv_exp = NULL;
+    CK_ATTRIBUTE *prime1 = NULL, *prime2 = NULL, *exp1 = NULL, *exp2 = NULL, *coeff = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    modulus = create_attribute(CKA_MODULUS, modulus_data, sizeof(modulus_data));
+    pub_exp = create_attribute(CKA_PUBLIC_EXPONENT, pub_exp_data, sizeof(pub_exp_data));
+    priv_exp = create_attribute(CKA_PRIVATE_EXPONENT, priv_exp_data, sizeof(priv_exp_data));
+    prime1 = create_attribute(CKA_PRIME_1, prime1_data, sizeof(prime1_data));
+    prime2 = create_attribute(CKA_PRIME_2, prime2_data, sizeof(prime2_data));
+    exp1 = create_attribute(CKA_EXPONENT_1, exp1_data, sizeof(exp1_data));
+    exp2 = create_attribute(CKA_EXPONENT_2, exp2_data, sizeof(exp2_data));
+    coeff = create_attribute(CKA_COEFFICIENT, coeff_data, sizeof(coeff_data));
+
+    if (!modulus || !pub_exp || !priv_exp || !prime1 || !prime2 || !exp1 || !exp2 || !coeff) {
+        fprintf(stderr, "[FAIL] test_encode_rsa_private_key_length_only: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = ber_encode_RSAPrivateKey(TRUE, &encoded, &encoded_len, modulus, pub_exp,
+                                  priv_exp, prime1, prime2, exp1, exp2, coeff);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_rsa_private_key_length_only: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* In length_only mode, encoded should be NULL but length should be set */
+    if (encoded != NULL) {
+        fprintf(stderr, "[FAIL] test_encode_rsa_private_key_length_only: encoded should be NULL\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    if (encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_rsa_private_key_length_only: length should be non-zero\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_encode_rsa_private_key_length_only\n");
+
+cleanup:
+    {
+        CK_ATTRIBUTE *attrs[] = {modulus, pub_exp, priv_exp, prime1, prime2, exp1, exp2, coeff};
+        free_attributes(attrs, 8);
+    }
+    return result;
+}
+
+/* Test ber_decode_RSAPrivateKey with valid encoded data */
+int test_decode_rsa_private_key_valid(void)
+{
+    CK_BYTE modulus_data[] = {0xC5, 0x3A, 0x7F, 0x8E, 0x9B, 0x2C, 0x1D, 0x0A};
+    CK_BYTE pub_exp_data[] = {0x01, 0x00, 0x01};
+    CK_BYTE priv_exp_data[] = {0x5A, 0x3B, 0x7C, 0x8D, 0x9E, 0x2F, 0x1A, 0x0B};
+    CK_BYTE prime1_data[] = {0xE7, 0x9A, 0x3B, 0x5C, 0x1F};
+    CK_BYTE prime2_data[] = {0xD9, 0x8C, 0x4E, 0x6F, 0x2A};
+    CK_BYTE exp1_data[] = {0x7B, 0x4C, 0x8D, 0x9E};
+    CK_BYTE exp2_data[] = {0x6A, 0x3B, 0x7C, 0x8D};
+    CK_BYTE coeff_data[] = {0x5C, 0x2D, 0x9E, 0x7F};
+
+    CK_ATTRIBUTE *enc_modulus = NULL, *enc_pub_exp = NULL, *enc_priv_exp = NULL;
+    CK_ATTRIBUTE *enc_prime1 = NULL, *enc_prime2 = NULL, *enc_exp1 = NULL;
+    CK_ATTRIBUTE *enc_exp2 = NULL, *enc_coeff = NULL;
+    CK_ATTRIBUTE *dec_modulus = NULL, *dec_pub_exp = NULL, *dec_priv_exp = NULL;
+    CK_ATTRIBUTE *dec_prime1 = NULL, *dec_prime2 = NULL, *dec_exp1 = NULL;
+    CK_ATTRIBUTE *dec_exp2 = NULL, *dec_coeff = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* First encode */
+    enc_modulus = create_attribute(CKA_MODULUS, modulus_data, sizeof(modulus_data));
+    enc_pub_exp = create_attribute(CKA_PUBLIC_EXPONENT, pub_exp_data, sizeof(pub_exp_data));
+    enc_priv_exp = create_attribute(CKA_PRIVATE_EXPONENT, priv_exp_data, sizeof(priv_exp_data));
+    enc_prime1 = create_attribute(CKA_PRIME_1, prime1_data, sizeof(prime1_data));
+    enc_prime2 = create_attribute(CKA_PRIME_2, prime2_data, sizeof(prime2_data));
+    enc_exp1 = create_attribute(CKA_EXPONENT_1, exp1_data, sizeof(exp1_data));
+    enc_exp2 = create_attribute(CKA_EXPONENT_2, exp2_data, sizeof(exp2_data));
+    enc_coeff = create_attribute(CKA_COEFFICIENT, coeff_data, sizeof(coeff_data));
+
+    if (!enc_modulus || !enc_pub_exp || !enc_priv_exp || !enc_prime1 ||
+        !enc_prime2 || !enc_exp1 || !enc_exp2 || !enc_coeff) {
+        fprintf(stderr, "[FAIL] test_decode_rsa_private_key_valid: failed to create encode attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = ber_encode_RSAPrivateKey(FALSE, &encoded, &encoded_len, enc_modulus, enc_pub_exp,
+                                  enc_priv_exp, enc_prime1, enc_prime2, enc_exp1, enc_exp2, enc_coeff);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_rsa_private_key_valid: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Now decode */
+    rv = ber_decode_RSAPrivateKey(encoded, encoded_len, &dec_modulus, &dec_pub_exp,
+                                  &dec_priv_exp, &dec_prime1, &dec_prime2,
+                                  &dec_exp1, &dec_exp2, &dec_coeff);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_rsa_private_key_valid: decode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify all components were decoded */
+    if (!dec_modulus || !dec_pub_exp || !dec_priv_exp || !dec_prime1 ||
+        !dec_prime2 || !dec_exp1 || !dec_exp2 || !dec_coeff) {
+        fprintf(stderr, "[FAIL] test_decode_rsa_private_key_valid: missing decoded attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify modulus matches */
+    if (dec_modulus->ulValueLen != sizeof(modulus_data) ||
+        memcmp(dec_modulus->pValue, modulus_data, sizeof(modulus_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_rsa_private_key_valid: modulus mismatch\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify public exponent matches */
+    if (dec_pub_exp->ulValueLen != sizeof(pub_exp_data) ||
+        memcmp(dec_pub_exp->pValue, pub_exp_data, sizeof(pub_exp_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_rsa_private_key_valid: public exponent mismatch\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_decode_rsa_private_key_valid\n");
+
+cleanup:
+    {
+        CK_ATTRIBUTE *enc_attrs[] = {enc_modulus, enc_pub_exp, enc_priv_exp, enc_prime1,
+                                      enc_prime2, enc_exp1, enc_exp2, enc_coeff};
+        CK_ATTRIBUTE *dec_attrs[] = {dec_modulus, dec_pub_exp, dec_priv_exp, dec_prime1,
+                                      dec_prime2, dec_exp1, dec_exp2, dec_coeff};
+        free_attributes(enc_attrs, 8);
+        free_attributes(dec_attrs, 8);
+    }
+    if (encoded)
+        free(encoded);
+    return result;
+}
+
+/* Test ber_decode_RSAPrivateKey with invalid algorithm identifier */
+int test_decode_rsa_private_key_invalid_alg(void)
+{
+    /* Create a PrivateKeyInfo with wrong algorithm OID (using DSA OID instead of RSA) */
+    CK_BYTE invalid_data[] = {
+        0x30, 0x20,  /* SEQUENCE */
+        0x02, 0x01, 0x00,  /* version = 0 */
+        0x30, 0x09,  /* AlgorithmIdentifier SEQUENCE */
+        0x06, 0x07, 0x2A, 0x86, 0x48, 0xCE, 0x38, 0x04, 0x01,  /* DSA OID */
+        0x04, 0x10,  /* OCTET STRING (private key) */
+        0x30, 0x0E,  /* SEQUENCE */
+        0x02, 0x01, 0x00,  /* version */
+        0x02, 0x03, 0x01, 0x00, 0x01,  /* some integer */
+        0x02, 0x04, 0x01, 0x02, 0x03, 0x04  /* another integer */
+    };
+
+    CK_ATTRIBUTE *modulus = NULL, *pub_exp = NULL, *priv_exp = NULL;
+    CK_ATTRIBUTE *prime1 = NULL, *prime2 = NULL, *exp1 = NULL, *exp2 = NULL, *coeff = NULL;
+    CK_RV rv;
+
+    rv = ber_decode_RSAPrivateKey(invalid_data, sizeof(invalid_data), &modulus, &pub_exp,
+                                  &priv_exp, &prime1, &prime2, &exp1, &exp2, &coeff);
+
+    /* Should fail with wrong algorithm */
+    if (rv == CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_rsa_private_key_invalid_alg: should have failed with invalid algorithm\n");
+        CK_ATTRIBUTE *attrs[] = {modulus, pub_exp, priv_exp, prime1, prime2, exp1, exp2, coeff};
+        free_attributes(attrs, 8);
+        return 1;
+    }
+
+    printf("[PASS] test_decode_rsa_private_key_invalid_alg\n");
+    return 0;
+}
+
+/* Test round-trip encoding and decoding of RSA private key */
+int test_roundtrip_rsa_private_key(void)
+{
+    CK_BYTE modulus_data[] = {0xC5, 0x3A, 0x7F, 0x8E, 0x9B, 0x2C, 0x1D, 0x0A, 0x55, 0x66};
+    CK_BYTE pub_exp_data[] = {0x01, 0x00, 0x01};
+    CK_BYTE priv_exp_data[] = {0x5A, 0x3B, 0x7C, 0x8D, 0x9E, 0x2F, 0x1A, 0x0B, 0x77, 0x11};
+    CK_BYTE prime1_data[] = {0xE7, 0x9A, 0x3B, 0x5C, 0x1F, 0x22};
+    CK_BYTE prime2_data[] = {0xD9, 0x8C, 0x4E, 0x6F, 0x2A, 0x33};
+    CK_BYTE exp1_data[] = {0x7B, 0x4C, 0x8D, 0x9E, 0x11};
+    CK_BYTE exp2_data[] = {0x6A, 0x3B, 0x7C, 0x8D, 0x22};
+    CK_BYTE coeff_data[] = {0x5C, 0x2D, 0x9E, 0x7F, 0x33};
+
+    CK_ATTRIBUTE *orig_modulus = NULL, *orig_pub_exp = NULL, *orig_priv_exp = NULL;
+    CK_ATTRIBUTE *orig_prime1 = NULL, *orig_prime2 = NULL, *orig_exp1 = NULL;
+    CK_ATTRIBUTE *orig_exp2 = NULL, *orig_coeff = NULL;
+    CK_ATTRIBUTE *dec_modulus = NULL, *dec_pub_exp = NULL, *dec_priv_exp = NULL;
+    CK_ATTRIBUTE *dec_prime1 = NULL, *dec_prime2 = NULL, *dec_exp1 = NULL;
+    CK_ATTRIBUTE *dec_exp2 = NULL, *dec_coeff = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* Create original attributes */
+    orig_modulus = create_attribute(CKA_MODULUS, modulus_data, sizeof(modulus_data));
+    orig_pub_exp = create_attribute(CKA_PUBLIC_EXPONENT, pub_exp_data, sizeof(pub_exp_data));
+    orig_priv_exp = create_attribute(CKA_PRIVATE_EXPONENT, priv_exp_data, sizeof(priv_exp_data));
+    orig_prime1 = create_attribute(CKA_PRIME_1, prime1_data, sizeof(prime1_data));
+    orig_prime2 = create_attribute(CKA_PRIME_2, prime2_data, sizeof(prime2_data));
+    orig_exp1 = create_attribute(CKA_EXPONENT_1, exp1_data, sizeof(exp1_data));
+    orig_exp2 = create_attribute(CKA_EXPONENT_2, exp2_data, sizeof(exp2_data));
+    orig_coeff = create_attribute(CKA_COEFFICIENT, coeff_data, sizeof(coeff_data));
+
+    if (!orig_modulus || !orig_pub_exp || !orig_priv_exp || !orig_prime1 ||
+        !orig_prime2 || !orig_exp1 || !orig_exp2 || !orig_coeff) {
+        fprintf(stderr, "[FAIL] test_roundtrip_rsa_private_key: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Encode */
+    rv = ber_encode_RSAPrivateKey(FALSE, &encoded, &encoded_len, orig_modulus, orig_pub_exp,
+                                  orig_priv_exp, orig_prime1, orig_prime2, orig_exp1,
+                                  orig_exp2, orig_coeff);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_rsa_private_key: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Decode */
+    rv = ber_decode_RSAPrivateKey(encoded, encoded_len, &dec_modulus, &dec_pub_exp,
+                                  &dec_priv_exp, &dec_prime1, &dec_prime2,
+                                  &dec_exp1, &dec_exp2, &dec_coeff);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_rsa_private_key: decode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify all components match */
+    if (dec_modulus->ulValueLen != sizeof(modulus_data) ||
+        memcmp(dec_modulus->pValue, modulus_data, sizeof(modulus_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_rsa_private_key: modulus mismatch\n");
+        result = 1;
+    }
+
+    if (dec_pub_exp->ulValueLen != sizeof(pub_exp_data) ||
+        memcmp(dec_pub_exp->pValue, pub_exp_data, sizeof(pub_exp_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_rsa_private_key: public exponent mismatch\n");
+        result = 1;
+    }
+
+    if (dec_priv_exp->ulValueLen != sizeof(priv_exp_data) ||
+        memcmp(dec_priv_exp->pValue, priv_exp_data, sizeof(priv_exp_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_rsa_private_key: private exponent mismatch\n");
+        result = 1;
+    }
+
+    if (dec_prime1->ulValueLen != sizeof(prime1_data) ||
+        memcmp(dec_prime1->pValue, prime1_data, sizeof(prime1_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_rsa_private_key: prime1 mismatch\n");
+        result = 1;
+    }
+
+    if (dec_prime2->ulValueLen != sizeof(prime2_data) ||
+        memcmp(dec_prime2->pValue, prime2_data, sizeof(prime2_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_rsa_private_key: prime2 mismatch\n");
+        result = 1;
+    }
+
+    if (dec_exp1->ulValueLen != sizeof(exp1_data) ||
+        memcmp(dec_exp1->pValue, exp1_data, sizeof(exp1_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_rsa_private_key: exponent1 mismatch\n");
+        result = 1;
+    }
+
+    if (dec_exp2->ulValueLen != sizeof(exp2_data) ||
+        memcmp(dec_exp2->pValue, exp2_data, sizeof(exp2_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_rsa_private_key: exponent2 mismatch\n");
+        result = 1;
+    }
+
+    if (dec_coeff->ulValueLen != sizeof(coeff_data) ||
+        memcmp(dec_coeff->pValue, coeff_data, sizeof(coeff_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_rsa_private_key: coefficient mismatch\n");
+        result = 1;
+    }
+
+    if (result == 0)
+        printf("[PASS] test_roundtrip_rsa_private_key\n");
+
+cleanup:
+    {
+        CK_ATTRIBUTE *orig_attrs[] = {orig_modulus, orig_pub_exp, orig_priv_exp, orig_prime1,
+                                       orig_prime2, orig_exp1, orig_exp2, orig_coeff};
+        CK_ATTRIBUTE *dec_attrs[] = {dec_modulus, dec_pub_exp, dec_priv_exp, dec_prime1,
+                                      dec_prime2, dec_exp1, dec_exp2, dec_coeff};
+        free_attributes(orig_attrs, 8);
+        free_attributes(dec_attrs, 8);
+    }
+    if (encoded)
+        free(encoded);
+    return result;
+}
+
+/* ============================================================================
+ * RSA Public Key Tests
+ * ============================================================================ */
+
+/* Test ber_encode_RSAPublicKey with basic RSA public key components */
+int test_encode_rsa_public_key_basic(void)
+{
+    CK_BYTE modulus_data[] = {0xC5, 0x3A, 0x7F, 0x8E, 0x9B, 0x2C, 0x1D, 0x0A};
+    CK_BYTE pub_exp_data[] = {0x01, 0x00, 0x01};  /* 65537 */
+
+    CK_ATTRIBUTE *modulus = NULL, *pub_exp = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    modulus = create_attribute(CKA_MODULUS, modulus_data, sizeof(modulus_data));
+    pub_exp = create_attribute(CKA_PUBLIC_EXPONENT, pub_exp_data, sizeof(pub_exp_data));
+
+    if (!modulus || !pub_exp) {
+        fprintf(stderr, "[FAIL] test_encode_rsa_public_key_basic: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = ber_encode_RSAPublicKey(FALSE, &encoded, &encoded_len, modulus, pub_exp);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_rsa_public_key_basic: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify we got some encoded data */
+    if (encoded == NULL || encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_rsa_public_key_basic: no encoded data\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Basic sanity check: should start with SEQUENCE tag (0x30) for SubjectPublicKeyInfo */
+    if (encoded[0] != 0x30) {
+        fprintf(stderr, "[FAIL] test_encode_rsa_public_key_basic: invalid tag (expected 0x30, got 0x%02X)\n",
+                encoded[0]);
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_encode_rsa_public_key_basic\n");
+
+cleanup:
+    if (modulus)
+        free(modulus);
+    if (pub_exp)
+        free(pub_exp);
+    if (encoded)
+        free(encoded);
+    return result;
+}
+
+/* Test ber_decode_RSAPublicKey with valid encoded data */
+int test_decode_rsa_public_key_valid(void)
+{
+    CK_BYTE modulus_data[] = {0xC5, 0x3A, 0x7F, 0x8E, 0x9B, 0x2C, 0x1D, 0x0A};
+    CK_BYTE pub_exp_data[] = {0x01, 0x00, 0x01};
+
+    CK_ATTRIBUTE *enc_modulus = NULL, *enc_pub_exp = NULL;
+    CK_ATTRIBUTE *dec_modulus = NULL, *dec_pub_exp = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* First encode */
+    enc_modulus = create_attribute(CKA_MODULUS, modulus_data, sizeof(modulus_data));
+    enc_pub_exp = create_attribute(CKA_PUBLIC_EXPONENT, pub_exp_data, sizeof(pub_exp_data));
+
+    if (!enc_modulus || !enc_pub_exp) {
+        fprintf(stderr, "[FAIL] test_decode_rsa_public_key_valid: failed to create encode attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = ber_encode_RSAPublicKey(FALSE, &encoded, &encoded_len, enc_modulus, enc_pub_exp);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_rsa_public_key_valid: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Now decode */
+    rv = ber_decode_RSAPublicKey(encoded, encoded_len, &dec_modulus, &dec_pub_exp);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_rsa_public_key_valid: decode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify components were decoded */
+    if (!dec_modulus || !dec_pub_exp) {
+        fprintf(stderr, "[FAIL] test_decode_rsa_public_key_valid: missing decoded attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify modulus matches */
+    if (dec_modulus->ulValueLen != sizeof(modulus_data) ||
+        memcmp(dec_modulus->pValue, modulus_data, sizeof(modulus_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_rsa_public_key_valid: modulus mismatch\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify public exponent matches */
+    if (dec_pub_exp->ulValueLen != sizeof(pub_exp_data) ||
+        memcmp(dec_pub_exp->pValue, pub_exp_data, sizeof(pub_exp_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_rsa_public_key_valid: public exponent mismatch\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_decode_rsa_public_key_valid\n");
+
+cleanup:
+    if (enc_modulus)
+        free(enc_modulus);
+    if (enc_pub_exp)
+        free(enc_pub_exp);
+    if (dec_modulus)
+        free(dec_modulus);
+    if (dec_pub_exp)
+        free(dec_pub_exp);
+    if (encoded)
+        free(encoded);
+    return result;
+}
+
+/* Test ber_decode_RSAPublicKey with invalid algorithm identifier */
+int test_decode_rsa_public_key_invalid_alg(void)
+{
+    /* Create a SubjectPublicKeyInfo with wrong algorithm OID (using DSA OID instead of RSA) */
+    CK_BYTE invalid_data[] = {
+        0x30, 0x1E,  /* SEQUENCE */
+        0x30, 0x09,  /* AlgorithmIdentifier SEQUENCE */
+        0x06, 0x07, 0x2A, 0x86, 0x48, 0xCE, 0x38, 0x04, 0x01,  /* DSA OID */
+        0x03, 0x11,  /* BIT STRING */
+        0x00,  /* unused bits */
+        0x30, 0x0C,  /* SEQUENCE */
+        0x02, 0x05, 0x00, 0xC5, 0x3A, 0x7F, 0x8E,  /* modulus */
+        0x02, 0x03, 0x01, 0x00, 0x01  /* exponent */
+    };
+
+    CK_ATTRIBUTE *modulus = NULL, *pub_exp = NULL;
+    CK_RV rv;
+
+    rv = ber_decode_RSAPublicKey(invalid_data, sizeof(invalid_data), &modulus, &pub_exp);
+
+    /* Should fail with wrong algorithm */
+    if (rv == CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_rsa_public_key_invalid_alg: should have failed with invalid algorithm\n");
+        if (modulus)
+            free(modulus);
+        if (pub_exp)
+            free(pub_exp);
+        return 1;
+    }
+
+    printf("[PASS] test_decode_rsa_public_key_invalid_alg\n");
+    return 0;
+}
+
+/* Test round-trip encoding and decoding of RSA public key */
+int test_roundtrip_rsa_public_key(void)
+{
+    CK_BYTE modulus_data[] = {0xC5, 0x3A, 0x7F, 0x8E, 0x9B, 0x2C, 0x1D, 0x0A, 0x55, 0x66, 0x77};
+    CK_BYTE pub_exp_data[] = {0x01, 0x00, 0x01};
+
+    CK_ATTRIBUTE *orig_modulus = NULL, *orig_pub_exp = NULL;
+    CK_ATTRIBUTE *dec_modulus = NULL, *dec_pub_exp = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* Create original attributes */
+    orig_modulus = create_attribute(CKA_MODULUS, modulus_data, sizeof(modulus_data));
+    orig_pub_exp = create_attribute(CKA_PUBLIC_EXPONENT, pub_exp_data, sizeof(pub_exp_data));
+
+    if (!orig_modulus || !orig_pub_exp) {
+        fprintf(stderr, "[FAIL] test_roundtrip_rsa_public_key: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Encode */
+    rv = ber_encode_RSAPublicKey(FALSE, &encoded, &encoded_len, orig_modulus, orig_pub_exp);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_rsa_public_key: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Decode */
+    rv = ber_decode_RSAPublicKey(encoded, encoded_len, &dec_modulus, &dec_pub_exp);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_rsa_public_key: decode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify components match */
+    if (dec_modulus->ulValueLen != sizeof(modulus_data) ||
+        memcmp(dec_modulus->pValue, modulus_data, sizeof(modulus_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_rsa_public_key: modulus mismatch\n");
+        result = 1;
+    }
+
+    if (dec_pub_exp->ulValueLen != sizeof(pub_exp_data) ||
+        memcmp(dec_pub_exp->pValue, pub_exp_data, sizeof(pub_exp_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_rsa_public_key: public exponent mismatch\n");
+        result = 1;
+    }
+
+    if (result == 0)
+        printf("[PASS] test_roundtrip_rsa_public_key\n");
+
+cleanup:
+    if (orig_modulus)
+        free(orig_modulus);
+    if (orig_pub_exp)
+        free(orig_pub_exp);
+    if (dec_modulus)
+        free(dec_modulus);
+    if (dec_pub_exp)
+        free(dec_pub_exp);
+    if (encoded)
+        free(encoded);
+
+    return result;
+}
+
+/* ============================================================================
+ * DSA Private Key Tests
+ * ============================================================================ */
+
+/* Test ber_encode_DSAPrivateKey with basic DSA key components */
+int test_encode_dsa_private_key_basic(void)
+{
+    /* DSA key components for testing - no leading zeros */
+    CK_BYTE prime_data[] = {0xC5, 0x3A, 0x7F, 0x8E, 0x9B, 0x2C, 0x1D, 0x0A};
+    CK_BYTE subprime_data[] = {0xD9, 0x8C, 0x4E, 0x6F, 0x2A};
+    CK_BYTE base_data[] = {0xE7, 0x9A, 0x3B, 0x5C, 0x1F};
+    CK_BYTE priv_key_data[] = {0x5A, 0x3B, 0x7C, 0x8D};
+
+    CK_ATTRIBUTE *prime = NULL, *subprime = NULL, *base = NULL, *priv_key = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* Create attributes */
+    prime = create_attribute(CKA_PRIME, prime_data, sizeof(prime_data));
+    subprime = create_attribute(CKA_SUBPRIME, subprime_data, sizeof(subprime_data));
+    base = create_attribute(CKA_BASE, base_data, sizeof(base_data));
+    priv_key = create_attribute(CKA_VALUE, priv_key_data, sizeof(priv_key_data));
+
+    if (!prime || !subprime || !base || !priv_key) {
+        fprintf(stderr, "[FAIL] test_encode_dsa_private_key_basic: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = ber_encode_DSAPrivateKey(FALSE, &encoded, &encoded_len, prime, subprime, base, priv_key);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_dsa_private_key_basic: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify we got some encoded data */
+    if (encoded == NULL || encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_dsa_private_key_basic: no encoded data\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Basic sanity check: should start with SEQUENCE tag (0x30) for PrivateKeyInfo */
+    if (encoded[0] != 0x30) {
+        fprintf(stderr, "[FAIL] test_encode_dsa_private_key_basic: invalid tag (expected 0x30, got 0x%02X)\n",
+                encoded[0]);
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_encode_dsa_private_key_basic\n");
+
+cleanup:
+    if (prime)
+        free(prime);
+    if (subprime)
+        free(subprime);
+    if (base)
+        free(base);
+    if (priv_key)
+        free(priv_key);
+    if (encoded)
+        free(encoded);
+    return result;
+}
+
+/* Test ber_encode_DSAPrivateKey in length_only mode */
+int test_encode_dsa_private_key_length_only(void)
+{
+    CK_BYTE prime_data[] = {0xC5, 0x3A, 0x7F, 0x8E, 0x9B, 0x2C, 0x1D, 0x0A};
+    CK_BYTE subprime_data[] = {0xD9, 0x8C, 0x4E, 0x6F, 0x2A};
+    CK_BYTE base_data[] = {0xE7, 0x9A, 0x3B, 0x5C, 0x1F};
+    CK_BYTE priv_key_data[] = {0x5A, 0x3B, 0x7C, 0x8D};
+
+    CK_ATTRIBUTE *prime = NULL, *subprime = NULL, *base = NULL, *priv_key = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    prime = create_attribute(CKA_PRIME, prime_data, sizeof(prime_data));
+    subprime = create_attribute(CKA_SUBPRIME, subprime_data, sizeof(subprime_data));
+    base = create_attribute(CKA_BASE, base_data, sizeof(base_data));
+    priv_key = create_attribute(CKA_VALUE, priv_key_data, sizeof(priv_key_data));
+
+    if (!prime || !subprime || !base || !priv_key) {
+        fprintf(stderr, "[FAIL] test_encode_dsa_private_key_length_only: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = ber_encode_DSAPrivateKey(TRUE, &encoded, &encoded_len, prime, subprime, base, priv_key);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_dsa_private_key_length_only: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* In length_only mode, encoded should be NULL but length should be set */
+    if (encoded != NULL) {
+        fprintf(stderr, "[FAIL] test_encode_dsa_private_key_length_only: encoded should be NULL\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    if (encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_dsa_private_key_length_only: length should be non-zero\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_encode_dsa_private_key_length_only\n");
+
+cleanup:
+    if (prime)
+        free(prime);
+    if (subprime)
+        free(subprime);
+    if (base)
+        free(base);
+    if (priv_key)
+        free(priv_key);
+    return result;
+}
+
+/* Test ber_decode_DSAPrivateKey with valid encoded data */
+int test_decode_dsa_private_key_valid(void)
+{
+    CK_BYTE prime_data[] = {0xC5, 0x3A, 0x7F, 0x8E, 0x9B, 0x2C, 0x1D, 0x0A};
+    CK_BYTE subprime_data[] = {0xD9, 0x8C, 0x4E, 0x6F, 0x2A};
+    CK_BYTE base_data[] = {0xE7, 0x9A, 0x3B, 0x5C, 0x1F};
+    CK_BYTE priv_key_data[] = {0x5A, 0x3B, 0x7C, 0x8D};
+
+    CK_ATTRIBUTE *enc_prime = NULL, *enc_subprime = NULL, *enc_base = NULL, *enc_priv_key = NULL;
+    CK_ATTRIBUTE *dec_prime = NULL, *dec_subprime = NULL, *dec_base = NULL, *dec_priv_key = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* First encode */
+    enc_prime = create_attribute(CKA_PRIME, prime_data, sizeof(prime_data));
+    enc_subprime = create_attribute(CKA_SUBPRIME, subprime_data, sizeof(subprime_data));
+    enc_base = create_attribute(CKA_BASE, base_data, sizeof(base_data));
+    enc_priv_key = create_attribute(CKA_VALUE, priv_key_data, sizeof(priv_key_data));
+
+    if (!enc_prime || !enc_subprime || !enc_base || !enc_priv_key) {
+        fprintf(stderr, "[FAIL] test_decode_dsa_private_key_valid: failed to create encode attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = ber_encode_DSAPrivateKey(FALSE, &encoded, &encoded_len, enc_prime, enc_subprime, enc_base, enc_priv_key);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_dsa_private_key_valid: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Now decode */
+    rv = ber_decode_DSAPrivateKey(encoded, encoded_len, &dec_prime, &dec_subprime, &dec_base, &dec_priv_key);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_dsa_private_key_valid: decode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify all components were decoded */
+    if (!dec_prime || !dec_subprime || !dec_base || !dec_priv_key) {
+        fprintf(stderr, "[FAIL] test_decode_dsa_private_key_valid: missing decoded attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify prime matches */
+    if (dec_prime->ulValueLen != sizeof(prime_data) ||
+        memcmp(dec_prime->pValue, prime_data, sizeof(prime_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_dsa_private_key_valid: prime mismatch\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify subprime matches */
+    if (dec_subprime->ulValueLen != sizeof(subprime_data) ||
+        memcmp(dec_subprime->pValue, subprime_data, sizeof(subprime_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_dsa_private_key_valid: subprime mismatch\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_decode_dsa_private_key_valid\n");
+
+cleanup:
+    if (enc_prime)
+        free(enc_prime);
+    if (enc_subprime)
+        free(enc_subprime);
+    if (enc_base)
+        free(enc_base);
+    if (enc_priv_key)
+        free(enc_priv_key);
+    if (dec_prime)
+        free(dec_prime);
+    if (dec_subprime)
+        free(dec_subprime);
+    if (dec_base)
+        free(dec_base);
+    if (dec_priv_key)
+        free(dec_priv_key);
+    if (encoded)
+        free(encoded);
+    return result;
+}
+
+/* Test round-trip encoding and decoding of DSA private key */
+int test_roundtrip_dsa_private_key(void)
+{
+    CK_BYTE prime_data[] = {0xC5, 0x3A, 0x7F, 0x8E, 0x9B, 0x2C, 0x1D, 0x0A, 0x55};
+    CK_BYTE subprime_data[] = {0xD9, 0x8C, 0x4E, 0x6F, 0x2A, 0x66};
+    CK_BYTE base_data[] = {0xE7, 0x9A, 0x3B, 0x5C, 0x1F, 0x77};
+    CK_BYTE priv_key_data[] = {0x5A, 0x3B, 0x7C, 0x8D, 0x88};
+
+    CK_ATTRIBUTE *orig_prime = NULL, *orig_subprime = NULL, *orig_base = NULL, *orig_priv_key = NULL;
+    CK_ATTRIBUTE *dec_prime = NULL, *dec_subprime = NULL, *dec_base = NULL, *dec_priv_key = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* Create original attributes */
+    orig_prime = create_attribute(CKA_PRIME, prime_data, sizeof(prime_data));
+    orig_subprime = create_attribute(CKA_SUBPRIME, subprime_data, sizeof(subprime_data));
+    orig_base = create_attribute(CKA_BASE, base_data, sizeof(base_data));
+    orig_priv_key = create_attribute(CKA_VALUE, priv_key_data, sizeof(priv_key_data));
+
+    if (!orig_prime || !orig_subprime || !orig_base || !orig_priv_key) {
+        fprintf(stderr, "[FAIL] test_roundtrip_dsa_private_key: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Encode */
+    rv = ber_encode_DSAPrivateKey(FALSE, &encoded, &encoded_len, orig_prime, orig_subprime, orig_base, orig_priv_key);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_dsa_private_key: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Decode */
+    rv = ber_decode_DSAPrivateKey(encoded, encoded_len, &dec_prime, &dec_subprime, &dec_base, &dec_priv_key);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_dsa_private_key: decode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify all components match */
+    if (dec_prime->ulValueLen != sizeof(prime_data) ||
+        memcmp(dec_prime->pValue, prime_data, sizeof(prime_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_dsa_private_key: prime mismatch\n");
+        result = 1;
+    }
+
+    if (dec_subprime->ulValueLen != sizeof(subprime_data) ||
+        memcmp(dec_subprime->pValue, subprime_data, sizeof(subprime_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_dsa_private_key: subprime mismatch\n");
+        result = 1;
+    }
+
+    if (dec_base->ulValueLen != sizeof(base_data) ||
+        memcmp(dec_base->pValue, base_data, sizeof(base_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_dsa_private_key: base mismatch\n");
+        result = 1;
+    }
+
+    if (dec_priv_key->ulValueLen != sizeof(priv_key_data) ||
+        memcmp(dec_priv_key->pValue, priv_key_data, sizeof(priv_key_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_dsa_private_key: private key mismatch\n");
+        result = 1;
+    }
+
+    if (result == 0)
+        printf("[PASS] test_roundtrip_dsa_private_key\n");
+
+cleanup:
+    if (orig_prime)
+        free(orig_prime);
+    if (orig_subprime)
+        free(orig_subprime);
+    if (orig_base)
+        free(orig_base);
+    if (orig_priv_key)
+        free(orig_priv_key);
+    if (dec_prime)
+        free(dec_prime);
+    if (dec_subprime)
+        free(dec_subprime);
+    if (dec_base)
+        free(dec_base);
+    if (dec_priv_key)
+        free(dec_priv_key);
+    if (encoded)
+        free(encoded);
+    return result;
+}
+
+/* ============================================================================
+ * DSA Public Key Tests
+ * ============================================================================ */
+
+/* Test ber_encode_DSAPublicKey with basic DSA public key components */
+int test_encode_dsa_public_key_basic(void)
+{
+    CK_BYTE prime_data[] = {0xC5, 0x3A, 0x7F, 0x8E, 0x9B, 0x2C, 0x1D, 0x0A};
+    CK_BYTE subprime_data[] = {0xD9, 0x8C, 0x4E, 0x6F, 0x2A};
+    CK_BYTE base_data[] = {0xE7, 0x9A, 0x3B, 0x5C, 0x1F};
+    CK_BYTE value_data[] = {0x5A, 0x3B, 0x7C, 0x8D};
+
+    CK_ATTRIBUTE *prime = NULL, *subprime = NULL, *base = NULL, *value = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    prime = create_attribute(CKA_PRIME, prime_data, sizeof(prime_data));
+    subprime = create_attribute(CKA_SUBPRIME, subprime_data, sizeof(subprime_data));
+    base = create_attribute(CKA_BASE, base_data, sizeof(base_data));
+    value = create_attribute(CKA_VALUE, value_data, sizeof(value_data));
+
+    if (!prime || !subprime || !base || !value) {
+        fprintf(stderr, "[FAIL] test_encode_dsa_public_key_basic: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = ber_encode_DSAPublicKey(FALSE, &encoded, &encoded_len, prime, subprime, base, value);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_dsa_public_key_basic: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify we got some encoded data */
+    if (encoded == NULL || encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_dsa_public_key_basic: no encoded data\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Basic sanity check: should start with SEQUENCE tag (0x30) for SubjectPublicKeyInfo */
+    if (encoded[0] != 0x30) {
+        fprintf(stderr, "[FAIL] test_encode_dsa_public_key_basic: invalid tag (expected 0x30, got 0x%02X)\n",
+                encoded[0]);
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_encode_dsa_public_key_basic\n");
+
+cleanup:
+    if (prime)
+        free(prime);
+    if (subprime)
+        free(subprime);
+    if (base)
+        free(base);
+    if (value)
+        free(value);
+    if (encoded)
+        free(encoded);
+    return result;
+}
+
+/* Test ber_decode_DSAPublicKey with valid encoded data */
+int test_decode_dsa_public_key_valid(void)
+{
+    CK_BYTE prime_data[] = {0xC5, 0x3A, 0x7F, 0x8E, 0x9B, 0x2C, 0x1D, 0x0A};
+    CK_BYTE subprime_data[] = {0xD9, 0x8C, 0x4E, 0x6F, 0x2A};
+    CK_BYTE base_data[] = {0xE7, 0x9A, 0x3B, 0x5C, 0x1F};
+    CK_BYTE value_data[] = {0x5A, 0x3B, 0x7C, 0x8D};
+
+    CK_ATTRIBUTE *enc_prime = NULL, *enc_subprime = NULL, *enc_base = NULL, *enc_value = NULL;
+    CK_ATTRIBUTE *dec_prime = NULL, *dec_subprime = NULL, *dec_base = NULL, *dec_value = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* First encode */
+    enc_prime = create_attribute(CKA_PRIME, prime_data, sizeof(prime_data));
+    enc_subprime = create_attribute(CKA_SUBPRIME, subprime_data, sizeof(subprime_data));
+    enc_base = create_attribute(CKA_BASE, base_data, sizeof(base_data));
+    enc_value = create_attribute(CKA_VALUE, value_data, sizeof(value_data));
+
+    if (!enc_prime || !enc_subprime || !enc_base || !enc_value) {
+        fprintf(stderr, "[FAIL] test_decode_dsa_public_key_valid: failed to create encode attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = ber_encode_DSAPublicKey(FALSE, &encoded, &encoded_len, enc_prime, enc_subprime, enc_base, enc_value);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_dsa_public_key_valid: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Now decode */
+    rv = ber_decode_DSAPublicKey(encoded, encoded_len, &dec_prime, &dec_subprime, &dec_base, &dec_value);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_dsa_public_key_valid: decode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify components were decoded */
+    if (!dec_prime || !dec_subprime || !dec_base || !dec_value) {
+        fprintf(stderr, "[FAIL] test_decode_dsa_public_key_valid: missing decoded attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify prime matches */
+    if (dec_prime->ulValueLen != sizeof(prime_data) ||
+        memcmp(dec_prime->pValue, prime_data, sizeof(prime_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_dsa_public_key_valid: prime mismatch\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify subprime matches */
+    if (dec_subprime->ulValueLen != sizeof(subprime_data) ||
+        memcmp(dec_subprime->pValue, subprime_data, sizeof(subprime_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_dsa_public_key_valid: subprime mismatch\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_decode_dsa_public_key_valid\n");
+
+cleanup:
+    if (enc_prime)
+        free(enc_prime);
+    if (enc_subprime)
+        free(enc_subprime);
+    if (enc_base)
+        free(enc_base);
+    if (enc_value)
+        free(enc_value);
+    if (dec_prime)
+        free(dec_prime);
+    if (dec_subprime)
+        free(dec_subprime);
+    if (dec_base)
+        free(dec_base);
+    if (dec_value)
+        free(dec_value);
+    if (encoded)
+        free(encoded);
+    return result;
+}
+
+/* Test round-trip encoding and decoding of DSA public key */
+int test_roundtrip_dsa_public_key(void)
+{
+    CK_BYTE prime_data[] = {0xC5, 0x3A, 0x7F, 0x8E, 0x9B, 0x2C, 0x1D, 0x0A, 0x55};
+    CK_BYTE subprime_data[] = {0xD9, 0x8C, 0x4E, 0x6F, 0x2A, 0x66};
+    CK_BYTE base_data[] = {0xE7, 0x9A, 0x3B, 0x5C, 0x1F, 0x77};
+    CK_BYTE value_data[] = {0x5A, 0x3B, 0x7C, 0x8D, 0x88};
+
+    CK_ATTRIBUTE *orig_prime = NULL, *orig_subprime = NULL, *orig_base = NULL, *orig_value = NULL;
+    CK_ATTRIBUTE *dec_prime = NULL, *dec_subprime = NULL, *dec_base = NULL, *dec_value = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* Create original attributes */
+    orig_prime = create_attribute(CKA_PRIME, prime_data, sizeof(prime_data));
+    orig_subprime = create_attribute(CKA_SUBPRIME, subprime_data, sizeof(subprime_data));
+    orig_base = create_attribute(CKA_BASE, base_data, sizeof(base_data));
+    orig_value = create_attribute(CKA_VALUE, value_data, sizeof(value_data));
+
+    if (!orig_prime || !orig_subprime || !orig_base || !orig_value) {
+        fprintf(stderr, "[FAIL] test_roundtrip_dsa_public_key: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Encode */
+    rv = ber_encode_DSAPublicKey(FALSE, &encoded, &encoded_len, orig_prime, orig_subprime, orig_base, orig_value);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_dsa_public_key: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Decode */
+    rv = ber_decode_DSAPublicKey(encoded, encoded_len, &dec_prime, &dec_subprime, &dec_base, &dec_value);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_dsa_public_key: decode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify components match */
+    if (dec_prime->ulValueLen != sizeof(prime_data) ||
+        memcmp(dec_prime->pValue, prime_data, sizeof(prime_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_dsa_public_key: prime mismatch\n");
+        result = 1;
+    }
+
+    if (dec_subprime->ulValueLen != sizeof(subprime_data) ||
+        memcmp(dec_subprime->pValue, subprime_data, sizeof(subprime_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_dsa_public_key: subprime mismatch\n");
+        result = 1;
+    }
+
+    if (dec_base->ulValueLen != sizeof(base_data) ||
+        memcmp(dec_base->pValue, base_data, sizeof(base_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_dsa_public_key: base mismatch\n");
+        result = 1;
+    }
+
+    if (dec_value->ulValueLen != sizeof(value_data) ||
+        memcmp(dec_value->pValue, value_data, sizeof(value_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_dsa_public_key: value mismatch\n");
+        result = 1;
+    }
+
+    if (result == 0)
+        printf("[PASS] test_roundtrip_dsa_public_key\n");
+
+cleanup:
+    if (orig_prime)
+        free(orig_prime);
+    if (orig_subprime)
+        free(orig_subprime);
+    if (orig_base)
+        free(orig_base);
+    if (orig_value)
+        free(orig_value);
+    if (dec_prime)
+        free(dec_prime);
+    if (dec_subprime)
+        free(dec_subprime);
+    if (dec_base)
+        free(dec_base);
+    if (dec_value)
+        free(dec_value);
+    if (encoded)
+        free(encoded);
+    return result;
+}
+
+/* ========================================================================
+ * DH Private Key Tests
+ * ======================================================================== */
+
+int test_encode_dh_private_key_basic(void)
+{
+    CK_RV rv;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_ATTRIBUTE *prime = NULL, *base = NULL, *priv_key = NULL;
+    int result = 0;
+
+    /* Test data - DH has 3 components: prime (p), base (g), private key (x) */
+    CK_BYTE prime_data[] = {
+        0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF,
+        0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54, 0x32, 0x10
+    };
+    CK_BYTE base_data[] = {
+        0x11, 0x22, 0x33, 0x44
+    };
+    CK_BYTE priv_key_data[] = {
+        0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC
+    };
+
+    printf("Testing ber_encode_DHPrivateKey (basic)... ");
+
+    /* Create attributes */
+    prime = create_attribute(CKA_PRIME, prime_data, sizeof(prime_data));
+    base = create_attribute(CKA_BASE, base_data, sizeof(base_data));
+    priv_key = create_attribute(CKA_VALUE, priv_key_data, sizeof(priv_key_data));
+
+    if (!prime || !base || !priv_key) {
+        fprintf(stderr, "[FAIL] test_encode_dh_private_key_basic: Failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Encode */
+    rv = ber_encode_DHPrivateKey(FALSE, &encoded, &encoded_len, prime, base, priv_key);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_dh_private_key_basic: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (!encoded || encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_dh_private_key_basic: No data encoded\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS]\n");
+
+cleanup:
+    if (prime)
+        free(prime);
+    if (base)
+        free(base);
+    if (priv_key)
+        free(priv_key);
+    if (encoded)
+        free(encoded);
+    return result;
+}
+
+int test_encode_dh_private_key_length_only(void)
+{
+    CK_RV rv;
+    CK_ULONG encoded_len = 0;
+    CK_ATTRIBUTE *prime = NULL, *base = NULL, *priv_key = NULL;
+    int result = 0;
+
+    CK_BYTE prime_data[] = {
+        0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF,
+        0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54, 0x32, 0x10
+    };
+    CK_BYTE base_data[] = {
+        0x11, 0x22, 0x33, 0x44
+    };
+    CK_BYTE priv_key_data[] = {
+        0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC
+    };
+
+    printf("Testing ber_encode_DHPrivateKey (length only)... ");
+
+    prime = create_attribute(CKA_PRIME, prime_data, sizeof(prime_data));
+    base = create_attribute(CKA_BASE, base_data, sizeof(base_data));
+    priv_key = create_attribute(CKA_VALUE, priv_key_data, sizeof(priv_key_data));
+
+    if (!prime || !base || !priv_key) {
+        fprintf(stderr, "[FAIL] test_encode_dh_private_key_length_only: Failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Get length only */
+    rv = ber_encode_DHPrivateKey(TRUE, NULL, &encoded_len, prime, base, priv_key);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_dh_private_key_length_only: length calculation failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_dh_private_key_length_only: Length is zero\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS]\n");
+
+cleanup:
+    if (prime)
+        free(prime);
+    if (base)
+        free(base);
+    if (priv_key)
+        free(priv_key);
+    return result;
+}
+
+int test_decode_dh_private_key_valid(void)
+{
+    CK_RV rv;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_ATTRIBUTE *orig_prime = NULL, *orig_base = NULL, *orig_priv_key = NULL;
+    CK_ATTRIBUTE *dec_prime = NULL, *dec_base = NULL, *dec_priv_key = NULL;
+    int result = 0;
+
+    CK_BYTE prime_data[] = {
+        0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF,
+        0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54, 0x32, 0x10
+    };
+    CK_BYTE base_data[] = {
+        0x11, 0x22, 0x33, 0x44
+    };
+    CK_BYTE priv_key_data[] = {
+        0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC
+    };
+
+    printf("Testing ber_decode_DHPrivateKey (valid)... ");
+
+    /* Create and encode */
+    orig_prime = create_attribute(CKA_PRIME, prime_data, sizeof(prime_data));
+    orig_base = create_attribute(CKA_BASE, base_data, sizeof(base_data));
+    orig_priv_key = create_attribute(CKA_VALUE, priv_key_data, sizeof(priv_key_data));
+
+    if (!orig_prime || !orig_base || !orig_priv_key) {
+        fprintf(stderr, "[FAIL] test_decode_dh_private_key_valid: Failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = ber_encode_DHPrivateKey(FALSE, &encoded, &encoded_len, orig_prime, orig_base, orig_priv_key);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_dh_private_key_valid: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Decode */
+    rv = ber_decode_DHPrivateKey(encoded, encoded_len, &dec_prime, &dec_base, &dec_priv_key);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_dh_private_key_valid: decode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify components */
+    if (dec_prime->ulValueLen != sizeof(prime_data) ||
+        memcmp(dec_prime->pValue, prime_data, sizeof(prime_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_dh_private_key_valid: prime mismatch\n");
+        result = 1;
+    }
+
+    if (dec_base->ulValueLen != sizeof(base_data) ||
+        memcmp(dec_base->pValue, base_data, sizeof(base_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_dh_private_key_valid: base mismatch\n");
+        result = 1;
+    }
+
+    if (dec_priv_key->ulValueLen != sizeof(priv_key_data) ||
+        memcmp(dec_priv_key->pValue, priv_key_data, sizeof(priv_key_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_dh_private_key_valid: private key mismatch\n");
+        result = 1;
+    }
+
+    if (result == 0)
+        printf("[PASS]\n");
+
+cleanup:
+    if (orig_prime)
+        free(orig_prime);
+    if (orig_base)
+        free(orig_base);
+    if (orig_priv_key)
+        free(orig_priv_key);
+    if (dec_prime)
+        free(dec_prime);
+    if (dec_base)
+        free(dec_base);
+    if (dec_priv_key)
+        free(dec_priv_key);
+    if (encoded)
+        free(encoded);
+    return result;
+}
+
+int test_roundtrip_dh_private_key(void)
+{
+    CK_RV rv;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_ATTRIBUTE *orig_prime = NULL, *orig_base = NULL, *orig_priv_key = NULL;
+    CK_ATTRIBUTE *dec_prime = NULL, *dec_base = NULL, *dec_priv_key = NULL;
+    int result = 0;
+
+    CK_BYTE prime_data[] = {
+        0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF,
+        0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54, 0x32, 0x10
+    };
+    CK_BYTE base_data[] = {
+        0x11, 0x22, 0x33, 0x44
+    };
+    CK_BYTE priv_key_data[] = {
+        0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC
+    };
+
+    printf("Testing DH private key roundtrip... ");
+
+    /* Create attributes */
+    orig_prime = create_attribute(CKA_PRIME, prime_data, sizeof(prime_data));
+    orig_base = create_attribute(CKA_BASE, base_data, sizeof(base_data));
+    orig_priv_key = create_attribute(CKA_VALUE, priv_key_data, sizeof(priv_key_data));
+
+    if (!orig_prime || !orig_base || !orig_priv_key) {
+        fprintf(stderr, "[FAIL] test_roundtrip_dh_private_key: Failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Encode */
+    rv = ber_encode_DHPrivateKey(FALSE, &encoded, &encoded_len, orig_prime, orig_base, orig_priv_key);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_dh_private_key: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Decode */
+    rv = ber_decode_DHPrivateKey(encoded, encoded_len, &dec_prime, &dec_base, &dec_priv_key);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_dh_private_key: decode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify all components match */
+    if (dec_prime->ulValueLen != sizeof(prime_data) ||
+        memcmp(dec_prime->pValue, prime_data, sizeof(prime_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_dh_private_key: prime mismatch\n");
+        result = 1;
+    }
+
+    if (dec_base->ulValueLen != sizeof(base_data) ||
+        memcmp(dec_base->pValue, base_data, sizeof(base_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_dh_private_key: base mismatch\n");
+        result = 1;
+    }
+
+    if (dec_priv_key->ulValueLen != sizeof(priv_key_data) ||
+        memcmp(dec_priv_key->pValue, priv_key_data, sizeof(priv_key_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_dh_private_key: private key mismatch\n");
+        result = 1;
+    }
+
+    if (result == 0)
+        printf("[PASS]\n");
+
+cleanup:
+    if (orig_prime)
+        free(orig_prime);
+    if (orig_base)
+        free(orig_base);
+    if (orig_priv_key)
+        free(orig_priv_key);
+    if (dec_prime)
+        free(dec_prime);
+    if (dec_base)
+        free(dec_base);
+    if (dec_priv_key)
+        free(dec_priv_key);
+    if (encoded)
+        free(encoded);
+    return result;
+}
+
+/* ========================================================================
+ * DH Public Key Tests
+ * ======================================================================== */
+
+int test_encode_dh_public_key_basic(void)
+{
+    CK_RV rv;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_ATTRIBUTE *prime = NULL, *base = NULL, *value = NULL;
+    int result = 0;
+
+    /* Test data - DH public key has 3 components: prime (p), base (g), public value (y) */
+    CK_BYTE prime_data[] = {
+        0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF,
+        0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54, 0x32, 0x10
+    };
+    CK_BYTE base_data[] = {
+        0x11, 0x22, 0x33, 0x44
+    };
+    CK_BYTE value_data[] = {
+        0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC
+    };
+
+    printf("Testing ber_encode_DHPublicKey (basic)... ");
+
+    /* Create attributes */
+    prime = create_attribute(CKA_PRIME, prime_data, sizeof(prime_data));
+    base = create_attribute(CKA_BASE, base_data, sizeof(base_data));
+    value = create_attribute(CKA_VALUE, value_data, sizeof(value_data));
+
+    if (!prime || !base || !value) {
+        fprintf(stderr, "[FAIL] test_encode_dh_public_key_basic: Failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Encode */
+    rv = ber_encode_DHPublicKey(FALSE, &encoded, &encoded_len, prime, base, value);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_dh_public_key_basic: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (!encoded || encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_dh_public_key_basic: No data encoded\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS]\n");
+
+cleanup:
+    if (prime)
+        free(prime);
+    if (base)
+        free(base);
+    if (value)
+        free(value);
+    if (encoded)
+        free(encoded);
+    return result;
+}
+
+int test_decode_dh_public_key_valid(void)
+{
+    CK_RV rv;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_ATTRIBUTE *orig_prime = NULL, *orig_base = NULL, *orig_value = NULL;
+    CK_ATTRIBUTE *dec_prime = NULL, *dec_base = NULL, *dec_value = NULL;
+    int result = 0;
+
+    CK_BYTE prime_data[] = {
+        0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF,
+        0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54, 0x32, 0x10
+    };
+    CK_BYTE base_data[] = {
+        0x11, 0x22, 0x33, 0x44
+    };
+    CK_BYTE value_data[] = {
+        0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC
+    };
+
+    printf("Testing ber_decode_DHPublicKey (valid)... ");
+
+    /* Create and encode */
+    orig_prime = create_attribute(CKA_PRIME, prime_data, sizeof(prime_data));
+    orig_base = create_attribute(CKA_BASE, base_data, sizeof(base_data));
+    orig_value = create_attribute(CKA_VALUE, value_data, sizeof(value_data));
+
+    if (!orig_prime || !orig_base || !orig_value) {
+        fprintf(stderr, "[FAIL] test_decode_dh_public_key_valid: Failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = ber_encode_DHPublicKey(FALSE, &encoded, &encoded_len, orig_prime, orig_base, orig_value);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_dh_public_key_valid: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Decode */
+    rv = ber_decode_DHPublicKey(encoded, encoded_len, &dec_prime, &dec_base, &dec_value);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_dh_public_key_valid: decode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify components */
+    if (dec_prime->ulValueLen != sizeof(prime_data) ||
+        memcmp(dec_prime->pValue, prime_data, sizeof(prime_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_dh_public_key_valid: prime mismatch\n");
+        result = 1;
+    }
+
+    if (dec_base->ulValueLen != sizeof(base_data) ||
+        memcmp(dec_base->pValue, base_data, sizeof(base_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_dh_public_key_valid: base mismatch\n");
+        result = 1;
+    }
+
+    if (dec_value->ulValueLen != sizeof(value_data) ||
+        memcmp(dec_value->pValue, value_data, sizeof(value_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_dh_public_key_valid: value mismatch\n");
+        result = 1;
+    }
+
+    if (result == 0)
+        printf("[PASS]\n");
+
+cleanup:
+    if (orig_prime)
+        free(orig_prime);
+    if (orig_base)
+        free(orig_base);
+    if (orig_value)
+        free(orig_value);
+    if (dec_prime)
+        free(dec_prime);
+    if (dec_base)
+        free(dec_base);
+    if (dec_value)
+        free(dec_value);
+    if (encoded)
+        free(encoded);
+    return result;
+}
+
+int test_roundtrip_dh_public_key(void)
+{
+    CK_RV rv;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_ATTRIBUTE *orig_prime = NULL, *orig_base = NULL, *orig_value = NULL;
+    CK_ATTRIBUTE *dec_prime = NULL, *dec_base = NULL, *dec_value = NULL;
+    int result = 0;
+
+    CK_BYTE prime_data[] = {
+        0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF,
+        0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54, 0x32, 0x10
+    };
+    CK_BYTE base_data[] = {
+        0x11, 0x22, 0x33, 0x44
+    };
+    CK_BYTE value_data[] = {
+        0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC
+    };
+
+    printf("Testing DH public key roundtrip... ");
+
+    /* Create attributes */
+    orig_prime = create_attribute(CKA_PRIME, prime_data, sizeof(prime_data));
+    orig_base = create_attribute(CKA_BASE, base_data, sizeof(base_data));
+    orig_value = create_attribute(CKA_VALUE, value_data, sizeof(value_data));
+
+    if (!orig_prime || !orig_base || !orig_value) {
+        fprintf(stderr, "[FAIL] test_roundtrip_dh_public_key: Failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Encode */
+    rv = ber_encode_DHPublicKey(FALSE, &encoded, &encoded_len, orig_prime, orig_base, orig_value);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_dh_public_key: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Decode */
+    rv = ber_decode_DHPublicKey(encoded, encoded_len, &dec_prime, &dec_base, &dec_value);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_dh_public_key: decode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify all components match */
+    if (dec_prime->ulValueLen != sizeof(prime_data) ||
+        memcmp(dec_prime->pValue, prime_data, sizeof(prime_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_dh_public_key: prime mismatch\n");
+        result = 1;
+    }
+
+    if (dec_base->ulValueLen != sizeof(base_data) ||
+        memcmp(dec_base->pValue, base_data, sizeof(base_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_dh_public_key: base mismatch\n");
+        result = 1;
+    }
+
+    if (dec_value->ulValueLen != sizeof(value_data) ||
+        memcmp(dec_value->pValue, value_data, sizeof(value_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_dh_public_key: value mismatch\n");
+        result = 1;
+    }
+
+    if (result == 0)
+        printf("[PASS]\n");
+
+cleanup:
+    if (orig_prime)
+        free(orig_prime);
+    if (orig_base)
+        free(orig_base);
+    if (orig_value)
+        free(orig_value);
+    if (dec_prime)
+        free(dec_prime);
+    if (dec_base)
+        free(dec_base);
+    if (dec_value)
+        free(dec_value);
+    if (encoded)
+        free(encoded);
+    return result;
+}
+
+/* ========================================================================
+ * EC Private Key Tests (CKK_EC)
+ * ======================================================================== */
+
+int test_encode_ec_private_key_basic(void)
+{
+    CK_RV rv;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_ATTRIBUTE *params = NULL, *privkey = NULL, *pubkey = NULL;
+    int result = 0;
+
+    /* EC params: prime256v1 curve OID */
+    CK_BYTE params_data[] = {
+        0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07
+    };
+    /* Private key value (32 bytes for P-256) */
+    CK_BYTE privkey_data[] = {
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+        0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+        0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28,
+        0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38
+    };
+    /* Public key point (BER-encoded OCTET STRING containing uncompressed point) */
+    CK_BYTE pubkey_data[] = {
+        0x04, 0x41,  /* OCTET STRING, length 65 */
+        0x04,  /* Uncompressed point indicator */
+        0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48,
+        0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58,
+        0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68,
+        0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78,
+        0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+        0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28,
+        0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38,
+        0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48
+    };
+
+    printf("Testing der_encode_ECPrivateKey (basic)... ");
+
+    params = create_attribute(CKA_EC_PARAMS, params_data, sizeof(params_data));
+    privkey = create_attribute(CKA_VALUE, privkey_data, sizeof(privkey_data));
+    pubkey = create_attribute(CKA_EC_POINT, pubkey_data, sizeof(pubkey_data));
+
+    if (!params || !privkey || !pubkey) {
+        fprintf(stderr, "[FAIL] test_encode_ec_private_key_basic: Failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = der_encode_ECPrivateKey(FALSE, &encoded, &encoded_len, params, privkey, pubkey, CKK_EC);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_ec_private_key_basic: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (!encoded || encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_ec_private_key_basic: No data encoded\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS]\n");
+
+cleanup:
+    if (params) free(params);
+    if (privkey) free(privkey);
+    if (pubkey) free(pubkey);
+    if (encoded) free(encoded);
+    return result;
+}
+
+int test_encode_ec_private_key_length_only(void)
+{
+    CK_RV rv;
+    CK_ULONG encoded_len = 0;
+    CK_ATTRIBUTE *params = NULL, *privkey = NULL;
+    int result = 0;
+
+    CK_BYTE params_data[] = {
+        0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07
+    };
+    CK_BYTE privkey_data[] = {
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+        0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+        0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28,
+        0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38
+    };
+
+    printf("Testing der_encode_ECPrivateKey (length only)... ");
+
+    params = create_attribute(CKA_EC_PARAMS, params_data, sizeof(params_data));
+    privkey = create_attribute(CKA_VALUE, privkey_data, sizeof(privkey_data));
+
+    if (!params || !privkey) {
+        fprintf(stderr, "[FAIL] test_encode_ec_private_key_length_only: Failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = der_encode_ECPrivateKey(TRUE, NULL, &encoded_len, params, privkey, NULL, CKK_EC);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_ec_private_key_length_only: length calculation failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_ec_private_key_length_only: Length is zero\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS]\n");
+
+cleanup:
+    if (params) free(params);
+    if (privkey) free(privkey);
+    return result;
+}
+
+int test_decode_ec_private_key_valid(void)
+{
+    CK_RV rv;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_ATTRIBUTE *orig_params = NULL, *orig_privkey = NULL, *orig_pubkey = NULL;
+    CK_ATTRIBUTE *dec_params = NULL, *dec_privkey = NULL, *dec_pubkey = NULL;
+    int result = 0;
+
+    CK_BYTE params_data[] = {
+        0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07
+    };
+    CK_BYTE privkey_data[] = {
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+        0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+        0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28,
+        0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38
+    };
+
+    printf("Testing der_decode_ECPrivateKey (valid)... ");
+
+    orig_params = create_attribute(CKA_EC_PARAMS, params_data, sizeof(params_data));
+    orig_privkey = create_attribute(CKA_VALUE, privkey_data, sizeof(privkey_data));
+
+    if (!orig_params || !orig_privkey) {
+        fprintf(stderr, "[FAIL] test_decode_ec_private_key_valid: Failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = der_encode_ECPrivateKey(FALSE, &encoded, &encoded_len, orig_params, orig_privkey, NULL, CKK_EC);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ec_private_key_valid: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = der_decode_ECPrivateKey(encoded, encoded_len, &dec_params, &dec_pubkey, &dec_privkey, CKK_EC);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ec_private_key_valid: decode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (dec_params->ulValueLen != sizeof(params_data) ||
+        memcmp(dec_params->pValue, params_data, sizeof(params_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_ec_private_key_valid: params mismatch (expected %lu bytes, got %lu bytes)\n",
+                (unsigned long)sizeof(params_data), (unsigned long)dec_params->ulValueLen);
+        if (dec_params->ulValueLen > 0 && dec_params->ulValueLen <= 20) {
+            {
+                CK_ULONG i;
+                fprintf(stderr, "  Expected: ");
+                for (i = 0; i < sizeof(params_data); i++)
+                    fprintf(stderr, "%02X ", params_data[i]);
+                fprintf(stderr, "\n  Got:      ");
+                for (i = 0; i < dec_params->ulValueLen; i++)
+                    fprintf(stderr, "%02X ", ((CK_BYTE*)dec_params->pValue)[i]);
+                fprintf(stderr, "\n");
+            }
+        }
+        result = 1;
+    }
+
+    if (dec_privkey->ulValueLen != sizeof(privkey_data) ||
+        memcmp(dec_privkey->pValue, privkey_data, sizeof(privkey_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_ec_private_key_valid: private key mismatch\n");
+        result = 1;
+    }
+
+    if (result == 0)
+        printf("[PASS]\n");
+
+cleanup:
+    if (orig_params) free(orig_params);
+    if (orig_privkey) free(orig_privkey);
+    if (orig_pubkey) free(orig_pubkey);
+    if (dec_params) free(dec_params);
+    if (dec_privkey) free(dec_privkey);
+    if (dec_pubkey) free(dec_pubkey);
+    if (encoded) free(encoded);
+    return result;
+}
+
+int test_roundtrip_ec_private_key(void)
+{
+    CK_RV rv;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_ATTRIBUTE *orig_params = NULL, *orig_privkey = NULL;
+    CK_ATTRIBUTE *dec_params = NULL, *dec_privkey = NULL, *dec_pubkey = NULL;
+    int result = 0;
+
+    CK_BYTE params_data[] = {
+        0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07
+    };
+    CK_BYTE privkey_data[] = {
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+        0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+        0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28,
+        0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38
+    };
+
+    printf("Testing EC private key roundtrip... ");
+
+    orig_params = create_attribute(CKA_EC_PARAMS, params_data, sizeof(params_data));
+    orig_privkey = create_attribute(CKA_VALUE, privkey_data, sizeof(privkey_data));
+
+    if (!orig_params || !orig_privkey) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ec_private_key: Failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = der_encode_ECPrivateKey(FALSE, &encoded, &encoded_len, orig_params, orig_privkey, NULL, CKK_EC);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ec_private_key: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = der_decode_ECPrivateKey(encoded, encoded_len, &dec_params, &dec_pubkey, &dec_privkey, CKK_EC);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ec_private_key: decode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (dec_params->ulValueLen != sizeof(params_data) ||
+        memcmp(dec_params->pValue, params_data, sizeof(params_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ec_private_key: params mismatch (expected %lu bytes, got %lu bytes)\n",
+                (unsigned long)sizeof(params_data), (unsigned long)dec_params->ulValueLen);
+        if (dec_params->ulValueLen > 0 && dec_params->ulValueLen <= 20) {
+            {
+                CK_ULONG i;
+                fprintf(stderr, "  Expected: ");
+                for (i = 0; i < sizeof(params_data); i++)
+                    fprintf(stderr, "%02X ", params_data[i]);
+                fprintf(stderr, "\n  Got:      ");
+                for (i = 0; i < dec_params->ulValueLen; i++)
+                    fprintf(stderr, "%02X ", ((CK_BYTE*)dec_params->pValue)[i]);
+                fprintf(stderr, "\n");
+            }
+        }
+        result = 1;
+    }
+
+    if (dec_privkey->ulValueLen != sizeof(privkey_data) ||
+        memcmp(dec_privkey->pValue, privkey_data, sizeof(privkey_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ec_private_key: private key mismatch\n");
+        result = 1;
+    }
+
+    if (result == 0)
+        printf("[PASS]\n");
+
+cleanup:
+    if (orig_params) free(orig_params);
+    if (orig_privkey) free(orig_privkey);
+    if (dec_params) free(dec_params);
+    if (dec_privkey) free(dec_privkey);
+    if (dec_pubkey) free(dec_pubkey);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* ========================================================================
+ * Edwards Curve (CKK_EC_EDWARDS) Private Key Tests
+ * ======================================================================== */
+
+int test_encode_edwards_private_key_basic(void)
+{
+    CK_RV rv;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_ATTRIBUTE *params = NULL, *privkey = NULL;
+    int result = 0;
+
+    /* Ed25519 OID: 1.3.101.112 */
+    CK_BYTE params_data[] = {
+        0x06, 0x03, 0x2B, 0x65, 0x70
+    };
+    CK_BYTE privkey_data[] = {
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+        0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+        0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28,
+        0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38
+    };
+
+    printf("Testing der_encode_ECPrivateKey (Edwards basic)... ");
+
+    params = create_attribute(CKA_EC_PARAMS, params_data, sizeof(params_data));
+    privkey = create_attribute(CKA_VALUE, privkey_data, sizeof(privkey_data));
+
+    if (!params || !privkey) {
+        fprintf(stderr, "[FAIL] test_encode_edwards_private_key_basic: Failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = der_encode_ECPrivateKey(FALSE, &encoded, &encoded_len, params, privkey, NULL, CKK_EC_EDWARDS);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_edwards_private_key_basic: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (!encoded || encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_edwards_private_key_basic: No data encoded\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS]\n");
+
+cleanup:
+    if (params) free(params);
+    if (privkey) free(privkey);
+    if (encoded) free(encoded);
+    return result;
+}
+
+int test_roundtrip_edwards_private_key(void)
+{
+    CK_RV rv;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_ATTRIBUTE *orig_params = NULL, *orig_privkey = NULL;
+    CK_ATTRIBUTE *dec_params = NULL, *dec_privkey = NULL, *dec_pubkey = NULL;
+    int result = 0;
+
+    /* Ed25519 OID: 1.3.101.112 */
+    CK_BYTE params_data[] = {
+        0x06, 0x03, 0x2B, 0x65, 0x70
+    };
+    CK_BYTE privkey_data[] = {
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+        0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+        0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28,
+        0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38
+    };
+
+    printf("Testing Edwards private key roundtrip... ");
+
+    orig_params = create_attribute(CKA_EC_PARAMS, params_data, sizeof(params_data));
+    orig_privkey = create_attribute(CKA_VALUE, privkey_data, sizeof(privkey_data));
+
+    if (!orig_params || !orig_privkey) {
+        fprintf(stderr, "[FAIL] test_roundtrip_edwards_private_key: Failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = der_encode_ECPrivateKey(FALSE, &encoded, &encoded_len, orig_params, orig_privkey, NULL, CKK_EC_EDWARDS);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_edwards_private_key: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = der_decode_ECPrivateKey(encoded, encoded_len, &dec_params, &dec_pubkey, &dec_privkey, CKK_EC_EDWARDS);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_edwards_private_key: decode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (dec_params->ulValueLen != sizeof(params_data) ||
+        memcmp(dec_params->pValue, params_data, sizeof(params_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_edwards_private_key: params mismatch\n");
+        result = 1;
+    }
+
+    if (dec_privkey->ulValueLen != sizeof(privkey_data) ||
+        memcmp(dec_privkey->pValue, privkey_data, sizeof(privkey_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_edwards_private_key: private key mismatch\n");
+        result = 1;
+    }
+
+    if (result == 0)
+        printf("[PASS]\n");
+
+cleanup:
+    if (orig_params) free(orig_params);
+    if (orig_privkey) free(orig_privkey);
+    if (dec_params) free(dec_params);
+    if (dec_privkey) free(dec_privkey);
+    if (dec_pubkey) free(dec_pubkey);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* ========================================================================
+ * Edwards Curve (CKK_EC_EDWARDS) Public Key Tests
+ * ======================================================================== */
+
+int test_encode_edwards_public_key_basic(void)
+{
+    CK_RV rv;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_ATTRIBUTE *params = NULL, *point = NULL;
+    int result = 0;
+
+    /* Ed25519 OID: 1.3.101.112 */
+    CK_BYTE params_data[] = {
+        0x06, 0x03, 0x2B, 0x65, 0x70
+    };
+    /* Raw Ed25519 public key (32 bytes) */
+    CK_BYTE point_data[] = {
+        0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48,
+        0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58,
+        0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68,
+        0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78
+    };
+
+    printf("Testing ber_encode_ECPublicKey (Edwards basic)... ");
+
+    params = create_attribute(CKA_EC_PARAMS, params_data, sizeof(params_data));
+    point = create_attribute(CKA_EC_POINT, point_data, sizeof(point_data));
+
+    if (!params || !point) {
+        fprintf(stderr, "[FAIL] test_encode_edwards_public_key_basic: Failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = ber_encode_ECPublicKey(FALSE, &encoded, &encoded_len, params, point, CKK_EC_EDWARDS);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_edwards_public_key_basic: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (!encoded || encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_edwards_public_key_basic: No data encoded\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS]\n");
+
+cleanup:
+    if (params) free(params);
+    if (point) free(point);
+    if (encoded) free(encoded);
+    return result;
+}
+
+int test_roundtrip_edwards_public_key(void)
+{
+    CK_RV rv;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_ATTRIBUTE *orig_params = NULL, *orig_point = NULL;
+    CK_ATTRIBUTE *dec_params = NULL, *dec_point = NULL;
+    int result = 0;
+
+    /* Ed25519 OID: 1.3.101.112 */
+    CK_BYTE params_data[] = {
+        0x06, 0x03, 0x2B, 0x65, 0x70
+    };
+    /* Raw Ed25519 public key (32 bytes) */
+    CK_BYTE point_data[] = {
+        0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48,
+        0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58,
+        0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68,
+        0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78
+    };
+
+    printf("Testing Edwards public key roundtrip... ");
+
+    orig_params = create_attribute(CKA_EC_PARAMS, params_data, sizeof(params_data));
+    orig_point = create_attribute(CKA_EC_POINT, point_data, sizeof(point_data));
+
+    if (!orig_params || !orig_point) {
+        fprintf(stderr, "[FAIL] test_roundtrip_edwards_public_key: Failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = ber_encode_ECPublicKey(FALSE, &encoded, &encoded_len, orig_params, orig_point, CKK_EC_EDWARDS);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_edwards_public_key: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = der_decode_ECPublicKey(encoded, encoded_len, &dec_params, &dec_point, CKK_EC_EDWARDS);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_edwards_public_key: decode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (dec_params->ulValueLen != sizeof(params_data) ||
+        memcmp(dec_params->pValue, params_data, sizeof(params_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_edwards_public_key: params mismatch\n");
+        result = 1;
+    }
+
+    if (dec_point->ulValueLen != sizeof(point_data) ||
+        memcmp(dec_point->pValue, point_data, sizeof(point_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_edwards_public_key: point mismatch\n");
+        result = 1;
+    }
+
+    if (result == 0)
+        printf("[PASS]\n");
+
+cleanup:
+    if (orig_params) free(orig_params);
+    if (orig_point) free(orig_point);
+    if (dec_params) free(dec_params);
+    if (dec_point) free(dec_point);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* ========================================================================
+ * Montgomery Curve (CKK_EC_MONTGOMERY) Private Key Tests
+ * ======================================================================== */
+
+int test_encode_montgomery_private_key_basic(void)
+{
+    CK_RV rv;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_ATTRIBUTE *params = NULL, *privkey = NULL;
+    int result = 0;
+
+    /* X25519 OID: 1.3.101.110 */
+    CK_BYTE params_data[] = {
+        0x06, 0x03, 0x2B, 0x65, 0x6E
+    };
+    CK_BYTE privkey_data[] = {
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+        0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+        0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28,
+        0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38
+    };
+
+    printf("Testing der_encode_ECPrivateKey (Montgomery basic)... ");
+
+    params = create_attribute(CKA_EC_PARAMS, params_data, sizeof(params_data));
+    privkey = create_attribute(CKA_VALUE, privkey_data, sizeof(privkey_data));
+
+    if (!params || !privkey) {
+        fprintf(stderr, "[FAIL] test_encode_montgomery_private_key_basic: Failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = der_encode_ECPrivateKey(FALSE, &encoded, &encoded_len, params, privkey, NULL, CKK_EC_MONTGOMERY);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_montgomery_private_key_basic: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (!encoded || encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_montgomery_private_key_basic: No data encoded\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS]\n");
+
+cleanup:
+    if (params) free(params);
+    if (privkey) free(privkey);
+    if (encoded) free(encoded);
+    return result;
+}
+
+int test_roundtrip_montgomery_private_key(void)
+{
+    CK_RV rv;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_ATTRIBUTE *orig_params = NULL, *orig_privkey = NULL;
+    CK_ATTRIBUTE *dec_params = NULL, *dec_privkey = NULL, *dec_pubkey = NULL;
+    int result = 0;
+
+    /* X25519 OID: 1.3.101.110 */
+    CK_BYTE params_data[] = {
+        0x06, 0x03, 0x2B, 0x65, 0x6E
+    };
+    CK_BYTE privkey_data[] = {
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+        0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+        0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28,
+        0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38
+    };
+
+    printf("Testing Montgomery private key roundtrip... ");
+
+    orig_params = create_attribute(CKA_EC_PARAMS, params_data, sizeof(params_data));
+    orig_privkey = create_attribute(CKA_VALUE, privkey_data, sizeof(privkey_data));
+
+    if (!orig_params || !orig_privkey) {
+        fprintf(stderr, "[FAIL] test_roundtrip_montgomery_private_key: Failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = der_encode_ECPrivateKey(FALSE, &encoded, &encoded_len, orig_params, orig_privkey, NULL, CKK_EC_MONTGOMERY);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_montgomery_private_key: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = der_decode_ECPrivateKey(encoded, encoded_len, &dec_params, &dec_pubkey, &dec_privkey, CKK_EC_MONTGOMERY);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_montgomery_private_key: decode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (dec_params->ulValueLen != sizeof(params_data) ||
+        memcmp(dec_params->pValue, params_data, sizeof(params_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_montgomery_private_key: params mismatch\n");
+        result = 1;
+    }
+
+    if (dec_privkey->ulValueLen != sizeof(privkey_data) ||
+        memcmp(dec_privkey->pValue, privkey_data, sizeof(privkey_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_montgomery_private_key: private key mismatch\n");
+        result = 1;
+    }
+
+    if (result == 0)
+        printf("[PASS]\n");
+
+cleanup:
+    if (orig_params) free(orig_params);
+    if (orig_privkey) free(orig_privkey);
+    if (dec_params) free(dec_params);
+    if (dec_privkey) free(dec_privkey);
+    if (dec_pubkey) free(dec_pubkey);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* ========================================================================
+ * Montgomery Curve (CKK_EC_MONTGOMERY) Public Key Tests
+ * ======================================================================== */
+
+int test_encode_montgomery_public_key_basic(void)
+{
+    CK_RV rv;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_ATTRIBUTE *params = NULL, *point = NULL;
+    int result = 0;
+
+    /* X25519 OID: 1.3.101.110 */
+    CK_BYTE params_data[] = {
+        0x06, 0x03, 0x2B, 0x65, 0x6E
+    };
+    /* Raw X25519 public key (32 bytes) */
+    CK_BYTE point_data[] = {
+        0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48,
+        0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58,
+        0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68,
+        0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78
+    };
+
+    printf("Testing ber_encode_ECPublicKey (Montgomery basic)... ");
+
+    params = create_attribute(CKA_EC_PARAMS, params_data, sizeof(params_data));
+    point = create_attribute(CKA_EC_POINT, point_data, sizeof(point_data));
+
+    if (!params || !point) {
+        fprintf(stderr, "[FAIL] test_encode_montgomery_public_key_basic: Failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = ber_encode_ECPublicKey(FALSE, &encoded, &encoded_len, params, point, CKK_EC_MONTGOMERY);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_montgomery_public_key_basic: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (!encoded || encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_montgomery_public_key_basic: No data encoded\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS]\n");
+
+cleanup:
+    if (params) free(params);
+    if (point) free(point);
+    if (encoded) free(encoded);
+    return result;
+}
+
+int test_roundtrip_montgomery_public_key(void)
+{
+    CK_RV rv;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_ATTRIBUTE *orig_params = NULL, *orig_point = NULL;
+    CK_ATTRIBUTE *dec_params = NULL, *dec_point = NULL;
+    int result = 0;
+
+    /* X25519 OID: 1.3.101.110 */
+    CK_BYTE params_data[] = {
+        0x06, 0x03, 0x2B, 0x65, 0x6E
+    };
+    /* Raw X25519 public key (32 bytes) */
+    CK_BYTE point_data[] = {
+        0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48,
+        0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58,
+        0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68,
+        0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78
+    };
+
+    printf("Testing Montgomery public key roundtrip... ");
+
+    orig_params = create_attribute(CKA_EC_PARAMS, params_data, sizeof(params_data));
+    orig_point = create_attribute(CKA_EC_POINT, point_data, sizeof(point_data));
+
+    if (!orig_params || !orig_point) {
+        fprintf(stderr, "[FAIL] test_roundtrip_montgomery_public_key: Failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = ber_encode_ECPublicKey(FALSE, &encoded, &encoded_len, orig_params, orig_point, CKK_EC_MONTGOMERY);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_montgomery_public_key: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = der_decode_ECPublicKey(encoded, encoded_len, &dec_params, &dec_point, CKK_EC_MONTGOMERY);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_montgomery_public_key: decode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (dec_params->ulValueLen != sizeof(params_data) ||
+        memcmp(dec_params->pValue, params_data, sizeof(params_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_montgomery_public_key: params mismatch\n");
+        result = 1;
+    }
+
+    if (dec_point->ulValueLen != sizeof(point_data) ||
+        memcmp(dec_point->pValue, point_data, sizeof(point_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_montgomery_public_key: point mismatch\n");
+        result = 1;
+    }
+
+    if (result == 0)
+        printf("[PASS]\n");
+
+cleanup:
+    if (orig_params) free(orig_params);
+    if (orig_point) free(orig_point);
+    if (dec_params) free(dec_params);
+    if (dec_point) free(dec_point);
+    if (encoded) free(encoded);
+    return result;
+}
+
+
+/* ========================================================================
+ * EC Public Key Tests (CKK_EC)
+ * ======================================================================== */
+
+int test_encode_ec_public_key_basic(void)
+{
+    CK_RV rv;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_ATTRIBUTE *params = NULL, *point = NULL;
+    int result = 0;
+
+    CK_BYTE params_data[] = {
+        0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07
+    };
+    CK_BYTE point_data[] = {
+        0x04, 0x41,  /* OCTET STRING, length 65 */
+        0x04,  /* Uncompressed point */
+        0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48,
+        0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58,
+        0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68,
+        0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78,
+        0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+        0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28,
+        0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38,
+        0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48
+    };
+
+    printf("Testing ber_encode_ECPublicKey (basic)... ");
+
+    params = create_attribute(CKA_EC_PARAMS, params_data, sizeof(params_data));
+    point = create_attribute(CKA_EC_POINT, point_data, sizeof(point_data));
+
+    if (!params || !point) {
+        fprintf(stderr, "[FAIL] test_encode_ec_public_key_basic: Failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = ber_encode_ECPublicKey(FALSE, &encoded, &encoded_len, params, point, CKK_EC);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_ec_public_key_basic: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (!encoded || encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_ec_public_key_basic: No data encoded\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS]\n");
+
+cleanup:
+    if (params) free(params);
+    if (point) free(point);
+    if (encoded) free(encoded);
+    return result;
+}
+
+int test_decode_ec_public_key_valid(void)
+{
+    CK_RV rv;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_ATTRIBUTE *orig_params = NULL, *orig_point = NULL;
+    CK_ATTRIBUTE *dec_params = NULL, *dec_point = NULL;
+    int result = 0;
+
+    CK_BYTE params_data[] = {
+        0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07
+    };
+    CK_BYTE point_data[] = {
+        0x04, 0x41,  /* OCTET STRING, length 65 */
+        0x04,  /* Uncompressed point */
+        0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48,
+        0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58,
+        0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68,
+        0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78,
+        0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+        0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28,
+        0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38,
+        0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48
+    };
+
+    printf("Testing der_decode_ECPublicKey (valid)... ");
+
+    orig_params = create_attribute(CKA_EC_PARAMS, params_data, sizeof(params_data));
+    orig_point = create_attribute(CKA_EC_POINT, point_data, sizeof(point_data));
+
+    if (!orig_params || !orig_point) {
+        fprintf(stderr, "[FAIL] test_decode_ec_public_key_valid: Failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = ber_encode_ECPublicKey(FALSE, &encoded, &encoded_len, orig_params, orig_point, CKK_EC);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ec_public_key_valid: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = der_decode_ECPublicKey(encoded, encoded_len, &dec_params, &dec_point, CKK_EC);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ec_public_key_valid: decode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (dec_params->ulValueLen != sizeof(params_data) ||
+        memcmp(dec_params->pValue, params_data, sizeof(params_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_ec_public_key_valid: params mismatch\n");
+        result = 1;
+    }
+
+    if (dec_point->ulValueLen != sizeof(point_data) ||
+        memcmp(dec_point->pValue, point_data, sizeof(point_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_ec_public_key_valid: point mismatch\n");
+        result = 1;
+    }
+
+    if (result == 0)
+        printf("[PASS]\n");
+
+cleanup:
+    if (orig_params) free(orig_params);
+    if (orig_point) free(orig_point);
+    if (dec_params) free(dec_params);
+    if (dec_point) free(dec_point);
+    if (encoded) free(encoded);
+    return result;
+}
+
+int test_roundtrip_ec_public_key(void)
+{
+    CK_RV rv;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_ATTRIBUTE *orig_params = NULL, *orig_point = NULL;
+    CK_ATTRIBUTE *dec_params = NULL, *dec_point = NULL;
+    int result = 0;
+
+    CK_BYTE params_data[] = {
+        0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07
+    };
+    CK_BYTE point_data[] = {
+        0x04, 0x41,  /* OCTET STRING, length 65 */
+        0x04,  /* Uncompressed point */
+        0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48,
+        0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58,
+        0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68,
+        0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78,
+        0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+        0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28,
+        0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38,
+        0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48
+    };
+
+    printf("Testing EC public key roundtrip... ");
+
+    orig_params = create_attribute(CKA_EC_PARAMS, params_data, sizeof(params_data));
+    orig_point = create_attribute(CKA_EC_POINT, point_data, sizeof(point_data));
+
+    if (!orig_params || !orig_point) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ec_public_key: Failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = ber_encode_ECPublicKey(FALSE, &encoded, &encoded_len, orig_params, orig_point, CKK_EC);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ec_public_key: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = der_decode_ECPublicKey(encoded, encoded_len, &dec_params, &dec_point, CKK_EC);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ec_public_key: decode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (dec_params->ulValueLen != sizeof(params_data) ||
+        memcmp(dec_params->pValue, params_data, sizeof(params_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ec_public_key: params mismatch\n");
+        result = 1;
+    }
+
+    if (dec_point->ulValueLen != sizeof(point_data) ||
+        memcmp(dec_point->pValue, point_data, sizeof(point_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ec_public_key: point mismatch\n");
+        result = 1;
+    }
+
+    if (result == 0)
+        printf("[PASS]\n");
+
+cleanup:
+    if (orig_params) free(orig_params);
+    if (orig_point) free(orig_point);
+    if (dec_params) free(dec_params);
+    if (dec_point) free(dec_point);
+    if (encoded) free(encoded);
+    return result;
+}

--- a/testcases/unit/asn1test_keys.h
+++ b/testcases/unit/asn1test_keys.h
@@ -1,0 +1,81 @@
+/*
+ * COPYRIGHT (c) International Business Machines Corp. 2026
+ *
+ * This program is provided under the terms of the Common Public License,
+ * version 1.0 (CPL-1.0). Any use, reproduction or distribution for this
+ * software constitutes recipient's acceptance of CPL-1.0 terms which can be
+ * found in the file LICENSE file or at
+ * https://opensource.org/licenses/cpl1.0.php
+ */
+
+/*
+ * Unit tests for cryptographic key encoding/decoding functions in asn1.c
+ * This header declares test functions for RSA, DSA, DH, EC, Edwards, and Montgomery keys
+ */
+
+#ifndef ASNT1TEST_KEYS_H
+#define ASNT1TEST_KEYS_H
+
+/* RSA Private Key Tests */
+int test_encode_rsa_private_key_basic(void);
+int test_encode_rsa_private_key_length_only(void);
+int test_decode_rsa_private_key_valid(void);
+int test_decode_rsa_private_key_invalid_alg(void);
+int test_roundtrip_rsa_private_key(void);
+
+/* RSA Public Key Tests */
+int test_encode_rsa_public_key_basic(void);
+int test_decode_rsa_public_key_valid(void);
+int test_decode_rsa_public_key_invalid_alg(void);
+int test_roundtrip_rsa_public_key(void);
+
+/* DSA Private Key Tests */
+int test_encode_dsa_private_key_basic(void);
+int test_encode_dsa_private_key_length_only(void);
+int test_decode_dsa_private_key_valid(void);
+int test_roundtrip_dsa_private_key(void);
+
+/* DSA Public Key Tests */
+int test_encode_dsa_public_key_basic(void);
+int test_decode_dsa_public_key_valid(void);
+int test_roundtrip_dsa_public_key(void);
+
+/* DH Private Key Tests */
+int test_encode_dh_private_key_basic(void);
+int test_encode_dh_private_key_length_only(void);
+int test_decode_dh_private_key_valid(void);
+int test_roundtrip_dh_private_key(void);
+
+/* DH Public Key Tests */
+int test_encode_dh_public_key_basic(void);
+int test_decode_dh_public_key_valid(void);
+int test_roundtrip_dh_public_key(void);
+
+/* EC Private Key Tests (CKK_EC) */
+int test_encode_ec_private_key_basic(void);
+int test_encode_ec_private_key_length_only(void);
+int test_decode_ec_private_key_valid(void);
+int test_roundtrip_ec_private_key(void);
+
+/* EC Public Key Tests (CKK_EC) */
+int test_encode_ec_public_key_basic(void);
+int test_decode_ec_public_key_valid(void);
+int test_roundtrip_ec_public_key(void);
+
+/* Edwards Curve Private Key Tests (CKK_EC_EDWARDS) */
+int test_encode_edwards_private_key_basic(void);
+int test_roundtrip_edwards_private_key(void);
+
+/* Edwards Curve Public Key Tests (CKK_EC_EDWARDS) */
+int test_encode_edwards_public_key_basic(void);
+int test_roundtrip_edwards_public_key(void);
+
+/* Montgomery Curve Private Key Tests (CKK_EC_MONTGOMERY) */
+int test_encode_montgomery_private_key_basic(void);
+int test_roundtrip_montgomery_private_key(void);
+
+/* Montgomery Curve Public Key Tests (CKK_EC_MONTGOMERY) */
+int test_encode_montgomery_public_key_basic(void);
+int test_roundtrip_montgomery_public_key(void);
+
+#endif /* ASNT1TEST_KEYS_H */

--- a/testcases/unit/asn1test_pqckeys.c
+++ b/testcases/unit/asn1test_pqckeys.c
@@ -1,0 +1,3884 @@
+/*
+ * COPYRIGHT (c) International Business Machines Corp. 2026
+ *
+ * This program is provided under the terms of the Common Public License,
+ * version 1.0 (CPL-1.0). Any use, reproduction or distribution for this
+ * software constitutes recipient's acceptance of CPL-1.0 terms which can be
+ * found in the file LICENSE file or at
+ * https://opensource.org/licenses/cpl1.0.php
+ */
+
+/*
+ * Post-Quantum Cryptography (PQC) key encoding/decoding unit tests
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "pkcs11types.h"
+#include "defs.h"
+#include "host_defs.h"
+#include "h_extern.h"
+#include "unittest.h"
+#include "asn1test_pqckeys.h"
+
+
+/* Helper function to create a CK_ATTRIBUTE with data */
+CK_ATTRIBUTE *create_attribute(CK_ATTRIBUTE_TYPE type, CK_BYTE *data, CK_ULONG data_len);
+
+/* Function prototypes from asn1.c */
+CK_RV ber_encode_IBM_ML_DSA_PublicKey(CK_MECHANISM_TYPE mech, CK_BBOOL length_only,
+                                       CK_BYTE **data, CK_ULONG *data_len,
+                                       const CK_BYTE *oid, CK_ULONG oid_len,
+                                       CK_ATTRIBUTE *rho, CK_ATTRIBUTE *t1);
+
+CK_RV ber_decode_IBM_ML_DSA_PublicKey(CK_MECHANISM_TYPE mech, CK_BYTE *data,
+                                       CK_ULONG data_len, CK_ATTRIBUTE **rho,
+                                       CK_ATTRIBUTE **t1, CK_ATTRIBUTE **value,
+                                       const struct pqc_oid **oid);
+
+CK_RV ber_encode_IBM_ML_DSA_PrivateKey(CK_MECHANISM_TYPE mech, CK_BBOOL length_only,
+                                        CK_BYTE **data, CK_ULONG *data_len,
+                                        const CK_BYTE *oid, CK_ULONG oid_len,
+                                        CK_ATTRIBUTE *rho, CK_ATTRIBUTE *seed,
+                                        CK_ATTRIBUTE *tr, CK_ATTRIBUTE *s1,
+                                        CK_ATTRIBUTE *s2, CK_ATTRIBUTE *t0,
+                                        CK_ATTRIBUTE *t1, CK_ATTRIBUTE *priv_seed);
+
+CK_RV ber_decode_IBM_ML_DSA_PrivateKey(CK_MECHANISM_TYPE mech, CK_BYTE *data,
+                                        CK_ULONG data_len, CK_ATTRIBUTE **rho,
+                                        CK_ATTRIBUTE **seed, CK_ATTRIBUTE **tr,
+                                        CK_ATTRIBUTE **s1, CK_ATTRIBUTE **s2,
+                                        CK_ATTRIBUTE **t0, CK_ATTRIBUTE **t1,
+                                        CK_ATTRIBUTE **priv_seed,
+                                        CK_ATTRIBUTE **value,
+                                        const struct pqc_oid **oid);
+
+CK_RV ber_encode_IBM_ML_KEM_PublicKey(CK_MECHANISM_TYPE mech, CK_BBOOL length_only,
+                                       CK_BYTE **data, CK_ULONG *data_len,
+                                       const CK_BYTE *oid, CK_ULONG oid_len,
+                                       CK_ATTRIBUTE *pk);
+
+CK_RV ber_decode_IBM_ML_KEM_PublicKey(CK_MECHANISM_TYPE mech, CK_BYTE *data,
+                                       CK_ULONG data_len, CK_ATTRIBUTE **pk,
+                                       CK_ATTRIBUTE **value,
+                                       const struct pqc_oid **oid);
+
+CK_RV ber_encode_IBM_ML_KEM_PrivateKey(CK_MECHANISM_TYPE mech, CK_BBOOL length_only,
+                                        CK_BYTE **data, CK_ULONG *data_len,
+                                        const CK_BYTE *oid, CK_ULONG oid_len,
+                                        CK_ATTRIBUTE *sk, CK_ATTRIBUTE *pk,
+                                        CK_ATTRIBUTE *priv_seed);
+
+CK_RV ber_decode_IBM_ML_KEM_PrivateKey(CK_MECHANISM_TYPE mech, CK_BYTE *data,
+                                        CK_ULONG data_len, CK_ATTRIBUTE **sk,
+                                        CK_ATTRIBUTE **pk,
+                                        CK_ATTRIBUTE **priv_seed,
+                                        CK_ATTRIBUTE **value,
+                                        const struct pqc_oid **oid);
+
+CK_RV ber_encode_ML_DSA_PublicKey(CK_BBOOL length_only, CK_BYTE **data,
+                                   CK_ULONG *data_len, const CK_BYTE *oid,
+                                   CK_ULONG oid_len, CK_ATTRIBUTE *value);
+
+CK_RV ber_decode_ML_DSA_PublicKey(CK_BYTE *data, CK_ULONG data_len,
+                                   CK_ATTRIBUTE **value,
+                                   const struct pqc_oid **oid);
+
+CK_RV ber_encode_ML_DSA_PrivateKey(CK_BBOOL length_only, CK_BYTE **data,
+                                    CK_ULONG *data_len, const CK_BYTE *oid,
+                                    CK_ULONG oid_len, CK_ATTRIBUTE *value,
+                                    CK_ATTRIBUTE *seed);
+
+CK_RV ber_decode_ML_DSA_PrivateKey(CK_BYTE *data, CK_ULONG data_len,
+                                    CK_ATTRIBUTE **value,
+                                    CK_ATTRIBUTE **seed,
+                                    const struct pqc_oid **oid);
+
+CK_RV ber_encode_ML_KEM_PublicKey(CK_BBOOL length_only, CK_BYTE **data,
+                                   CK_ULONG *data_len, const CK_BYTE *oid,
+                                   CK_ULONG oid_len, CK_ATTRIBUTE *value);
+
+CK_RV ber_decode_ML_KEM_PublicKey(CK_BYTE *data, CK_ULONG data_len,
+                                   CK_ATTRIBUTE **value,
+                                   const struct pqc_oid **oid);
+
+CK_RV ber_encode_ML_KEM_PrivateKey(CK_BBOOL length_only, CK_BYTE **data,
+                                    CK_ULONG *data_len, const CK_BYTE *oid,
+                                    CK_ULONG oid_len, CK_ATTRIBUTE *value,
+                                    CK_ATTRIBUTE *seed);
+
+CK_RV ber_decode_ML_KEM_PrivateKey(CK_BYTE *data, CK_ULONG data_len,
+                                    CK_ATTRIBUTE **value,
+                                    CK_ATTRIBUTE **seed,
+                                    const struct pqc_oid **oid);
+
+/* External OID constants from asn1test_stubs.c */
+extern const CK_BYTE ber_idML_DSA_65[];
+extern const CK_ULONG ber_idML_DSA_65Len;
+extern const CK_BYTE ber_idML_KEM_768[];
+extern const CK_ULONG ber_idML_KEM_768Len;
+
+/* ============================================================================
+ * IBM Dilithium (Round 2) Tests
+ * ============================================================================ */
+
+/* Test ber_encode_IBM_ML_DSA_PublicKey with basic ML-DSA-65 key components */
+int test_encode_ibm_ml_dsa_public_key_basic(void)
+{
+    /* ML-DSA-65 public key components for testing */
+    CK_BYTE rho_data[32] = {0xA1, 0xB2, 0xC3, 0xD4, 0xE5, 0xF6, 0x07, 0x18,
+                            0x29, 0x3A, 0x4B, 0x5C, 0x6D, 0x7E, 0x8F, 0x90,
+                            0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+                            0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x00};
+    CK_BYTE t1_data[1920];  /* ML-DSA-65 t1 size */
+    CK_ATTRIBUTE *rho = NULL, *t1 = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* Initialize t1 with test data */
+    memset(t1_data, 0x42, sizeof(t1_data));
+
+    /* Create attributes */
+    rho = create_attribute(CKA_IBM_ML_DSA_RHO, rho_data, sizeof(rho_data));
+    t1 = create_attribute(CKA_IBM_ML_DSA_T1, t1_data, sizeof(t1_data));
+
+    if (!rho || !t1) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_ml_dsa_public_key_basic: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Use external OID constant */
+    extern const CK_BYTE ber_idML_DSA_65[];
+    extern const CK_ULONG ber_idML_DSA_65Len;
+
+    rv = ber_encode_IBM_ML_DSA_PublicKey(CKM_IBM_ML_DSA, FALSE, &encoded, &encoded_len,
+                                         ber_idML_DSA_65, ber_idML_DSA_65Len,
+                                         rho, t1);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_ml_dsa_public_key_basic: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify we got some encoded data */
+    if (encoded == NULL || encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_ml_dsa_public_key_basic: no encoded data\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Basic sanity check: should start with SEQUENCE tag (0x30) for SPKI */
+    if (encoded[0] != 0x30) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_ml_dsa_public_key_basic: invalid tag (expected 0x30, got 0x%02X)\n",
+                encoded[0]);
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_encode_ibm_ml_dsa_public_key_basic\n");
+
+cleanup:
+    if (rho) free(rho);
+    if (t1) free(t1);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ber_decode_IBM_ML_DSA_PublicKey with valid encoded data */
+int test_decode_ibm_ml_dsa_public_key_valid(void)
+{
+    CK_BYTE rho_data[32] = {0xA1, 0xB2, 0xC3, 0xD4, 0xE5, 0xF6, 0x07, 0x18,
+                            0x29, 0x3A, 0x4B, 0x5C, 0x6D, 0x7E, 0x8F, 0x90,
+                            0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+                            0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x00};
+    CK_BYTE t1_data[1920];
+    CK_ATTRIBUTE *orig_rho = NULL, *orig_t1 = NULL;
+    CK_ATTRIBUTE *dec_rho = NULL, *dec_t1 = NULL, *dec_value = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    const struct pqc_oid *oid = NULL;
+    CK_RV rv;
+    int result = 0;
+
+    memset(t1_data, 0x42, sizeof(t1_data));
+
+    orig_rho = create_attribute(CKA_IBM_ML_DSA_RHO, rho_data, sizeof(rho_data));
+    orig_t1 = create_attribute(CKA_IBM_ML_DSA_T1, t1_data, sizeof(t1_data));
+
+    if (!orig_rho || !orig_t1) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_ml_dsa_public_key_valid: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    extern const CK_BYTE ber_idML_DSA_65[];
+    extern const CK_ULONG ber_idML_DSA_65Len;
+
+    /* First encode */
+    rv = ber_encode_IBM_ML_DSA_PublicKey(CKM_IBM_ML_DSA, FALSE, &encoded, &encoded_len,
+                                         ber_idML_DSA_65, ber_idML_DSA_65Len,
+                                         orig_rho, orig_t1);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_ml_dsa_public_key_valid: encode failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Now decode */
+    rv = ber_decode_IBM_ML_DSA_PublicKey(CKM_IBM_ML_DSA, encoded, encoded_len,
+                                         &dec_rho, &dec_t1, &dec_value, &oid);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_ml_dsa_public_key_valid: decode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify decoded data matches original */
+    if (!dec_rho || dec_rho->ulValueLen != sizeof(rho_data) ||
+        memcmp(dec_rho->pValue, rho_data, sizeof(rho_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_ml_dsa_public_key_valid: rho mismatch\n");
+        result = 1;
+    }
+
+    if (!dec_t1 || dec_t1->ulValueLen != sizeof(t1_data) ||
+        memcmp(dec_t1->pValue, t1_data, sizeof(t1_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_ml_dsa_public_key_valid: t1 mismatch\n");
+        result = 1;
+    }
+
+    if (result == 0)
+        printf("[PASS] test_decode_ibm_ml_dsa_public_key_valid\n");
+
+cleanup:
+    if (orig_rho) free(orig_rho);
+    if (orig_t1) free(orig_t1);
+    if (dec_rho) free(dec_rho);
+    if (dec_t1) free(dec_t1);
+    if (dec_value) free(dec_value);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ML-DSA public key encode/decode roundtrip */
+int test_roundtrip_ibm_ml_dsa_public_key(void)
+{
+    CK_BYTE rho_data[32] = {0xA1, 0xB2, 0xC3, 0xD4, 0xE5, 0xF6, 0x07, 0x18,
+                            0x29, 0x3A, 0x4B, 0x5C, 0x6D, 0x7E, 0x8F, 0x90,
+                            0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+                            0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x00};
+    CK_BYTE t1_data[1920];
+    CK_ATTRIBUTE *orig_rho = NULL, *orig_t1 = NULL;
+    CK_ATTRIBUTE *dec_rho = NULL, *dec_t1 = NULL, *dec_value = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    const struct pqc_oid *oid = NULL;
+    CK_RV rv;
+    int result = 0;
+
+    memset(t1_data, 0x42, sizeof(t1_data));
+
+    orig_rho = create_attribute(CKA_IBM_ML_DSA_RHO, rho_data, sizeof(rho_data));
+    orig_t1 = create_attribute(CKA_IBM_ML_DSA_T1, t1_data, sizeof(t1_data));
+
+    if (!orig_rho || !orig_t1) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_ml_dsa_public_key: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    extern const CK_BYTE ber_idML_DSA_65[];
+    extern const CK_ULONG ber_idML_DSA_65Len;
+
+    /* Encode */
+    rv = ber_encode_IBM_ML_DSA_PublicKey(CKM_IBM_ML_DSA, FALSE, &encoded, &encoded_len,
+                                         ber_idML_DSA_65, ber_idML_DSA_65Len,
+                                         orig_rho, orig_t1);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_ml_dsa_public_key: encode failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Decode */
+    rv = ber_decode_IBM_ML_DSA_PublicKey(CKM_IBM_ML_DSA, encoded, encoded_len,
+                                         &dec_rho, &dec_t1, &dec_value, &oid);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_ml_dsa_public_key: decode failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify roundtrip */
+    if (dec_rho->ulValueLen != sizeof(rho_data) ||
+        memcmp(dec_rho->pValue, rho_data, sizeof(rho_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_ml_dsa_public_key: rho mismatch\n");
+        result = 1;
+    }
+
+    if (dec_t1->ulValueLen != sizeof(t1_data) ||
+        memcmp(dec_t1->pValue, t1_data, sizeof(t1_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_ml_dsa_public_key: t1 mismatch\n");
+        result = 1;
+    }
+
+    if (result == 0)
+        printf("[PASS] test_roundtrip_ibm_ml_dsa_public_key\n");
+
+cleanup:
+    if (orig_rho) free(orig_rho);
+    if (orig_t1) free(orig_t1);
+    if (dec_rho) free(dec_rho);
+    if (dec_t1) free(dec_t1);
+    if (dec_value) free(dec_value);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* ============================================================================
+ * ML-DSA Private Key Tests
+ * ============================================================================ */
+
+/* Test ber_encode_IBM_ML_DSA_PrivateKey with basic ML-DSA-65 key components */
+int test_encode_ibm_ml_dsa_private_key_basic(void)
+{
+    /* ML-DSA-65 private key components */
+    CK_BYTE rho_data[32], seed_data[32], tr_data[64];
+    CK_BYTE s1_data[640], s2_data[768], t0_data[2496], t1_data[1920];
+    CK_ATTRIBUTE *rho = NULL, *seed = NULL, *tr = NULL;
+    CK_ATTRIBUTE *s1 = NULL, *s2 = NULL, *t0 = NULL, *t1 = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* Initialize with test data */
+    memset(rho_data, 0xA1, sizeof(rho_data));
+    memset(seed_data, 0xB2, sizeof(seed_data));
+    memset(tr_data, 0xC3, sizeof(tr_data));
+    memset(s1_data, 0xD4, sizeof(s1_data));
+    memset(s2_data, 0xE5, sizeof(s2_data));
+    memset(t0_data, 0xF6, sizeof(t0_data));
+    memset(t1_data, 0x07, sizeof(t1_data));
+
+    /* Create attributes */
+    rho = create_attribute(CKA_IBM_ML_DSA_RHO, rho_data, sizeof(rho_data));
+    seed = create_attribute(CKA_IBM_ML_DSA_SEED, seed_data, sizeof(seed_data));
+    tr = create_attribute(CKA_IBM_ML_DSA_TR, tr_data, sizeof(tr_data));
+    s1 = create_attribute(CKA_IBM_ML_DSA_S1, s1_data, sizeof(s1_data));
+    s2 = create_attribute(CKA_IBM_ML_DSA_S2, s2_data, sizeof(s2_data));
+    t0 = create_attribute(CKA_IBM_ML_DSA_T0, t0_data, sizeof(t0_data));
+    t1 = create_attribute(CKA_IBM_ML_DSA_T1, t1_data, sizeof(t1_data));
+
+    if (!rho || !seed || !tr || !s1 || !s2 || !t0 || !t1) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_ml_dsa_private_key_basic: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    extern const CK_BYTE ber_idML_DSA_65[];
+    extern const CK_ULONG ber_idML_DSA_65Len;
+
+    rv = ber_encode_IBM_ML_DSA_PrivateKey(CKM_IBM_ML_DSA, FALSE, &encoded, &encoded_len,
+                                          ber_idML_DSA_65, ber_idML_DSA_65Len,
+                                          rho, seed, tr, s1, s2, t0, t1, NULL);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_ml_dsa_private_key_basic: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (encoded == NULL || encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_ml_dsa_private_key_basic: no encoded data\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    if (encoded[0] != 0x30) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_ml_dsa_private_key_basic: invalid tag\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_encode_ibm_ml_dsa_private_key_basic\n");
+
+cleanup:
+    if (rho) free(rho);
+    if (seed) free(seed);
+    if (tr) free(tr);
+    if (s1) free(s1);
+    if (s2) free(s2);
+    if (t0) free(t0);
+    if (t1) free(t1);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ber_encode_IBM_ML_DSA_PrivateKey with length_only mode */
+int test_encode_ibm_ml_dsa_private_key_length_only(void)
+{
+    CK_BYTE rho_data[32], seed_data[32], tr_data[64];
+    CK_BYTE s1_data[640], s2_data[768], t0_data[2496], t1_data[1920];
+    CK_ATTRIBUTE *rho = NULL, *seed = NULL, *tr = NULL;
+    CK_ATTRIBUTE *s1 = NULL, *s2 = NULL, *t0 = NULL, *t1 = NULL;
+    CK_ULONG len1 = 0, len2 = 0;
+    CK_BYTE *encoded = NULL;
+    CK_RV rv;
+    int result = 0;
+
+    memset(rho_data, 0xA1, sizeof(rho_data));
+    memset(seed_data, 0xB2, sizeof(seed_data));
+    memset(tr_data, 0xC3, sizeof(tr_data));
+    memset(s1_data, 0xD4, sizeof(s1_data));
+    memset(s2_data, 0xE5, sizeof(s2_data));
+    memset(t0_data, 0xF6, sizeof(t0_data));
+    memset(t1_data, 0x07, sizeof(t1_data));
+
+    rho = create_attribute(CKA_IBM_ML_DSA_RHO, rho_data, sizeof(rho_data));
+    seed = create_attribute(CKA_IBM_ML_DSA_SEED, seed_data, sizeof(seed_data));
+    tr = create_attribute(CKA_IBM_ML_DSA_TR, tr_data, sizeof(tr_data));
+    s1 = create_attribute(CKA_IBM_ML_DSA_S1, s1_data, sizeof(s1_data));
+    s2 = create_attribute(CKA_IBM_ML_DSA_S2, s2_data, sizeof(s2_data));
+    t0 = create_attribute(CKA_IBM_ML_DSA_T0, t0_data, sizeof(t0_data));
+    t1 = create_attribute(CKA_IBM_ML_DSA_T1, t1_data, sizeof(t1_data));
+
+    if (!rho || !seed || !tr || !s1 || !s2 || !t0 || !t1) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_ml_dsa_private_key_length_only: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    extern const CK_BYTE ber_idML_DSA_65[];
+    extern const CK_ULONG ber_idML_DSA_65Len;
+
+    /* Get length */
+    rv = ber_encode_IBM_ML_DSA_PrivateKey(CKM_IBM_ML_DSA, TRUE, NULL, &len1,
+                                          ber_idML_DSA_65, ber_idML_DSA_65Len,
+                                          rho, seed, tr, s1, s2, t0, t1, NULL);
+    if (rv != CKR_OK || len1 == 0) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_ml_dsa_private_key_length_only: length calculation failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Actual encode */
+    rv = ber_encode_IBM_ML_DSA_PrivateKey(CKM_IBM_ML_DSA, FALSE, &encoded, &len2,
+                                          ber_idML_DSA_65, ber_idML_DSA_65Len,
+                                          rho, seed, tr, s1, s2, t0, t1, NULL);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_ml_dsa_private_key_length_only: encode failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    if (len1 != len2) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_ml_dsa_private_key_length_only: length mismatch (%lu vs %lu)\n",
+                len1, len2);
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_encode_ibm_ml_dsa_private_key_length_only\n");
+
+cleanup:
+    if (rho) free(rho);
+    if (seed) free(seed);
+    if (tr) free(tr);
+    if (s1) free(s1);
+    if (s2) free(s2);
+    if (t0) free(t0);
+    if (t1) free(t1);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ber_decode_IBM_ML_DSA_PrivateKey with valid encoded data */
+int test_decode_ibm_ml_dsa_private_key_valid(void)
+{
+    CK_BYTE rho_data[32], seed_data[32], tr_data[64];
+    CK_BYTE s1_data[640], s2_data[768], t0_data[2496], t1_data[1920];
+    CK_ATTRIBUTE *orig_rho = NULL, *orig_seed = NULL, *orig_tr = NULL;
+    CK_ATTRIBUTE *orig_s1 = NULL, *orig_s2 = NULL, *orig_t0 = NULL, *orig_t1 = NULL;
+    CK_ATTRIBUTE *dec_rho = NULL, *dec_seed = NULL, *dec_tr = NULL;
+    CK_ATTRIBUTE *dec_s1 = NULL, *dec_s2 = NULL, *dec_t0 = NULL, *dec_t1 = NULL;
+    CK_ATTRIBUTE *dec_priv_seed = NULL, *dec_value = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    const struct pqc_oid *oid = NULL;
+    CK_RV rv;
+    int result = 0;
+
+    memset(rho_data, 0xA1, sizeof(rho_data));
+    memset(seed_data, 0xB2, sizeof(seed_data));
+    memset(tr_data, 0xC3, sizeof(tr_data));
+    memset(s1_data, 0xD4, sizeof(s1_data));
+    memset(s2_data, 0xE5, sizeof(s2_data));
+    memset(t0_data, 0xF6, sizeof(t0_data));
+    memset(t1_data, 0x07, sizeof(t1_data));
+
+    orig_rho = create_attribute(CKA_IBM_ML_DSA_RHO, rho_data, sizeof(rho_data));
+    orig_seed = create_attribute(CKA_IBM_ML_DSA_SEED, seed_data, sizeof(seed_data));
+    orig_tr = create_attribute(CKA_IBM_ML_DSA_TR, tr_data, sizeof(tr_data));
+    orig_s1 = create_attribute(CKA_IBM_ML_DSA_S1, s1_data, sizeof(s1_data));
+    orig_s2 = create_attribute(CKA_IBM_ML_DSA_S2, s2_data, sizeof(s2_data));
+    orig_t0 = create_attribute(CKA_IBM_ML_DSA_T0, t0_data, sizeof(t0_data));
+    orig_t1 = create_attribute(CKA_IBM_ML_DSA_T1, t1_data, sizeof(t1_data));
+
+    if (!orig_rho || !orig_seed || !orig_tr || !orig_s1 || !orig_s2 || !orig_t0 || !orig_t1) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_ml_dsa_private_key_valid: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    extern const CK_BYTE ber_idML_DSA_65[];
+    extern const CK_ULONG ber_idML_DSA_65Len;
+
+    /* Encode */
+    rv = ber_encode_IBM_ML_DSA_PrivateKey(CKM_IBM_ML_DSA, FALSE, &encoded, &encoded_len,
+                                          ber_idML_DSA_65, ber_idML_DSA_65Len,
+                                          orig_rho, orig_seed, orig_tr, orig_s1, orig_s2,
+                                          orig_t0, orig_t1, NULL);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_ml_dsa_private_key_valid: encode failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Decode */
+    rv = ber_decode_IBM_ML_DSA_PrivateKey(CKM_IBM_ML_DSA, encoded, encoded_len,
+                                          &dec_rho, &dec_seed, &dec_tr, &dec_s1, &dec_s2,
+                                          &dec_t0, &dec_t1, &dec_priv_seed, &dec_value, &oid);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_ml_dsa_private_key_valid: decode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify decoded data */
+    if (!dec_rho || dec_rho->ulValueLen != sizeof(rho_data) ||
+        memcmp(dec_rho->pValue, rho_data, sizeof(rho_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_ml_dsa_private_key_valid: rho mismatch\n");
+        result = 1;
+    }
+
+    if (result == 0)
+        printf("[PASS] test_decode_ibm_ml_dsa_private_key_valid\n");
+
+cleanup:
+    if (orig_rho) free(orig_rho);
+    if (orig_seed) free(orig_seed);
+    if (orig_tr) free(orig_tr);
+    if (orig_s1) free(orig_s1);
+    if (orig_s2) free(orig_s2);
+    if (orig_t0) free(orig_t0);
+    if (orig_t1) free(orig_t1);
+    if (dec_rho) free(dec_rho);
+    if (dec_seed) free(dec_seed);
+    if (dec_tr) free(dec_tr);
+    if (dec_s1) free(dec_s1);
+    if (dec_s2) free(dec_s2);
+    if (dec_t0) free(dec_t0);
+    if (dec_t1) free(dec_t1);
+    if (dec_priv_seed) free(dec_priv_seed);
+    if (dec_value) free(dec_value);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ML-DSA private key encode/decode roundtrip */
+int test_roundtrip_ibm_ml_dsa_private_key(void)
+{
+    CK_BYTE rho_data[32], seed_data[32], tr_data[64];
+    CK_BYTE s1_data[640], s2_data[768], t0_data[2496], t1_data[1920];
+    CK_ATTRIBUTE *orig_rho = NULL, *orig_seed = NULL, *orig_tr = NULL;
+    CK_ATTRIBUTE *orig_s1 = NULL, *orig_s2 = NULL, *orig_t0 = NULL, *orig_t1 = NULL;
+    CK_ATTRIBUTE *dec_rho = NULL, *dec_seed = NULL, *dec_tr = NULL;
+    CK_ATTRIBUTE *dec_s1 = NULL, *dec_s2 = NULL, *dec_t0 = NULL, *dec_t1 = NULL;
+    CK_ATTRIBUTE *dec_priv_seed = NULL, *dec_value = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    const struct pqc_oid *oid = NULL;
+    CK_RV rv;
+    int result = 0;
+
+    memset(rho_data, 0xA1, sizeof(rho_data));
+    memset(seed_data, 0xB2, sizeof(seed_data));
+    memset(tr_data, 0xC3, sizeof(tr_data));
+    memset(s1_data, 0xD4, sizeof(s1_data));
+    memset(s2_data, 0xE5, sizeof(s2_data));
+    memset(t0_data, 0xF6, sizeof(t0_data));
+    memset(t1_data, 0x07, sizeof(t1_data));
+
+    orig_rho = create_attribute(CKA_IBM_ML_DSA_RHO, rho_data, sizeof(rho_data));
+    orig_seed = create_attribute(CKA_IBM_ML_DSA_SEED, seed_data, sizeof(seed_data));
+    orig_tr = create_attribute(CKA_IBM_ML_DSA_TR, tr_data, sizeof(tr_data));
+    orig_s1 = create_attribute(CKA_IBM_ML_DSA_S1, s1_data, sizeof(s1_data));
+    orig_s2 = create_attribute(CKA_IBM_ML_DSA_S2, s2_data, sizeof(s2_data));
+    orig_t0 = create_attribute(CKA_IBM_ML_DSA_T0, t0_data, sizeof(t0_data));
+    orig_t1 = create_attribute(CKA_IBM_ML_DSA_T1, t1_data, sizeof(t1_data));
+
+    if (!orig_rho || !orig_seed || !orig_tr || !orig_s1 || !orig_s2 || !orig_t0 || !orig_t1) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_ml_dsa_private_key: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    extern const CK_BYTE ber_idML_DSA_65[];
+    extern const CK_ULONG ber_idML_DSA_65Len;
+
+    /* Encode */
+    rv = ber_encode_IBM_ML_DSA_PrivateKey(CKM_IBM_ML_DSA, FALSE, &encoded, &encoded_len,
+                                          ber_idML_DSA_65, ber_idML_DSA_65Len,
+                                          orig_rho, orig_seed, orig_tr, orig_s1, orig_s2,
+                                          orig_t0, orig_t1, NULL);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_ml_dsa_private_key: encode failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Decode */
+    rv = ber_decode_IBM_ML_DSA_PrivateKey(CKM_IBM_ML_DSA, encoded, encoded_len,
+                                          &dec_rho, &dec_seed, &dec_tr, &dec_s1, &dec_s2,
+                                          &dec_t0, &dec_t1, &dec_priv_seed, &dec_value, &oid);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_ml_dsa_private_key: decode failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify roundtrip */
+    if (dec_rho->ulValueLen != sizeof(rho_data) ||
+        memcmp(dec_rho->pValue, rho_data, sizeof(rho_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_ml_dsa_private_key: rho mismatch\n");
+        result = 1;
+    }
+
+    if (dec_seed->ulValueLen != sizeof(seed_data) ||
+        memcmp(dec_seed->pValue, seed_data, sizeof(seed_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_ml_dsa_private_key: seed mismatch\n");
+        result = 1;
+    }
+
+    if (result == 0)
+        printf("[PASS] test_roundtrip_ibm_ml_dsa_private_key\n");
+
+cleanup:
+    if (orig_rho) free(orig_rho);
+    if (orig_seed) free(orig_seed);
+    if (orig_tr) free(orig_tr);
+    if (orig_s1) free(orig_s1);
+    if (orig_s2) free(orig_s2);
+    if (orig_t0) free(orig_t0);
+    if (orig_t1) free(orig_t1);
+    if (dec_rho) free(dec_rho);
+    if (dec_seed) free(dec_seed);
+    if (dec_tr) free(dec_tr);
+    if (dec_s1) free(dec_s1);
+    if (dec_s2) free(dec_s2);
+    if (dec_t0) free(dec_t0);
+    if (dec_t1) free(dec_t1);
+    if (dec_priv_seed) free(dec_priv_seed);
+    if (dec_value) free(dec_value);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* ============================================================================
+ * ML-KEM Public Key Tests
+ * ============================================================================ */
+
+/* Test ber_encode_IBM_ML_KEM_PublicKey with basic ML-KEM-768 key components */
+int test_encode_ibm_ml_kem_public_key_basic(void)
+{
+    /* ML-KEM-768 public key size */
+    CK_BYTE pk_data[1184];
+    CK_ATTRIBUTE *pk = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    memset(pk_data, 0x55, sizeof(pk_data));
+
+    pk = create_attribute(CKA_IBM_ML_KEM_PK, pk_data, sizeof(pk_data));
+
+    if (!pk) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_ml_kem_public_key_basic: failed to create attribute\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    extern const CK_BYTE ber_idML_KEM_768[];
+    extern const CK_ULONG ber_idML_KEM_768Len;
+
+    rv = ber_encode_IBM_ML_KEM_PublicKey(CKM_IBM_ML_KEM, FALSE, &encoded, &encoded_len,
+                                         ber_idML_KEM_768, ber_idML_KEM_768Len, pk);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_ml_kem_public_key_basic: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (encoded == NULL || encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_ml_kem_public_key_basic: no encoded data\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    if (encoded[0] != 0x30) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_ml_kem_public_key_basic: invalid tag\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_encode_ibm_ml_kem_public_key_basic\n");
+
+cleanup:
+    if (pk) free(pk);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ber_decode_IBM_ML_KEM_PublicKey with valid encoded data */
+int test_decode_ibm_ml_kem_public_key_valid(void)
+{
+    CK_BYTE pk_data[1184];
+    CK_ATTRIBUTE *orig_pk = NULL;
+    CK_ATTRIBUTE *dec_pk = NULL, *dec_value = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    const struct pqc_oid *oid = NULL;
+    CK_RV rv;
+    int result = 0;
+
+    memset(pk_data, 0x55, sizeof(pk_data));
+
+    orig_pk = create_attribute(CKA_IBM_ML_KEM_PK, pk_data, sizeof(pk_data));
+
+    if (!orig_pk) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_ml_kem_public_key_valid: failed to create attribute\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    extern const CK_BYTE ber_idML_KEM_768[];
+    extern const CK_ULONG ber_idML_KEM_768Len;
+
+    /* Encode */
+    rv = ber_encode_IBM_ML_KEM_PublicKey(CKM_IBM_ML_KEM, FALSE, &encoded, &encoded_len,
+                                         ber_idML_KEM_768, ber_idML_KEM_768Len, orig_pk);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_ml_kem_public_key_valid: encode failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Decode */
+    rv = ber_decode_IBM_ML_KEM_PublicKey(CKM_IBM_ML_KEM, encoded, encoded_len,
+                                         &dec_pk, &dec_value, &oid);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_ml_kem_public_key_valid: decode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify decoded data */
+    if (!dec_pk || dec_pk->ulValueLen != sizeof(pk_data) ||
+        memcmp(dec_pk->pValue, pk_data, sizeof(pk_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_ml_kem_public_key_valid: pk mismatch\n");
+        result = 1;
+    }
+
+    if (result == 0)
+        printf("[PASS] test_decode_ibm_ml_kem_public_key_valid\n");
+
+cleanup:
+    if (orig_pk) free(orig_pk);
+    if (dec_pk) free(dec_pk);
+    if (dec_value) free(dec_value);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ML-KEM public key encode/decode roundtrip */
+int test_roundtrip_ibm_ml_kem_public_key(void)
+{
+    CK_BYTE pk_data[1184];
+    CK_ATTRIBUTE *orig_pk = NULL;
+    CK_ATTRIBUTE *dec_pk = NULL, *dec_value = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    const struct pqc_oid *oid = NULL;
+    CK_RV rv;
+    int result = 0;
+
+    memset(pk_data, 0x55, sizeof(pk_data));
+
+    orig_pk = create_attribute(CKA_IBM_ML_KEM_PK, pk_data, sizeof(pk_data));
+
+    if (!orig_pk) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_ml_kem_public_key: failed to create attribute\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    extern const CK_BYTE ber_idML_KEM_768[];
+    extern const CK_ULONG ber_idML_KEM_768Len;
+
+    /* Encode */
+    rv = ber_encode_IBM_ML_KEM_PublicKey(CKM_IBM_ML_KEM, FALSE, &encoded, &encoded_len,
+                                         ber_idML_KEM_768, ber_idML_KEM_768Len, orig_pk);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_ml_kem_public_key: encode failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Decode */
+    rv = ber_decode_IBM_ML_KEM_PublicKey(CKM_IBM_ML_KEM, encoded, encoded_len,
+                                         &dec_pk, &dec_value, &oid);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_ml_kem_public_key: decode failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify roundtrip */
+    if (dec_pk->ulValueLen != sizeof(pk_data) ||
+        memcmp(dec_pk->pValue, pk_data, sizeof(pk_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_ml_kem_public_key: pk mismatch\n");
+        result = 1;
+    }
+
+    if (result == 0)
+        printf("[PASS] test_roundtrip_ibm_ml_kem_public_key\n");
+
+cleanup:
+    if (orig_pk) free(orig_pk);
+    if (dec_pk) free(dec_pk);
+    if (dec_value) free(dec_value);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* ============================================================================
+ * ML-KEM Private Key Tests
+ * ============================================================================ */
+
+/* Test ber_encode_IBM_ML_KEM_PrivateKey with basic ML-KEM-768 key components */
+int test_encode_ibm_ml_kem_private_key_basic(void)
+{
+    /* ML-KEM-768 key sizes */
+    CK_BYTE sk_data[2400];
+    CK_BYTE pk_data[1184];
+    CK_ATTRIBUTE *sk = NULL, *pk = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    memset(sk_data, 0x66, sizeof(sk_data));
+    memset(pk_data, 0x77, sizeof(pk_data));
+
+    sk = create_attribute(CKA_IBM_ML_KEM_SK, sk_data, sizeof(sk_data));
+    pk = create_attribute(CKA_IBM_ML_KEM_PK, pk_data, sizeof(pk_data));
+
+    if (!sk || !pk) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_ml_kem_private_key_basic: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    extern const CK_BYTE ber_idML_KEM_768[];
+    extern const CK_ULONG ber_idML_KEM_768Len;
+
+    rv = ber_encode_IBM_ML_KEM_PrivateKey(CKM_IBM_ML_KEM, FALSE, &encoded, &encoded_len,
+                                          ber_idML_KEM_768, ber_idML_KEM_768Len,
+                                          sk, pk, NULL);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_ml_kem_private_key_basic: encode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (encoded == NULL || encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_ml_kem_private_key_basic: no encoded data\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    if (encoded[0] != 0x30) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_ml_kem_private_key_basic: invalid tag\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_encode_ibm_ml_kem_private_key_basic\n");
+
+cleanup:
+    if (sk) free(sk);
+    if (pk) free(pk);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ber_encode_IBM_ML_KEM_PrivateKey with length_only mode */
+int test_encode_ibm_ml_kem_private_key_length_only(void)
+{
+    CK_BYTE sk_data[2400];
+    CK_BYTE pk_data[1184];
+    CK_ATTRIBUTE *sk = NULL, *pk = NULL;
+    CK_ULONG len1 = 0, len2 = 0;
+    CK_BYTE *encoded = NULL;
+    CK_RV rv;
+    int result = 0;
+
+    memset(sk_data, 0x66, sizeof(sk_data));
+    memset(pk_data, 0x77, sizeof(pk_data));
+
+    sk = create_attribute(CKA_IBM_ML_KEM_SK, sk_data, sizeof(sk_data));
+    pk = create_attribute(CKA_IBM_ML_KEM_PK, pk_data, sizeof(pk_data));
+
+    if (!sk || !pk) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_ml_kem_private_key_length_only: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    extern const CK_BYTE ber_idML_KEM_768[];
+    extern const CK_ULONG ber_idML_KEM_768Len;
+
+    /* Get length */
+    rv = ber_encode_IBM_ML_KEM_PrivateKey(CKM_IBM_ML_KEM, TRUE, NULL, &len1,
+                                          ber_idML_KEM_768, ber_idML_KEM_768Len,
+                                          sk, pk, NULL);
+    if (rv != CKR_OK || len1 == 0) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_ml_kem_private_key_length_only: length calculation failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Actual encode */
+    rv = ber_encode_IBM_ML_KEM_PrivateKey(CKM_IBM_ML_KEM, FALSE, &encoded, &len2,
+                                          ber_idML_KEM_768, ber_idML_KEM_768Len,
+                                          sk, pk, NULL);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_ml_kem_private_key_length_only: encode failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    if (len1 != len2) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_ml_kem_private_key_length_only: length mismatch (%lu vs %lu)\n",
+                len1, len2);
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_encode_ibm_ml_kem_private_key_length_only\n");
+
+cleanup:
+    if (sk) free(sk);
+    if (pk) free(pk);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ber_decode_IBM_ML_KEM_PrivateKey with valid encoded data */
+int test_decode_ibm_ml_kem_private_key_valid(void)
+{
+    CK_BYTE sk_data[2400];
+    CK_BYTE pk_data[1184];
+    CK_ATTRIBUTE *orig_sk = NULL, *orig_pk = NULL;
+    CK_ATTRIBUTE *dec_sk = NULL, *dec_pk = NULL;
+    CK_ATTRIBUTE *dec_priv_seed = NULL, *dec_value = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    const struct pqc_oid *oid = NULL;
+    CK_RV rv;
+    int result = 0;
+
+    memset(sk_data, 0x66, sizeof(sk_data));
+    memset(pk_data, 0x77, sizeof(pk_data));
+
+    orig_sk = create_attribute(CKA_IBM_ML_KEM_SK, sk_data, sizeof(sk_data));
+    orig_pk = create_attribute(CKA_IBM_ML_KEM_PK, pk_data, sizeof(pk_data));
+
+    if (!orig_sk || !orig_pk) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_ml_kem_private_key_valid: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    extern const CK_BYTE ber_idML_KEM_768[];
+    extern const CK_ULONG ber_idML_KEM_768Len;
+
+    /* Encode */
+    rv = ber_encode_IBM_ML_KEM_PrivateKey(CKM_IBM_ML_KEM, FALSE, &encoded, &encoded_len,
+                                          ber_idML_KEM_768, ber_idML_KEM_768Len,
+                                          orig_sk, orig_pk, NULL);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_ml_kem_private_key_valid: encode failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Decode */
+    rv = ber_decode_IBM_ML_KEM_PrivateKey(CKM_IBM_ML_KEM, encoded, encoded_len,
+                                          &dec_sk, &dec_pk, &dec_priv_seed, &dec_value, &oid);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_ml_kem_private_key_valid: decode failed with rv=%lu\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify decoded data */
+    if (!dec_sk || dec_sk->ulValueLen != sizeof(sk_data) ||
+        memcmp(dec_sk->pValue, sk_data, sizeof(sk_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_ml_kem_private_key_valid: sk mismatch\n");
+        result = 1;
+    }
+
+    if (result == 0)
+        printf("[PASS] test_decode_ibm_ml_kem_private_key_valid\n");
+
+cleanup:
+    if (orig_sk) free(orig_sk);
+    if (orig_pk) free(orig_pk);
+    if (dec_sk) free(dec_sk);
+    if (dec_pk) free(dec_pk);
+    if (dec_priv_seed) free(dec_priv_seed);
+    if (dec_value) free(dec_value);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ML-KEM private key encode/decode roundtrip */
+int test_roundtrip_ibm_ml_kem_private_key(void)
+{
+    CK_BYTE sk_data[2400];
+    CK_BYTE pk_data[1184];
+    CK_ATTRIBUTE *orig_sk = NULL, *orig_pk = NULL;
+    CK_ATTRIBUTE *dec_sk = NULL, *dec_pk = NULL;
+    CK_ATTRIBUTE *dec_priv_seed = NULL, *dec_value = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    const struct pqc_oid *oid = NULL;
+    CK_RV rv;
+    int result = 0;
+
+    memset(sk_data, 0x66, sizeof(sk_data));
+    memset(pk_data, 0x77, sizeof(pk_data));
+
+    orig_sk = create_attribute(CKA_IBM_ML_KEM_SK, sk_data, sizeof(sk_data));
+    orig_pk = create_attribute(CKA_IBM_ML_KEM_PK, pk_data, sizeof(pk_data));
+
+    if (!orig_sk || !orig_pk) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_ml_kem_private_key: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    extern const CK_BYTE ber_idML_KEM_768[];
+    extern const CK_ULONG ber_idML_KEM_768Len;
+
+    /* Encode */
+    rv = ber_encode_IBM_ML_KEM_PrivateKey(CKM_IBM_ML_KEM, FALSE, &encoded, &encoded_len,
+                                          ber_idML_KEM_768, ber_idML_KEM_768Len,
+                                          orig_sk, orig_pk, NULL);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_ml_kem_private_key: encode failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Decode */
+    rv = ber_decode_IBM_ML_KEM_PrivateKey(CKM_IBM_ML_KEM, encoded, encoded_len,
+                                          &dec_sk, &dec_pk, &dec_priv_seed, &dec_value, &oid);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_ml_kem_private_key: decode failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify roundtrip */
+    if (dec_sk->ulValueLen != sizeof(sk_data) ||
+        memcmp(dec_sk->pValue, sk_data, sizeof(sk_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_ml_kem_private_key: sk mismatch\n");
+        result = 1;
+    }
+
+    if (result == 0)
+        printf("[PASS] test_roundtrip_ibm_ml_kem_private_key\n");
+
+cleanup:
+    if (orig_sk) free(orig_sk);
+    if (orig_pk) free(orig_pk);
+    if (dec_sk) free(dec_sk);
+    if (dec_pk) free(dec_pk);
+    if (dec_priv_seed) free(dec_priv_seed);
+    if (dec_value) free(dec_value);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* ============================================================================
+ * IBM Dilithium Public Key Tests
+ * ============================================================================ */
+
+/* Test ber_encode_IBM_DilithiumPublicKey with basic Dilithium R2-65 key components */
+int test_encode_ibm_dilithium_public_key_basic(void)
+{
+    /* Dilithium R2-65 public key components for testing */
+    CK_BYTE rho_data[32] = {0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7, 0xD8,
+                            0xD9, 0xDA, 0xDB, 0xDC, 0xDD, 0xDE, 0xDF, 0xE0,
+                            0xE1, 0xE2, 0xE3, 0xE4, 0xE5, 0xE6, 0xE7, 0xE8,
+                            0xE9, 0xEA, 0xEB, 0xEC, 0xED, 0xEE, 0xEF, 0xF0};
+    CK_BYTE t1_data[1728];  /* Dilithium R2-65 t1 size */
+    CK_ATTRIBUTE *rho = NULL, *t1 = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* Initialize t1 with test data */
+    memset(t1_data, 0x52, sizeof(t1_data));
+
+    /* Create attributes */
+    rho = create_attribute(CKA_IBM_DILITHIUM_RHO, rho_data, sizeof(rho_data));
+    t1 = create_attribute(CKA_IBM_DILITHIUM_T1, t1_data, sizeof(t1_data));
+
+    if (!rho || !t1) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_dilithium_public_key_basic: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Use external OID constant */
+    extern const CK_BYTE ber_idDilithium_r2_65[];
+    extern const CK_ULONG ber_idDilithium_r2_65Len;
+
+    rv = ber_encode_IBM_ML_DSA_PublicKey(CKM_IBM_DILITHIUM, FALSE, &encoded, &encoded_len,
+                                           ber_idDilithium_r2_65, ber_idDilithium_r2_65Len,
+                                           rho, t1);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_dilithium_public_key_basic: ber_encode_IBM_DilithiumPublicKey failed with rv=0x%lx\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (!encoded || encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_dilithium_public_key_basic: encoding produced no data\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_encode_ibm_dilithium_public_key_basic\n");
+
+cleanup:
+    if (rho) free(rho);
+    if (t1) free(t1);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ber_decode_IBM_DilithiumPublicKey with encoded data */
+int test_decode_ibm_dilithium_public_key_basic(void)
+{
+    CK_BYTE rho_data[32] = {0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7, 0xD8,
+                            0xD9, 0xDA, 0xDB, 0xDC, 0xDD, 0xDE, 0xDF, 0xE0,
+                            0xE1, 0xE2, 0xE3, 0xE4, 0xE5, 0xE6, 0xE7, 0xE8,
+                            0xE9, 0xEA, 0xEB, 0xEC, 0xED, 0xEE, 0xEF, 0xF0};
+    CK_BYTE t1_data[1728];
+    CK_ATTRIBUTE *rho = NULL, *t1 = NULL;
+    CK_ATTRIBUTE *dec_rho = NULL, *dec_t1 = NULL, *dec_value = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    const struct pqc_oid *oid = NULL;
+    CK_RV rv;
+    int result = 0;
+
+    memset(t1_data, 0x52, sizeof(t1_data));
+
+    rho = create_attribute(CKA_IBM_DILITHIUM_RHO, rho_data, sizeof(rho_data));
+    t1 = create_attribute(CKA_IBM_DILITHIUM_T1, t1_data, sizeof(t1_data));
+
+    if (!rho || !t1) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_dilithium_public_key_basic: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    extern const CK_BYTE ber_idDilithium_r2_65[];
+    extern const CK_ULONG ber_idDilithium_r2_65Len;
+
+    rv = ber_encode_IBM_ML_DSA_PublicKey(CKM_IBM_DILITHIUM, FALSE, &encoded, &encoded_len,
+                                           ber_idDilithium_r2_65, ber_idDilithium_r2_65Len,
+                                           rho, t1);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_dilithium_public_key_basic: encoding failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = ber_decode_IBM_ML_DSA_PublicKey(CKM_IBM_DILITHIUM, encoded, encoded_len,
+                                           &dec_rho, &dec_t1, &dec_value, &oid);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_dilithium_public_key_basic: ber_decode_IBM_DilithiumPublicKey failed with rv=0x%lx\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (!dec_rho || !dec_t1) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_dilithium_public_key_basic: decoded attributes are NULL\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    if (dec_rho->ulValueLen != sizeof(rho_data) ||
+        memcmp(dec_rho->pValue, rho_data, sizeof(rho_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_dilithium_public_key_basic: rho mismatch\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    if (dec_t1->ulValueLen != sizeof(t1_data) ||
+        memcmp(dec_t1->pValue, t1_data, sizeof(t1_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_dilithium_public_key_basic: t1 mismatch\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_decode_ibm_dilithium_public_key_basic\n");
+
+cleanup:
+    if (rho) free(rho);
+    if (t1) free(t1);
+    if (dec_rho) free(dec_rho);
+    if (dec_t1) free(dec_t1);
+    if (dec_value) free(dec_value);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test Dilithium public key encode/decode roundtrip */
+int test_roundtrip_ibm_dilithium_public_key(void)
+{
+    CK_BYTE rho_data[32] = {0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7, 0xD8,
+                            0xD9, 0xDA, 0xDB, 0xDC, 0xDD, 0xDE, 0xDF, 0xE0,
+                            0xE1, 0xE2, 0xE3, 0xE4, 0xE5, 0xE6, 0xE7, 0xE8,
+                            0xE9, 0xEA, 0xEB, 0xEC, 0xED, 0xEE, 0xEF, 0xF0};
+    CK_BYTE t1_data[1728];
+    CK_ATTRIBUTE *orig_rho = NULL, *orig_t1 = NULL;
+    CK_ATTRIBUTE *dec_rho = NULL, *dec_t1 = NULL, *dec_value = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    const struct pqc_oid *oid = NULL;
+    CK_RV rv;
+    int result = 0;
+
+    memset(t1_data, 0x52, sizeof(t1_data));
+
+    orig_rho = create_attribute(CKA_IBM_DILITHIUM_RHO, rho_data, sizeof(rho_data));
+    orig_t1 = create_attribute(CKA_IBM_DILITHIUM_T1, t1_data, sizeof(t1_data));
+
+    if (!orig_rho || !orig_t1) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_dilithium_public_key: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    extern const CK_BYTE ber_idDilithium_r2_65[];
+    extern const CK_ULONG ber_idDilithium_r2_65Len;
+
+    rv = ber_encode_IBM_ML_DSA_PublicKey(CKM_IBM_DILITHIUM, FALSE, &encoded, &encoded_len,
+                                           ber_idDilithium_r2_65, ber_idDilithium_r2_65Len,
+                                           orig_rho, orig_t1);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_dilithium_public_key: encoding failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = ber_decode_IBM_ML_DSA_PublicKey(CKM_IBM_DILITHIUM, encoded, encoded_len,
+                                           &dec_rho, &dec_t1, &dec_value, &oid);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_dilithium_public_key: decoding failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    if (dec_rho->ulValueLen != orig_rho->ulValueLen ||
+        memcmp(dec_rho->pValue, orig_rho->pValue, orig_rho->ulValueLen) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_dilithium_public_key: rho roundtrip failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    if (dec_t1->ulValueLen != orig_t1->ulValueLen ||
+        memcmp(dec_t1->pValue, orig_t1->pValue, orig_t1->ulValueLen) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_dilithium_public_key: t1 roundtrip failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_roundtrip_ibm_dilithium_public_key\n");
+
+cleanup:
+    if (orig_rho) free(orig_rho);
+    if (orig_t1) free(orig_t1);
+    if (dec_rho) free(dec_rho);
+    if (dec_t1) free(dec_t1);
+    if (dec_value) free(dec_value);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* ============================================================================
+ * IBM Dilithium Private Key Tests
+ * ============================================================================ */
+
+/* Test ber_encode_IBM_DilithiumPrivateKey with basic Dilithium R2-65 key components */
+int test_encode_ibm_dilithium_private_key_basic(void)
+{
+    /* Dilithium R2-65 private key components for testing */
+    CK_BYTE rho_data[32] = {0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7, 0xD8,
+                            0xD9, 0xDA, 0xDB, 0xDC, 0xDD, 0xDE, 0xDF, 0xE0,
+                            0xE1, 0xE2, 0xE3, 0xE4, 0xE5, 0xE6, 0xE7, 0xE8,
+                            0xE9, 0xEA, 0xEB, 0xEC, 0xED, 0xEE, 0xEF, 0xF0};
+    CK_BYTE seed_data[32];
+    CK_BYTE tr_data[48];
+    CK_BYTE s1_data[480];
+    CK_BYTE s2_data[576];
+    CK_BYTE t0_data[2688];
+    CK_BYTE t1_data[1728];
+    CK_ATTRIBUTE *rho = NULL, *seed = NULL, *tr = NULL;
+    CK_ATTRIBUTE *s1 = NULL, *s2 = NULL, *t0 = NULL, *t1 = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* Initialize test data */
+    memset(seed_data, 0x53, sizeof(seed_data));
+    memset(tr_data, 0x54, sizeof(tr_data));
+    memset(s1_data, 0x55, sizeof(s1_data));
+    memset(s2_data, 0x56, sizeof(s2_data));
+    memset(t0_data, 0x57, sizeof(t0_data));
+    memset(t1_data, 0x58, sizeof(t1_data));
+
+    /* Create attributes */
+    rho = create_attribute(CKA_IBM_DILITHIUM_RHO, rho_data, sizeof(rho_data));
+    seed = create_attribute(CKA_IBM_DILITHIUM_SEED, seed_data, sizeof(seed_data));
+    tr = create_attribute(CKA_IBM_DILITHIUM_TR, tr_data, sizeof(tr_data));
+    s1 = create_attribute(CKA_IBM_DILITHIUM_S1, s1_data, sizeof(s1_data));
+    s2 = create_attribute(CKA_IBM_DILITHIUM_S2, s2_data, sizeof(s2_data));
+    t0 = create_attribute(CKA_IBM_DILITHIUM_T0, t0_data, sizeof(t0_data));
+    t1 = create_attribute(CKA_IBM_DILITHIUM_T1, t1_data, sizeof(t1_data));
+
+    if (!rho || !seed || !tr || !s1 || !s2 || !t0 || !t1) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_dilithium_private_key_basic: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    extern const CK_BYTE ber_idDilithium_r2_65[];
+    extern const CK_ULONG ber_idDilithium_r2_65Len;
+
+    rv = ber_encode_IBM_ML_DSA_PrivateKey(CKM_IBM_DILITHIUM, FALSE, &encoded, &encoded_len,
+                                            ber_idDilithium_r2_65, ber_idDilithium_r2_65Len,
+                                            rho, seed, tr, s1, s2, t0, t1, NULL);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_dilithium_private_key_basic: ber_encode_IBM_DilithiumPrivateKey failed with rv=0x%lx\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (!encoded || encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_dilithium_private_key_basic: encoding produced no data\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_encode_ibm_dilithium_private_key_basic\n");
+
+cleanup:
+    if (rho) free(rho);
+    if (seed) free(seed);
+    if (tr) free(tr);
+    if (s1) free(s1);
+    if (s2) free(s2);
+    if (t0) free(t0);
+    if (t1) free(t1);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ber_decode_IBM_DilithiumPrivateKey with encoded data */
+int test_decode_ibm_dilithium_private_key_basic(void)
+{
+    CK_BYTE rho_data[32] = {0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7, 0xD8,
+                            0xD9, 0xDA, 0xDB, 0xDC, 0xDD, 0xDE, 0xDF, 0xE0,
+                            0xE1, 0xE2, 0xE3, 0xE4, 0xE5, 0xE6, 0xE7, 0xE8,
+                            0xE9, 0xEA, 0xEB, 0xEC, 0xED, 0xEE, 0xEF, 0xF0};
+    CK_BYTE seed_data[32], tr_data[48], s1_data[480], s2_data[576], t0_data[2688], t1_data[1728];
+    CK_ATTRIBUTE *rho = NULL, *seed = NULL, *tr = NULL, *s1 = NULL, *s2 = NULL, *t0 = NULL, *t1 = NULL;
+    CK_ATTRIBUTE *dec_rho = NULL, *dec_seed = NULL, *dec_tr = NULL;
+    CK_ATTRIBUTE *dec_s1 = NULL, *dec_s2 = NULL, *dec_t0 = NULL, *dec_t1 = NULL, *dec_value = NULL;
+    CK_ATTRIBUTE *dec_priv_seed = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    const struct pqc_oid *oid = NULL;
+    CK_RV rv;
+    int result = 0;
+
+    memset(seed_data, 0x53, sizeof(seed_data));
+    memset(tr_data, 0x54, sizeof(tr_data));
+    memset(s1_data, 0x55, sizeof(s1_data));
+    memset(s2_data, 0x56, sizeof(s2_data));
+    memset(t0_data, 0x57, sizeof(t0_data));
+    memset(t1_data, 0x58, sizeof(t1_data));
+
+    rho = create_attribute(CKA_IBM_DILITHIUM_RHO, rho_data, sizeof(rho_data));
+    seed = create_attribute(CKA_IBM_DILITHIUM_SEED, seed_data, sizeof(seed_data));
+    tr = create_attribute(CKA_IBM_DILITHIUM_TR, tr_data, sizeof(tr_data));
+    s1 = create_attribute(CKA_IBM_DILITHIUM_S1, s1_data, sizeof(s1_data));
+    s2 = create_attribute(CKA_IBM_DILITHIUM_S2, s2_data, sizeof(s2_data));
+    t0 = create_attribute(CKA_IBM_DILITHIUM_T0, t0_data, sizeof(t0_data));
+    t1 = create_attribute(CKA_IBM_DILITHIUM_T1, t1_data, sizeof(t1_data));
+
+    if (!rho || !seed || !tr || !s1 || !s2 || !t0 || !t1) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_dilithium_private_key_basic: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    extern const CK_BYTE ber_idDilithium_r2_65[];
+    extern const CK_ULONG ber_idDilithium_r2_65Len;
+
+    rv = ber_encode_IBM_ML_DSA_PrivateKey(CKM_IBM_DILITHIUM, FALSE, &encoded, &encoded_len,
+                                            ber_idDilithium_r2_65, ber_idDilithium_r2_65Len,
+                                            rho, seed, tr, s1, s2, t0, t1, NULL);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_dilithium_private_key_basic: encoding failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = ber_decode_IBM_ML_DSA_PrivateKey(CKM_IBM_DILITHIUM, encoded, encoded_len,
+                                            &dec_rho, &dec_seed, &dec_tr,
+                                            &dec_s1, &dec_s2, &dec_t0, &dec_t1,
+                                            &dec_priv_seed, &dec_value, &oid);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_dilithium_private_key_basic: ber_decode_IBM_DilithiumPrivateKey failed with rv=0x%lx\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (!dec_rho || !dec_seed || !dec_tr || !dec_s1 || !dec_s2 || !dec_t0 || !dec_t1) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_dilithium_private_key_basic: decoded attributes are NULL\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    if (dec_rho->ulValueLen != sizeof(rho_data) ||
+        memcmp(dec_rho->pValue, rho_data, sizeof(rho_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_dilithium_private_key_basic: rho mismatch\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_decode_ibm_dilithium_private_key_basic\n");
+
+cleanup:
+    if (rho) free(rho);
+    if (seed) free(seed);
+    if (tr) free(tr);
+    if (s1) free(s1);
+    if (s2) free(s2);
+    if (t0) free(t0);
+    if (t1) free(t1);
+    if (dec_rho) free(dec_rho);
+    if (dec_seed) free(dec_seed);
+    if (dec_tr) free(dec_tr);
+    if (dec_s1) free(dec_s1);
+    if (dec_s2) free(dec_s2);
+    if (dec_t0) free(dec_t0);
+    if (dec_t1) free(dec_t1);
+    if (dec_value) free(dec_value);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test Dilithium private key encode/decode roundtrip */
+int test_roundtrip_ibm_dilithium_private_key(void)
+{
+    CK_BYTE rho_data[32] = {0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7, 0xD8,
+                            0xD9, 0xDA, 0xDB, 0xDC, 0xDD, 0xDE, 0xDF, 0xE0,
+                            0xE1, 0xE2, 0xE3, 0xE4, 0xE5, 0xE6, 0xE7, 0xE8,
+                            0xE9, 0xEA, 0xEB, 0xEC, 0xED, 0xEE, 0xEF, 0xF0};
+    CK_BYTE seed_data[32], tr_data[48], s1_data[480], s2_data[576], t0_data[2688], t1_data[1728];
+    CK_ATTRIBUTE *orig_rho = NULL, *orig_seed = NULL, *orig_tr = NULL;
+    CK_ATTRIBUTE *orig_s1 = NULL, *orig_s2 = NULL, *orig_t0 = NULL, *orig_t1 = NULL;
+    CK_ATTRIBUTE *dec_rho = NULL, *dec_seed = NULL, *dec_tr = NULL;
+    CK_ATTRIBUTE *dec_s1 = NULL, *dec_s2 = NULL, *dec_t0 = NULL, *dec_t1 = NULL, *dec_value = NULL;
+    CK_ATTRIBUTE *dec_priv_seed = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    const struct pqc_oid *oid = NULL;
+    CK_RV rv;
+    int result = 0;
+
+    memset(seed_data, 0x53, sizeof(seed_data));
+    memset(tr_data, 0x54, sizeof(tr_data));
+    memset(s1_data, 0x55, sizeof(s1_data));
+    memset(s2_data, 0x56, sizeof(s2_data));
+    memset(t0_data, 0x57, sizeof(t0_data));
+    memset(t1_data, 0x58, sizeof(t1_data));
+
+    orig_rho = create_attribute(CKA_IBM_DILITHIUM_RHO, rho_data, sizeof(rho_data));
+    orig_seed = create_attribute(CKA_IBM_DILITHIUM_SEED, seed_data, sizeof(seed_data));
+    orig_tr = create_attribute(CKA_IBM_DILITHIUM_TR, tr_data, sizeof(tr_data));
+    orig_s1 = create_attribute(CKA_IBM_DILITHIUM_S1, s1_data, sizeof(s1_data));
+    orig_s2 = create_attribute(CKA_IBM_DILITHIUM_S2, s2_data, sizeof(s2_data));
+    orig_t0 = create_attribute(CKA_IBM_DILITHIUM_T0, t0_data, sizeof(t0_data));
+    orig_t1 = create_attribute(CKA_IBM_DILITHIUM_T1, t1_data, sizeof(t1_data));
+
+    if (!orig_rho || !orig_seed || !orig_tr || !orig_s1 || !orig_s2 || !orig_t0 || !orig_t1) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_dilithium_private_key: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    extern const CK_BYTE ber_idDilithium_r2_65[];
+    extern const CK_ULONG ber_idDilithium_r2_65Len;
+
+    rv = ber_encode_IBM_ML_DSA_PrivateKey(CKM_IBM_DILITHIUM, FALSE, &encoded, &encoded_len,
+                                            ber_idDilithium_r2_65, ber_idDilithium_r2_65Len,
+                                            orig_rho, orig_seed, orig_tr,
+                                            orig_s1, orig_s2, orig_t0, orig_t1, NULL);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_dilithium_private_key: encoding failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = ber_decode_IBM_ML_DSA_PrivateKey(CKM_IBM_DILITHIUM, encoded, encoded_len,
+                                            &dec_rho, &dec_seed, &dec_tr,
+                                            &dec_s1, &dec_s2, &dec_t0, &dec_t1,
+                                            &dec_priv_seed, &dec_value, &oid);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_dilithium_private_key: decoding failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    if (dec_rho->ulValueLen != orig_rho->ulValueLen ||
+        memcmp(dec_rho->pValue, orig_rho->pValue, orig_rho->ulValueLen) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_dilithium_private_key: rho roundtrip failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    if (dec_s1->ulValueLen != orig_s1->ulValueLen ||
+        memcmp(dec_s1->pValue, orig_s1->pValue, orig_s1->ulValueLen) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_dilithium_private_key: s1 roundtrip failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_roundtrip_ibm_dilithium_private_key\n");
+
+cleanup:
+    if (orig_rho) free(orig_rho);
+    if (orig_seed) free(orig_seed);
+    if (orig_tr) free(orig_tr);
+    if (orig_s1) free(orig_s1);
+    if (orig_s2) free(orig_s2);
+    if (orig_t0) free(orig_t0);
+    if (orig_t1) free(orig_t1);
+    if (dec_rho) free(dec_rho);
+    if (dec_seed) free(dec_seed);
+    if (dec_tr) free(dec_tr);
+    if (dec_s1) free(dec_s1);
+    if (dec_s2) free(dec_s2);
+    if (dec_t0) free(dec_t0);
+    if (dec_t1) free(dec_t1);
+    if (dec_value) free(dec_value);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test Dilithium private key with NULL optional attributes */
+int test_ibm_dilithium_private_key_null_optional(void)
+{
+    CK_BYTE rho_data[32] = {0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7, 0xD8,
+                            0xD9, 0xDA, 0xDB, 0xDC, 0xDD, 0xDE, 0xDF, 0xE0,
+                            0xE1, 0xE2, 0xE3, 0xE4, 0xE5, 0xE6, 0xE7, 0xE8,
+                            0xE9, 0xEA, 0xEB, 0xEC, 0xED, 0xEE, 0xEF, 0xF0};
+    CK_BYTE seed_data[32], tr_data[48], s1_data[480], s2_data[576], t0_data[2688];
+    CK_ATTRIBUTE *rho = NULL, *seed = NULL, *tr = NULL, *s1 = NULL, *s2 = NULL, *t0 = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    memset(seed_data, 0x53, sizeof(seed_data));
+    memset(tr_data, 0x54, sizeof(tr_data));
+    memset(s1_data, 0x55, sizeof(s1_data));
+    memset(s2_data, 0x56, sizeof(s2_data));
+    memset(t0_data, 0x57, sizeof(t0_data));
+
+    rho = create_attribute(CKA_IBM_DILITHIUM_RHO, rho_data, sizeof(rho_data));
+    seed = create_attribute(CKA_IBM_DILITHIUM_SEED, seed_data, sizeof(seed_data));
+    tr = create_attribute(CKA_IBM_DILITHIUM_TR, tr_data, sizeof(tr_data));
+    s1 = create_attribute(CKA_IBM_DILITHIUM_S1, s1_data, sizeof(s1_data));
+    s2 = create_attribute(CKA_IBM_DILITHIUM_S2, s2_data, sizeof(s2_data));
+    t0 = create_attribute(CKA_IBM_DILITHIUM_T0, t0_data, sizeof(t0_data));
+
+    if (!rho || !seed || !tr || !s1 || !s2 || !t0) {
+        fprintf(stderr, "[FAIL] test_ibm_dilithium_private_key_null_optional: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    extern const CK_BYTE ber_idDilithium_r2_65[];
+    extern const CK_ULONG ber_idDilithium_r2_65Len;
+
+    /* Test with NULL t1 (optional) */
+    rv = ber_encode_IBM_ML_DSA_PrivateKey(CKM_IBM_DILITHIUM, FALSE, &encoded, &encoded_len,
+                                            ber_idDilithium_r2_65, ber_idDilithium_r2_65Len,
+                                            rho, seed, tr, s1, s2, t0, NULL, NULL);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_ibm_dilithium_private_key_null_optional: encoding with NULL t1 failed with rv=0x%lx\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (!encoded || encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_ibm_dilithium_private_key_null_optional: encoding produced no data\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_ibm_dilithium_private_key_null_optional\n");
+
+cleanup:
+    if (rho) free(rho);
+    if (seed) free(seed);
+    if (tr) free(tr);
+    if (s1) free(s1);
+    if (s2) free(s2);
+    if (t0) free(t0);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* ============================================================================
+ * IBM Kyber Public Key Tests
+ * ============================================================================ */
+
+/* Test ber_encode_IBM_KyberPublicKey with basic Kyber R2-1024 key components */
+int test_encode_ibm_kyber_public_key_basic(void)
+{
+    /* Kyber R2-1024 public key for testing */
+    CK_BYTE pk_data[1568];  /* Kyber R2-1024 pk size */
+    CK_ATTRIBUTE *pk = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* Initialize pk with test data */
+    memset(pk_data, 0x4B, sizeof(pk_data));
+
+    /* Create attribute */
+    pk = create_attribute(CKA_IBM_KYBER_PK, pk_data, sizeof(pk_data));
+
+    if (!pk) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_kyber_public_key_basic: failed to create attribute\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Use external OID constant */
+    extern const CK_BYTE ber_idKyber_r2_1024[];
+    extern const CK_ULONG ber_idKyber_r2_1024Len;
+
+    rv = ber_encode_IBM_ML_KEM_PublicKey(CKM_IBM_KYBER, FALSE, &encoded, &encoded_len,
+                                       ber_idKyber_r2_1024, ber_idKyber_r2_1024Len,
+                                       pk);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_kyber_public_key_basic: ber_encode_IBM_KyberPublicKey failed with rv=0x%lx\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (!encoded || encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_kyber_public_key_basic: encoding produced no data\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_encode_ibm_kyber_public_key_basic\n");
+
+cleanup:
+    if (pk) free(pk);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ber_decode_IBM_KyberPublicKey with encoded data */
+int test_decode_ibm_kyber_public_key_basic(void)
+{
+    CK_BYTE pk_data[1568];
+    CK_ATTRIBUTE *pk = NULL;
+    CK_ATTRIBUTE *dec_pk = NULL, *dec_value = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    const struct pqc_oid *oid = NULL;
+    CK_RV rv;
+    int result = 0;
+
+    memset(pk_data, 0x4B, sizeof(pk_data));
+
+    pk = create_attribute(CKA_IBM_KYBER_PK, pk_data, sizeof(pk_data));
+
+    if (!pk) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_kyber_public_key_basic: failed to create attribute\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    extern const CK_BYTE ber_idKyber_r2_1024[];
+    extern const CK_ULONG ber_idKyber_r2_1024Len;
+
+    rv = ber_encode_IBM_ML_KEM_PublicKey(CKM_IBM_KYBER, FALSE, &encoded, &encoded_len,
+                                       ber_idKyber_r2_1024, ber_idKyber_r2_1024Len,
+                                       pk);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_kyber_public_key_basic: encoding failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = ber_decode_IBM_ML_KEM_PublicKey(CKM_IBM_KYBER, encoded, encoded_len,
+                                       &dec_pk, &dec_value, &oid);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_kyber_public_key_basic: ber_decode_IBM_KyberPublicKey failed with rv=0x%lx\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (!dec_pk) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_kyber_public_key_basic: decoded attribute is NULL\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    if (dec_pk->ulValueLen != sizeof(pk_data) ||
+        memcmp(dec_pk->pValue, pk_data, sizeof(pk_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_kyber_public_key_basic: pk mismatch\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_decode_ibm_kyber_public_key_basic\n");
+
+cleanup:
+    if (pk) free(pk);
+    if (dec_pk) free(dec_pk);
+    if (dec_value) free(dec_value);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test Kyber public key encode/decode roundtrip */
+int test_roundtrip_ibm_kyber_public_key(void)
+{
+    CK_BYTE pk_data[1568];
+    CK_ATTRIBUTE *orig_pk = NULL;
+    CK_ATTRIBUTE *dec_pk = NULL, *dec_value = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    const struct pqc_oid *oid = NULL;
+    CK_RV rv;
+    int result = 0;
+
+    memset(pk_data, 0x4B, sizeof(pk_data));
+
+    orig_pk = create_attribute(CKA_IBM_KYBER_PK, pk_data, sizeof(pk_data));
+
+    if (!orig_pk) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_kyber_public_key: failed to create attribute\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    extern const CK_BYTE ber_idKyber_r2_1024[];
+    extern const CK_ULONG ber_idKyber_r2_1024Len;
+
+    rv = ber_encode_IBM_ML_KEM_PublicKey(CKM_IBM_KYBER, FALSE, &encoded, &encoded_len,
+                                       ber_idKyber_r2_1024, ber_idKyber_r2_1024Len,
+                                       orig_pk);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_kyber_public_key: encoding failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = ber_decode_IBM_ML_KEM_PublicKey(CKM_IBM_KYBER, encoded, encoded_len,
+                                       &dec_pk, &dec_value, &oid);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_kyber_public_key: decoding failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    if (dec_pk->ulValueLen != orig_pk->ulValueLen ||
+        memcmp(dec_pk->pValue, orig_pk->pValue, orig_pk->ulValueLen) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_kyber_public_key: pk roundtrip failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_roundtrip_ibm_kyber_public_key\n");
+
+cleanup:
+    if (orig_pk) free(orig_pk);
+    if (dec_pk) free(dec_pk);
+    if (dec_value) free(dec_value);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* ============================================================================
+ * IBM Kyber Private Key Tests
+ * ============================================================================ */
+
+/* Test ber_encode_IBM_KyberPrivateKey with basic Kyber R2-1024 key components */
+int test_encode_ibm_kyber_private_key_basic(void)
+{
+    /* Kyber R2-1024 private key components for testing */
+    CK_BYTE sk_data[3168];  /* Kyber R2-1024 sk size */
+    CK_BYTE pk_data[1568];  /* Kyber R2-1024 pk size */
+    CK_ATTRIBUTE *sk = NULL, *pk = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* Initialize test data */
+    memset(sk_data, 0x4C, sizeof(sk_data));
+    memset(pk_data, 0x4D, sizeof(pk_data));
+
+    /* Create attributes */
+    sk = create_attribute(CKA_IBM_KYBER_SK, sk_data, sizeof(sk_data));
+    pk = create_attribute(CKA_IBM_KYBER_PK, pk_data, sizeof(pk_data));
+
+    if (!sk || !pk) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_kyber_private_key_basic: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    extern const CK_BYTE ber_idKyber_r2_1024[];
+    extern const CK_ULONG ber_idKyber_r2_1024Len;
+
+    rv = ber_encode_IBM_ML_KEM_PrivateKey(CKM_IBM_KYBER, FALSE, &encoded, &encoded_len,
+                                        ber_idKyber_r2_1024, ber_idKyber_r2_1024Len,
+                                        sk, pk, NULL);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_kyber_private_key_basic: ber_encode_IBM_KyberPrivateKey failed with rv=0x%lx\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (!encoded || encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_ibm_kyber_private_key_basic: encoding produced no data\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_encode_ibm_kyber_private_key_basic\n");
+
+cleanup:
+    if (sk) free(sk);
+    if (pk) free(pk);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ber_decode_IBM_KyberPrivateKey with encoded data */
+int test_decode_ibm_kyber_private_key_basic(void)
+{
+    CK_BYTE sk_data[3168];
+    CK_BYTE pk_data[1568];
+    CK_ATTRIBUTE *sk = NULL, *pk = NULL;
+    CK_ATTRIBUTE *dec_sk = NULL, *dec_pk = NULL, *dec_value = NULL;
+    CK_ATTRIBUTE *dec_priv_seed = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    const struct pqc_oid *oid = NULL;
+    CK_RV rv;
+    int result = 0;
+
+    memset(sk_data, 0x4C, sizeof(sk_data));
+    memset(pk_data, 0x4D, sizeof(pk_data));
+
+    sk = create_attribute(CKA_IBM_KYBER_SK, sk_data, sizeof(sk_data));
+    pk = create_attribute(CKA_IBM_KYBER_PK, pk_data, sizeof(pk_data));
+
+    if (!sk || !pk) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_kyber_private_key_basic: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    extern const CK_BYTE ber_idKyber_r2_1024[];
+    extern const CK_ULONG ber_idKyber_r2_1024Len;
+
+    rv = ber_encode_IBM_ML_KEM_PrivateKey(CKM_IBM_KYBER, FALSE, &encoded, &encoded_len,
+                                        ber_idKyber_r2_1024, ber_idKyber_r2_1024Len,
+                                        sk, pk, NULL);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_kyber_private_key_basic: encoding failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = ber_decode_IBM_ML_KEM_PrivateKey(CKM_IBM_KYBER, encoded, encoded_len,
+                                        &dec_sk, &dec_pk, &dec_priv_seed, &dec_value, &oid);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_kyber_private_key_basic: ber_decode_IBM_KyberPrivateKey failed with rv=0x%lx\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (!dec_sk || !dec_pk) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_kyber_private_key_basic: decoded attributes are NULL\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    if (dec_sk->ulValueLen != sizeof(sk_data) ||
+        memcmp(dec_sk->pValue, sk_data, sizeof(sk_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_kyber_private_key_basic: sk mismatch\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    if (dec_pk->ulValueLen != sizeof(pk_data) ||
+        memcmp(dec_pk->pValue, pk_data, sizeof(pk_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_ibm_kyber_private_key_basic: pk mismatch\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_decode_ibm_kyber_private_key_basic\n");
+
+cleanup:
+    if (sk) free(sk);
+    if (pk) free(pk);
+    if (dec_sk) free(dec_sk);
+    if (dec_pk) free(dec_pk);
+    if (dec_value) free(dec_value);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test Kyber private key encode/decode roundtrip */
+int test_roundtrip_ibm_kyber_private_key(void)
+{
+    CK_BYTE sk_data[3168];
+    CK_BYTE pk_data[1568];
+    CK_ATTRIBUTE *orig_sk = NULL, *orig_pk = NULL;
+    CK_ATTRIBUTE *dec_sk = NULL, *dec_pk = NULL, *dec_value = NULL;
+    CK_ATTRIBUTE *dec_priv_seed = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    const struct pqc_oid *oid = NULL;
+    CK_RV rv;
+    int result = 0;
+
+    memset(sk_data, 0x4C, sizeof(sk_data));
+    memset(pk_data, 0x4D, sizeof(pk_data));
+
+    orig_sk = create_attribute(CKA_IBM_KYBER_SK, sk_data, sizeof(sk_data));
+    orig_pk = create_attribute(CKA_IBM_KYBER_PK, pk_data, sizeof(pk_data));
+
+    if (!orig_sk || !orig_pk) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_kyber_private_key: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    extern const CK_BYTE ber_idKyber_r2_1024[];
+    extern const CK_ULONG ber_idKyber_r2_1024Len;
+
+    rv = ber_encode_IBM_ML_KEM_PrivateKey(CKM_IBM_KYBER, FALSE, &encoded, &encoded_len,
+                                        ber_idKyber_r2_1024, ber_idKyber_r2_1024Len,
+                                        orig_sk, orig_pk, NULL);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_kyber_private_key: encoding failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    rv = ber_decode_IBM_ML_KEM_PrivateKey(CKM_IBM_KYBER, encoded, encoded_len,
+                                        &dec_sk, &dec_pk, &dec_priv_seed, &dec_value, &oid);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_kyber_private_key: decoding failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    if (dec_sk->ulValueLen != orig_sk->ulValueLen ||
+        memcmp(dec_sk->pValue, orig_sk->pValue, orig_sk->ulValueLen) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_kyber_private_key: sk roundtrip failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    if (dec_pk->ulValueLen != orig_pk->ulValueLen ||
+        memcmp(dec_pk->pValue, orig_pk->pValue, orig_pk->ulValueLen) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ibm_kyber_private_key: pk roundtrip failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_roundtrip_ibm_kyber_private_key\n");
+
+cleanup:
+    if (orig_sk) free(orig_sk);
+    if (orig_pk) free(orig_pk);
+    if (dec_sk) free(dec_sk);
+    if (dec_pk) free(dec_pk);
+    if (dec_value) free(dec_value);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test Kyber private key with NULL optional attributes */
+int test_ibm_kyber_private_key_null_optional(void)
+{
+    CK_BYTE sk_data[3168];
+    CK_ATTRIBUTE *sk = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    memset(sk_data, 0x4C, sizeof(sk_data));
+
+    sk = create_attribute(CKA_IBM_KYBER_SK, sk_data, sizeof(sk_data));
+
+    if (!sk) {
+        fprintf(stderr, "[FAIL] test_ibm_kyber_private_key_null_optional: failed to create attribute\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    extern const CK_BYTE ber_idKyber_r2_1024[];
+    extern const CK_ULONG ber_idKyber_r2_1024Len;
+
+    /* Test with NULL pk (optional) */
+    rv = ber_encode_IBM_ML_KEM_PrivateKey(CKM_IBM_KYBER, FALSE, &encoded, &encoded_len,
+                                        ber_idKyber_r2_1024, ber_idKyber_r2_1024Len,
+                                        sk, NULL, NULL);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_ibm_kyber_private_key_null_optional: encoding with NULL pk failed with rv=0x%lx\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (!encoded || encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_ibm_kyber_private_key_null_optional: encoding produced no data\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_ibm_kyber_private_key_null_optional\n");
+
+cleanup:
+    if (sk) free(sk);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* ============================================================================
+ * ML-DSA (NIST standardized) Tests
+ * ============================================================================ */
+
+/* Test ber_encode_ML_DSA_PublicKey with basic ML-DSA-65 key */
+int test_encode_ml_dsa_public_key_basic(void)
+{
+    /* ML-DSA-65 public key value for testing (1952 bytes) */
+    CK_BYTE value_data[1952];
+    CK_ATTRIBUTE *value = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* Initialize value with test data */
+    memset(value_data, 0xA5, sizeof(value_data));
+
+    /* Create attribute */
+    value = create_attribute(CKA_VALUE, value_data, sizeof(value_data));
+
+    if (!value) {
+        fprintf(stderr, "[FAIL] test_encode_ml_dsa_public_key_basic: failed to create attribute\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Encode with ML-DSA-65 OID */
+    rv = ber_encode_ML_DSA_PublicKey(FALSE, &encoded, &encoded_len,
+                                      ber_idML_DSA_65, ber_idML_DSA_65Len,
+                                      value);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_ml_dsa_public_key_basic: encoding failed with rv=0x%lx\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (!encoded || encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_ml_dsa_public_key_basic: encoding produced no data\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_encode_ml_dsa_public_key_basic\n");
+
+cleanup:
+    if (value) free(value);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ber_decode_ML_DSA_PublicKey with valid encoded data */
+int test_decode_ml_dsa_public_key_valid(void)
+{
+    CK_BYTE value_data[1952];
+    CK_ATTRIBUTE *orig_value = NULL;
+    CK_ATTRIBUTE *dec_value = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    const struct pqc_oid *oid = NULL;
+    CK_RV rv;
+    int result = 0;
+
+    memset(value_data, 0xB6, sizeof(value_data));
+
+    orig_value = create_attribute(CKA_VALUE, value_data, sizeof(value_data));
+
+    if (!orig_value) {
+        fprintf(stderr, "[FAIL] test_decode_ml_dsa_public_key_valid: failed to create attribute\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* First encode */
+    rv = ber_encode_ML_DSA_PublicKey(FALSE, &encoded, &encoded_len,
+                                      ber_idML_DSA_65, ber_idML_DSA_65Len,
+                                      orig_value);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ml_dsa_public_key_valid: encoding failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Now decode */
+    rv = ber_decode_ML_DSA_PublicKey(encoded, encoded_len, &dec_value, &oid);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ml_dsa_public_key_valid: decoding failed with rv=0x%lx\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (!dec_value || !oid) {
+        fprintf(stderr, "[FAIL] test_decode_ml_dsa_public_key_valid: decode produced NULL output\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify decoded value matches original */
+    if (dec_value->ulValueLen != sizeof(value_data) ||
+        memcmp(dec_value->pValue, value_data, sizeof(value_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_ml_dsa_public_key_valid: value mismatch\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_decode_ml_dsa_public_key_valid\n");
+
+cleanup:
+    if (orig_value) free(orig_value);
+    if (dec_value) free(dec_value);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ML-DSA public key encode/decode roundtrip */
+int test_roundtrip_ml_dsa_public_key(void)
+{
+    CK_BYTE value_data[1952];
+    CK_ATTRIBUTE *orig_value = NULL;
+    CK_ATTRIBUTE *dec_value = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    const struct pqc_oid *oid = NULL;
+    CK_RV rv;
+    int result = 0;
+
+    memset(value_data, 0xC7, sizeof(value_data));
+
+    orig_value = create_attribute(CKA_VALUE, value_data, sizeof(value_data));
+
+    if (!orig_value) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_dsa_public_key: failed to create attribute\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Encode */
+    rv = ber_encode_ML_DSA_PublicKey(FALSE, &encoded, &encoded_len,
+                                      ber_idML_DSA_65, ber_idML_DSA_65Len,
+                                      orig_value);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_dsa_public_key: encode failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Decode */
+    rv = ber_decode_ML_DSA_PublicKey(encoded, encoded_len, &dec_value, &oid);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_dsa_public_key: decode failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify roundtrip */
+    if (dec_value->ulValueLen != sizeof(value_data) ||
+        memcmp(dec_value->pValue, value_data, sizeof(value_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_dsa_public_key: value mismatch\n");
+        result = 1;
+    }
+
+    if (result == 0)
+        printf("[PASS] test_roundtrip_ml_dsa_public_key\n");
+
+cleanup:
+    if (orig_value) free(orig_value);
+    if (dec_value) free(dec_value);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ber_encode_ML_DSA_PrivateKey with basic ML-DSA-65 key */
+int test_encode_ml_dsa_private_key_basic(void)
+{
+    /* ML-DSA-65 private key value for testing (4032 bytes) */
+    CK_BYTE value_data[4032];
+    CK_ATTRIBUTE *value = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* Initialize value with test data */
+    memset(value_data, 0xD8, sizeof(value_data));
+
+    /* Create attribute */
+    value = create_attribute(CKA_VALUE, value_data, sizeof(value_data));
+
+    if (!value) {
+        fprintf(stderr, "[FAIL] test_encode_ml_dsa_private_key_basic: failed to create attribute\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Encode with ML-DSA-65 OID */
+    rv = ber_encode_ML_DSA_PrivateKey(FALSE, &encoded, &encoded_len,
+                                       ber_idML_DSA_65, ber_idML_DSA_65Len,
+                                       value, NULL);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_ml_dsa_private_key_basic: encoding failed with rv=0x%lx\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (!encoded || encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_ml_dsa_private_key_basic: encoding produced no data\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_encode_ml_dsa_private_key_basic\n");
+
+cleanup:
+    if (value) free(value);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ber_encode_ML_DSA_PrivateKey with length_only mode */
+int test_encode_ml_dsa_private_key_length_only(void)
+{
+    CK_BYTE value_data[4032];
+    CK_ATTRIBUTE *value = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    memset(value_data, 0xE9, sizeof(value_data));
+
+    value = create_attribute(CKA_VALUE, value_data, sizeof(value_data));
+
+    if (!value) {
+        fprintf(stderr, "[FAIL] test_encode_ml_dsa_private_key_length_only: failed to create attribute\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Encode with length_only = TRUE */
+    rv = ber_encode_ML_DSA_PrivateKey(TRUE, &encoded, &encoded_len,
+                                       ber_idML_DSA_65, ber_idML_DSA_65Len,
+                                       value, NULL);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_ml_dsa_private_key_length_only: encoding failed with rv=0x%lx\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (encoded != NULL) {
+        fprintf(stderr, "[FAIL] test_encode_ml_dsa_private_key_length_only: encoded should be NULL in length_only mode\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    if (encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_ml_dsa_private_key_length_only: encoded_len should be non-zero\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_encode_ml_dsa_private_key_length_only\n");
+
+cleanup:
+    if (value) free(value);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ber_decode_ML_DSA_PrivateKey with valid encoded data */
+int test_decode_ml_dsa_private_key_valid(void)
+{
+    CK_BYTE value_data[4032];
+    CK_ATTRIBUTE *orig_value = NULL;
+    CK_ATTRIBUTE *dec_value = NULL;
+    CK_ATTRIBUTE *dec_seed = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    const struct pqc_oid *oid = NULL;
+    CK_RV rv;
+    int result = 0;
+
+    memset(value_data, 0xFA, sizeof(value_data));
+
+    orig_value = create_attribute(CKA_VALUE, value_data, sizeof(value_data));
+
+    if (!orig_value) {
+        fprintf(stderr, "[FAIL] test_decode_ml_dsa_private_key_valid: failed to create attribute\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* First encode */
+    rv = ber_encode_ML_DSA_PrivateKey(FALSE, &encoded, &encoded_len,
+                                       ber_idML_DSA_65, ber_idML_DSA_65Len,
+                                       orig_value, NULL);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ml_dsa_private_key_valid: encoding failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Now decode */
+    rv = ber_decode_ML_DSA_PrivateKey(encoded, encoded_len, &dec_value, &dec_seed, &oid);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ml_dsa_private_key_valid: decoding failed with rv=0x%lx\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (!dec_value || !oid) {
+        fprintf(stderr, "[FAIL] test_decode_ml_dsa_private_key_valid: decode produced NULL output\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify decoded value matches original */
+    if (dec_value->ulValueLen != sizeof(value_data) ||
+        memcmp(dec_value->pValue, value_data, sizeof(value_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_ml_dsa_private_key_valid: value mismatch\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_decode_ml_dsa_private_key_valid\n");
+
+cleanup:
+    if (orig_value) free(orig_value);
+    if (dec_value) free(dec_value);
+    if (dec_seed) free(dec_seed);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ML-DSA private key encode/decode roundtrip */
+int test_roundtrip_ml_dsa_private_key(void)
+{
+    CK_BYTE value_data[4032];
+    CK_ATTRIBUTE *orig_value = NULL;
+    CK_ATTRIBUTE *dec_value = NULL;
+    CK_ATTRIBUTE *dec_seed = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    const struct pqc_oid *oid = NULL;
+    CK_RV rv;
+    int result = 0;
+
+    memset(value_data, 0x0B, sizeof(value_data));
+
+    orig_value = create_attribute(CKA_VALUE, value_data, sizeof(value_data));
+
+    if (!orig_value) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_dsa_private_key: failed to create attribute\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Encode */
+    rv = ber_encode_ML_DSA_PrivateKey(FALSE, &encoded, &encoded_len,
+                                       ber_idML_DSA_65, ber_idML_DSA_65Len,
+                                       orig_value, NULL);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_dsa_private_key: encode failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Decode */
+    rv = ber_decode_ML_DSA_PrivateKey(encoded, encoded_len, &dec_value, &dec_seed, &oid);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_dsa_private_key: decode failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify roundtrip */
+    if (dec_value->ulValueLen != sizeof(value_data) ||
+        memcmp(dec_value->pValue, value_data, sizeof(value_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_dsa_private_key: value mismatch\n");
+        result = 1;
+    }
+
+    if (result == 0)
+        printf("[PASS] test_roundtrip_ml_dsa_private_key\n");
+
+cleanup:
+    if (orig_value) free(orig_value);
+    if (dec_value) free(dec_value);
+    if (dec_seed) free(dec_seed);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ber_encode_ML_DSA_PrivateKey with seed value */
+int test_encode_ml_dsa_private_key_with_seed(void)
+{
+    /* ML-DSA-65 private key value for testing (4032 bytes) */
+    CK_BYTE value_data[4032];
+    CK_BYTE seed_data[32];  /* Seed is 32 bytes */
+    CK_ATTRIBUTE *value = NULL;
+    CK_ATTRIBUTE *seed = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* Initialize value and seed with test data */
+    memset(value_data, 0xD8, sizeof(value_data));
+    memset(seed_data, 0xAB, sizeof(seed_data));
+
+    /* Create attributes */
+    value = create_attribute(CKA_VALUE, value_data, sizeof(value_data));
+    seed = create_attribute(CKA_VALUE, seed_data, sizeof(seed_data));
+
+    if (!value || !seed) {
+        fprintf(stderr, "[FAIL] test_encode_ml_dsa_private_key_with_seed: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Encode with ML-DSA-65 OID and seed */
+    rv = ber_encode_ML_DSA_PrivateKey(FALSE, &encoded, &encoded_len,
+                                       ber_idML_DSA_65, ber_idML_DSA_65Len,
+                                       value, seed);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_ml_dsa_private_key_with_seed: encoding failed with rv=0x%lx\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (!encoded || encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_ml_dsa_private_key_with_seed: encoding produced no data\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_encode_ml_dsa_private_key_with_seed\n");
+
+cleanup:
+    if (value) free(value);
+    if (seed) free(seed);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ber_encode_ML_DSA_PrivateKey with seed in length_only mode */
+int test_encode_ml_dsa_private_key_with_seed_length_only(void)
+{
+    CK_BYTE value_data[4032];
+    CK_BYTE seed_data[32];
+    CK_ATTRIBUTE *value = NULL;
+    CK_ATTRIBUTE *seed = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    memset(value_data, 0xE9, sizeof(value_data));
+    memset(seed_data, 0xCD, sizeof(seed_data));
+
+    value = create_attribute(CKA_VALUE, value_data, sizeof(value_data));
+    seed = create_attribute(CKA_VALUE, seed_data, sizeof(seed_data));
+
+    if (!value || !seed) {
+        fprintf(stderr, "[FAIL] test_encode_ml_dsa_private_key_with_seed_length_only: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Encode with length_only = TRUE and seed */
+    rv = ber_encode_ML_DSA_PrivateKey(TRUE, &encoded, &encoded_len,
+                                       ber_idML_DSA_65, ber_idML_DSA_65Len,
+                                       value, seed);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_ml_dsa_private_key_with_seed_length_only: encoding failed with rv=0x%lx\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (encoded != NULL) {
+        fprintf(stderr, "[FAIL] test_encode_ml_dsa_private_key_with_seed_length_only: encoded should be NULL in length_only mode\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    if (encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_ml_dsa_private_key_with_seed_length_only: encoded_len should be non-zero\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_encode_ml_dsa_private_key_with_seed_length_only\n");
+
+cleanup:
+    if (value) free(value);
+    if (seed) free(seed);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ber_decode_ML_DSA_PrivateKey with seed in encoded data */
+int test_decode_ml_dsa_private_key_with_seed(void)
+{
+    CK_BYTE value_data[4032];
+    CK_BYTE seed_data[32];
+    CK_ATTRIBUTE *orig_value = NULL;
+    CK_ATTRIBUTE *orig_seed = NULL;
+    CK_ATTRIBUTE *dec_value = NULL;
+    CK_ATTRIBUTE *dec_seed = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    const struct pqc_oid *oid = NULL;
+    CK_RV rv;
+    int result = 0;
+
+    memset(value_data, 0xFA, sizeof(value_data));
+    memset(seed_data, 0xEF, sizeof(seed_data));
+
+    orig_value = create_attribute(CKA_VALUE, value_data, sizeof(value_data));
+    orig_seed = create_attribute(CKA_VALUE, seed_data, sizeof(seed_data));
+
+    if (!orig_value || !orig_seed) {
+        fprintf(stderr, "[FAIL] test_decode_ml_dsa_private_key_with_seed: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* First encode with seed */
+    rv = ber_encode_ML_DSA_PrivateKey(FALSE, &encoded, &encoded_len,
+                                       ber_idML_DSA_65, ber_idML_DSA_65Len,
+                                       orig_value, orig_seed);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ml_dsa_private_key_with_seed: encoding failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Now decode */
+    rv = ber_decode_ML_DSA_PrivateKey(encoded, encoded_len, &dec_value, &dec_seed, &oid);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ml_dsa_private_key_with_seed: decoding failed with rv=0x%lx\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (!dec_value || !dec_seed || !oid) {
+        fprintf(stderr, "[FAIL] test_decode_ml_dsa_private_key_with_seed: decode produced NULL output\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify decoded value matches original */
+    if (dec_value->ulValueLen != sizeof(value_data) ||
+        memcmp(dec_value->pValue, value_data, sizeof(value_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_ml_dsa_private_key_with_seed: value mismatch\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify decoded seed matches original */
+    if (dec_seed->ulValueLen != sizeof(seed_data) ||
+        memcmp(dec_seed->pValue, seed_data, sizeof(seed_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_ml_dsa_private_key_with_seed: seed mismatch\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_decode_ml_dsa_private_key_with_seed\n");
+
+cleanup:
+    if (orig_value) free(orig_value);
+    if (orig_seed) free(orig_seed);
+    if (dec_value) free(dec_value);
+    if (dec_seed) free(dec_seed);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ML-DSA private key with seed encode/decode roundtrip */
+int test_roundtrip_ml_dsa_private_key_with_seed(void)
+{
+    CK_BYTE value_data[4032];
+    CK_BYTE seed_data[32];
+    CK_ATTRIBUTE *orig_value = NULL;
+    CK_ATTRIBUTE *orig_seed = NULL;
+    CK_ATTRIBUTE *dec_value = NULL;
+    CK_ATTRIBUTE *dec_seed = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    const struct pqc_oid *oid = NULL;
+    CK_RV rv;
+    int result = 0;
+
+    memset(value_data, 0x0B, sizeof(value_data));
+    memset(seed_data, 0x12, sizeof(seed_data));
+
+    orig_value = create_attribute(CKA_VALUE, value_data, sizeof(value_data));
+    orig_seed = create_attribute(CKA_VALUE, seed_data, sizeof(seed_data));
+
+    if (!orig_value || !orig_seed) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_dsa_private_key_with_seed: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Encode with seed */
+    rv = ber_encode_ML_DSA_PrivateKey(FALSE, &encoded, &encoded_len,
+                                       ber_idML_DSA_65, ber_idML_DSA_65Len,
+                                       orig_value, orig_seed);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_dsa_private_key_with_seed: encode failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Decode */
+    rv = ber_decode_ML_DSA_PrivateKey(encoded, encoded_len, &dec_value, &dec_seed, &oid);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_dsa_private_key_with_seed: decode failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify roundtrip for value */
+    if (dec_value->ulValueLen != sizeof(value_data) ||
+        memcmp(dec_value->pValue, value_data, sizeof(value_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_dsa_private_key_with_seed: value mismatch\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify roundtrip for seed */
+    if (dec_seed->ulValueLen != sizeof(seed_data) ||
+        memcmp(dec_seed->pValue, seed_data, sizeof(seed_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_dsa_private_key_with_seed: seed mismatch\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    if (result == 0)
+        printf("[PASS] test_roundtrip_ml_dsa_private_key_with_seed\n");
+
+cleanup:
+    if (orig_value) free(orig_value);
+    if (orig_seed) free(orig_seed);
+    if (dec_value) free(dec_value);
+    if (dec_seed) free(dec_seed);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ber_encode_ML_DSA_PrivateKey with seed-only (no value) */
+int test_encode_ml_dsa_private_key_seed_only(void)
+{
+    /* ML-DSA-65 seed for testing (32 bytes) */
+    CK_BYTE seed_data[32];
+    CK_ATTRIBUTE *seed = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* Initialize seed with test data */
+    memset(seed_data, 0xAB, sizeof(seed_data));
+
+    /* Create seed attribute */
+    seed = create_attribute(CKA_VALUE, seed_data, sizeof(seed_data));
+
+    if (!seed) {
+        fprintf(stderr, "[FAIL] test_encode_ml_dsa_private_key_seed_only: failed to create seed attribute\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Encode with ML-DSA-65 OID, NULL value, and seed */
+    rv = ber_encode_ML_DSA_PrivateKey(FALSE, &encoded, &encoded_len,
+                                       ber_idML_DSA_65, ber_idML_DSA_65Len,
+                                       NULL, seed);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_ml_dsa_private_key_seed_only: encoding failed with rv=0x%lx\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (!encoded || encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_ml_dsa_private_key_seed_only: encoding produced no data\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_encode_ml_dsa_private_key_seed_only\n");
+
+cleanup:
+    if (seed) free(seed);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ber_encode_ML_DSA_PrivateKey with seed-only in length_only mode */
+int test_encode_ml_dsa_private_key_seed_only_length_only(void)
+{
+    CK_BYTE seed_data[32];
+    CK_ATTRIBUTE *seed = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    memset(seed_data, 0xCD, sizeof(seed_data));
+
+    seed = create_attribute(CKA_VALUE, seed_data, sizeof(seed_data));
+
+    if (!seed) {
+        fprintf(stderr, "[FAIL] test_encode_ml_dsa_private_key_seed_only_length_only: failed to create seed attribute\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Encode with length_only = TRUE, NULL value, and seed */
+    rv = ber_encode_ML_DSA_PrivateKey(TRUE, &encoded, &encoded_len,
+                                       ber_idML_DSA_65, ber_idML_DSA_65Len,
+                                       NULL, seed);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_ml_dsa_private_key_seed_only_length_only: encoding failed with rv=0x%lx\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (encoded != NULL) {
+        fprintf(stderr, "[FAIL] test_encode_ml_dsa_private_key_seed_only_length_only: encoded should be NULL in length_only mode\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    if (encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_ml_dsa_private_key_seed_only_length_only: encoded_len should be non-zero\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_encode_ml_dsa_private_key_seed_only_length_only\n");
+
+cleanup:
+    if (seed) free(seed);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ber_decode_ML_DSA_PrivateKey with seed-only in encoded data */
+int test_decode_ml_dsa_private_key_seed_only(void)
+{
+    CK_BYTE seed_data[32];
+    CK_ATTRIBUTE *orig_seed = NULL;
+    CK_ATTRIBUTE *dec_value = NULL;
+    CK_ATTRIBUTE *dec_seed = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    const struct pqc_oid *oid = NULL;
+    CK_RV rv;
+    int result = 0;
+
+    memset(seed_data, 0xEF, sizeof(seed_data));
+
+    orig_seed = create_attribute(CKA_VALUE, seed_data, sizeof(seed_data));
+
+    if (!orig_seed) {
+        fprintf(stderr, "[FAIL] test_decode_ml_dsa_private_key_seed_only: failed to create seed attribute\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* First encode with NULL value and seed */
+    rv = ber_encode_ML_DSA_PrivateKey(FALSE, &encoded, &encoded_len,
+                                       ber_idML_DSA_65, ber_idML_DSA_65Len,
+                                       NULL, orig_seed);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ml_dsa_private_key_seed_only: encoding failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Now decode */
+    rv = ber_decode_ML_DSA_PrivateKey(encoded, encoded_len, &dec_value, &dec_seed, &oid);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ml_dsa_private_key_seed_only: decoding failed with rv=0x%lx\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (!dec_seed || !oid) {
+        fprintf(stderr, "[FAIL] test_decode_ml_dsa_private_key_seed_only: decode produced NULL output\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify decoded seed matches original */
+    if (dec_seed->ulValueLen != sizeof(seed_data) ||
+        memcmp(dec_seed->pValue, seed_data, sizeof(seed_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_ml_dsa_private_key_seed_only: seed mismatch\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Value should be NULL for seed-only keys */
+    if (dec_value != NULL) {
+        fprintf(stderr, "[FAIL] test_decode_ml_dsa_private_key_seed_only: value should be NULL for seed-only key\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_decode_ml_dsa_private_key_seed_only\n");
+
+cleanup:
+    if (orig_seed) free(orig_seed);
+    if (dec_value) free(dec_value);
+    if (dec_seed) free(dec_seed);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ML-DSA private key seed-only encode/decode roundtrip */
+int test_roundtrip_ml_dsa_private_key_seed_only(void)
+{
+    CK_BYTE seed_data[32];
+    CK_ATTRIBUTE *orig_seed = NULL;
+    CK_ATTRIBUTE *dec_value = NULL;
+    CK_ATTRIBUTE *dec_seed = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    const struct pqc_oid *oid = NULL;
+    CK_RV rv;
+    int result = 0;
+
+    memset(seed_data, 0x12, sizeof(seed_data));
+
+    orig_seed = create_attribute(CKA_VALUE, seed_data, sizeof(seed_data));
+
+    if (!orig_seed) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_dsa_private_key_seed_only: failed to create seed attribute\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Encode with NULL value and seed */
+    rv = ber_encode_ML_DSA_PrivateKey(FALSE, &encoded, &encoded_len,
+                                       ber_idML_DSA_65, ber_idML_DSA_65Len,
+                                       NULL, orig_seed);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_dsa_private_key_seed_only: encode failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Decode */
+    rv = ber_decode_ML_DSA_PrivateKey(encoded, encoded_len, &dec_value, &dec_seed, &oid);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_dsa_private_key_seed_only: decode failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify value is NULL */
+    if (dec_value != NULL) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_dsa_private_key_seed_only: value should be NULL\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify roundtrip for seed */
+    if (dec_seed->ulValueLen != sizeof(seed_data) ||
+        memcmp(dec_seed->pValue, seed_data, sizeof(seed_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_dsa_private_key_seed_only: seed mismatch\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    if (result == 0)
+        printf("[PASS] test_roundtrip_ml_dsa_private_key_seed_only\n");
+
+cleanup:
+    if (orig_seed) free(orig_seed);
+    if (dec_value) free(dec_value);
+    if (dec_seed) free(dec_seed);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* ============================================================================
+ * ML-KEM (NIST standardized) Tests
+ * ============================================================================ */
+
+/* Test ber_encode_ML_KEM_PublicKey with basic ML-KEM-768 key */
+int test_encode_ml_kem_public_key_basic(void)
+{
+    /* ML-KEM-768 public key value for testing (1184 bytes) */
+    CK_BYTE value_data[1184];
+    CK_ATTRIBUTE *value = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* Initialize value with test data */
+    memset(value_data, 0x1C, sizeof(value_data));
+
+    /* Create attribute */
+    value = create_attribute(CKA_VALUE, value_data, sizeof(value_data));
+
+    if (!value) {
+        fprintf(stderr, "[FAIL] test_encode_ml_kem_public_key_basic: failed to create attribute\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Encode with ML-KEM-768 OID */
+    rv = ber_encode_ML_KEM_PublicKey(FALSE, &encoded, &encoded_len,
+                                      ber_idML_KEM_768, ber_idML_KEM_768Len,
+                                      value);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_ml_kem_public_key_basic: encoding failed with rv=0x%lx\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (!encoded || encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_ml_kem_public_key_basic: encoding produced no data\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_encode_ml_kem_public_key_basic\n");
+
+cleanup:
+    if (value) free(value);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ber_decode_ML_KEM_PublicKey with valid encoded data */
+int test_decode_ml_kem_public_key_valid(void)
+{
+    CK_BYTE value_data[1184];
+    CK_ATTRIBUTE *orig_value = NULL;
+    CK_ATTRIBUTE *dec_value = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    const struct pqc_oid *oid = NULL;
+    CK_RV rv;
+    int result = 0;
+
+    memset(value_data, 0x2D, sizeof(value_data));
+
+    orig_value = create_attribute(CKA_VALUE, value_data, sizeof(value_data));
+
+    if (!orig_value) {
+        fprintf(stderr, "[FAIL] test_decode_ml_kem_public_key_valid: failed to create attribute\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* First encode */
+    rv = ber_encode_ML_KEM_PublicKey(FALSE, &encoded, &encoded_len,
+                                      ber_idML_KEM_768, ber_idML_KEM_768Len,
+                                      orig_value);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ml_kem_public_key_valid: encoding failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Now decode */
+    rv = ber_decode_ML_KEM_PublicKey(encoded, encoded_len, &dec_value, &oid);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ml_kem_public_key_valid: decoding failed with rv=0x%lx\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (!dec_value || !oid) {
+        fprintf(stderr, "[FAIL] test_decode_ml_kem_public_key_valid: decode produced NULL output\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify decoded value matches original */
+    if (dec_value->ulValueLen != sizeof(value_data) ||
+        memcmp(dec_value->pValue, value_data, sizeof(value_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_ml_kem_public_key_valid: value mismatch\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_decode_ml_kem_public_key_valid\n");
+
+cleanup:
+    if (orig_value) free(orig_value);
+    if (dec_value) free(dec_value);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ML-KEM public key encode/decode roundtrip */
+int test_roundtrip_ml_kem_public_key(void)
+{
+    CK_BYTE value_data[1184];
+    CK_ATTRIBUTE *orig_value = NULL;
+    CK_ATTRIBUTE *dec_value = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    const struct pqc_oid *oid = NULL;
+    CK_RV rv;
+    int result = 0;
+
+    memset(value_data, 0x3E, sizeof(value_data));
+
+    orig_value = create_attribute(CKA_VALUE, value_data, sizeof(value_data));
+
+    if (!orig_value) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_kem_public_key: failed to create attribute\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Encode */
+    rv = ber_encode_ML_KEM_PublicKey(FALSE, &encoded, &encoded_len,
+                                      ber_idML_KEM_768, ber_idML_KEM_768Len,
+                                      orig_value);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_kem_public_key: encode failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Decode */
+    rv = ber_decode_ML_KEM_PublicKey(encoded, encoded_len, &dec_value, &oid);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_kem_public_key: decode failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify roundtrip */
+    if (dec_value->ulValueLen != sizeof(value_data) ||
+        memcmp(dec_value->pValue, value_data, sizeof(value_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_kem_public_key: value mismatch\n");
+        result = 1;
+    }
+
+    if (result == 0)
+        printf("[PASS] test_roundtrip_ml_kem_public_key\n");
+
+cleanup:
+    if (orig_value) free(orig_value);
+    if (dec_value) free(dec_value);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ber_encode_ML_KEM_PrivateKey with basic ML-KEM-768 key */
+int test_encode_ml_kem_private_key_basic(void)
+{
+    /* ML-KEM-768 private key value for testing (2400 bytes) */
+    CK_BYTE value_data[2400];
+    CK_ATTRIBUTE *value = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* Initialize value with test data */
+    memset(value_data, 0x4F, sizeof(value_data));
+
+    /* Create attribute */
+    value = create_attribute(CKA_VALUE, value_data, sizeof(value_data));
+
+    if (!value) {
+        fprintf(stderr, "[FAIL] test_encode_ml_kem_private_key_basic: failed to create attribute\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Encode with ML-KEM-768 OID */
+    rv = ber_encode_ML_KEM_PrivateKey(FALSE, &encoded, &encoded_len,
+                                       ber_idML_KEM_768, ber_idML_KEM_768Len,
+                                       value, NULL);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_ml_kem_private_key_basic: encoding failed with rv=0x%lx\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (!encoded || encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_ml_kem_private_key_basic: encoding produced no data\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_encode_ml_kem_private_key_basic\n");
+
+cleanup:
+    if (value) free(value);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ber_encode_ML_KEM_PrivateKey with length_only mode */
+int test_encode_ml_kem_private_key_length_only(void)
+{
+    CK_BYTE value_data[2400];
+    CK_ATTRIBUTE *value = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    memset(value_data, 0x50, sizeof(value_data));
+
+    value = create_attribute(CKA_VALUE, value_data, sizeof(value_data));
+
+    if (!value) {
+        fprintf(stderr, "[FAIL] test_encode_ml_kem_private_key_length_only: failed to create attribute\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Encode with length_only = TRUE */
+    rv = ber_encode_ML_KEM_PrivateKey(TRUE, &encoded, &encoded_len,
+                                       ber_idML_KEM_768, ber_idML_KEM_768Len,
+                                       value, NULL);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_ml_kem_private_key_length_only: encoding failed with rv=0x%lx\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (encoded != NULL) {
+        fprintf(stderr, "[FAIL] test_encode_ml_kem_private_key_length_only: encoded should be NULL in length_only mode\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    if (encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_ml_kem_private_key_length_only: encoded_len should be non-zero\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_encode_ml_kem_private_key_length_only\n");
+
+cleanup:
+    if (value) free(value);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ber_decode_ML_KEM_PrivateKey with valid encoded data */
+int test_decode_ml_kem_private_key_valid(void)
+{
+    CK_BYTE value_data[2400];
+    CK_ATTRIBUTE *orig_value = NULL;
+    CK_ATTRIBUTE *dec_value = NULL;
+    CK_ATTRIBUTE *dec_seed = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    const struct pqc_oid *oid = NULL;
+    CK_RV rv;
+    int result = 0;
+
+    memset(value_data, 0x61, sizeof(value_data));
+
+    orig_value = create_attribute(CKA_VALUE, value_data, sizeof(value_data));
+
+    if (!orig_value) {
+        fprintf(stderr, "[FAIL] test_decode_ml_kem_private_key_valid: failed to create attribute\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* First encode */
+    rv = ber_encode_ML_KEM_PrivateKey(FALSE, &encoded, &encoded_len,
+                                       ber_idML_KEM_768, ber_idML_KEM_768Len,
+                                       orig_value, NULL);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ml_kem_private_key_valid: encoding failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Now decode */
+    rv = ber_decode_ML_KEM_PrivateKey(encoded, encoded_len, &dec_value, &dec_seed, &oid);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ml_kem_private_key_valid: decoding failed with rv=0x%lx\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (!dec_value || !oid) {
+        fprintf(stderr, "[FAIL] test_decode_ml_kem_private_key_valid: decode produced NULL output\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify decoded value matches original */
+    if (dec_value->ulValueLen != sizeof(value_data) ||
+        memcmp(dec_value->pValue, value_data, sizeof(value_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_ml_kem_private_key_valid: value mismatch\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_decode_ml_kem_private_key_valid\n");
+
+cleanup:
+    if (orig_value) free(orig_value);
+    if (dec_value) free(dec_value);
+    if (dec_seed) free(dec_seed);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ML-KEM private key encode/decode roundtrip */
+int test_roundtrip_ml_kem_private_key(void)
+{
+    CK_BYTE value_data[2400];
+    CK_ATTRIBUTE *orig_value = NULL;
+    CK_ATTRIBUTE *dec_value = NULL;
+    CK_ATTRIBUTE *dec_seed = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    const struct pqc_oid *oid = NULL;
+    CK_RV rv;
+    int result = 0;
+
+    memset(value_data, 0x72, sizeof(value_data));
+
+    orig_value = create_attribute(CKA_VALUE, value_data, sizeof(value_data));
+
+    if (!orig_value) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_kem_private_key: failed to create attribute\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Encode */
+    rv = ber_encode_ML_KEM_PrivateKey(FALSE, &encoded, &encoded_len,
+                                       ber_idML_KEM_768, ber_idML_KEM_768Len,
+                                       orig_value, NULL);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_kem_private_key: encode failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Decode */
+    rv = ber_decode_ML_KEM_PrivateKey(encoded, encoded_len, &dec_value, &dec_seed, &oid);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_kem_private_key: decode failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify roundtrip */
+    if (dec_value->ulValueLen != sizeof(value_data) ||
+        memcmp(dec_value->pValue, value_data, sizeof(value_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_kem_private_key: value mismatch\n");
+        result = 1;
+    }
+
+    if (result == 0)
+        printf("[PASS] test_roundtrip_ml_kem_private_key\n");
+
+cleanup:
+    if (orig_value) free(orig_value);
+    if (dec_value) free(dec_value);
+    if (dec_seed) free(dec_seed);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ber_encode_ML_KEM_PrivateKey with seed value */
+int test_encode_ml_kem_private_key_with_seed(void)
+{
+    /* ML-KEM-768 private key value for testing (2400 bytes) */
+    CK_BYTE value_data[2400];
+    CK_BYTE seed_data[64];  /* Seed is 64 bytes for ML-KEM */
+    CK_ATTRIBUTE *value = NULL;
+    CK_ATTRIBUTE *seed = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* Initialize value and seed with test data */
+    memset(value_data, 0x4F, sizeof(value_data));
+    memset(seed_data, 0xBC, sizeof(seed_data));
+
+    /* Create attributes */
+    value = create_attribute(CKA_VALUE, value_data, sizeof(value_data));
+    seed = create_attribute(CKA_VALUE, seed_data, sizeof(seed_data));
+
+    if (!value || !seed) {
+        fprintf(stderr, "[FAIL] test_encode_ml_kem_private_key_with_seed: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Encode with ML-KEM-768 OID and seed */
+    rv = ber_encode_ML_KEM_PrivateKey(FALSE, &encoded, &encoded_len,
+                                       ber_idML_KEM_768, ber_idML_KEM_768Len,
+                                       value, seed);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_ml_kem_private_key_with_seed: encoding failed with rv=0x%lx\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (!encoded || encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_ml_kem_private_key_with_seed: encoding produced no data\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_encode_ml_kem_private_key_with_seed\n");
+
+cleanup:
+    if (value) free(value);
+    if (seed) free(seed);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ber_encode_ML_KEM_PrivateKey with seed in length_only mode */
+int test_encode_ml_kem_private_key_with_seed_length_only(void)
+{
+    CK_BYTE value_data[2400];
+    CK_BYTE seed_data[64];
+    CK_ATTRIBUTE *value = NULL;
+    CK_ATTRIBUTE *seed = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    memset(value_data, 0x60, sizeof(value_data));
+    memset(seed_data, 0xDE, sizeof(seed_data));
+
+    value = create_attribute(CKA_VALUE, value_data, sizeof(value_data));
+    seed = create_attribute(CKA_VALUE, seed_data, sizeof(seed_data));
+
+    if (!value || !seed) {
+        fprintf(stderr, "[FAIL] test_encode_ml_kem_private_key_with_seed_length_only: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Encode with length_only = TRUE and seed */
+    rv = ber_encode_ML_KEM_PrivateKey(TRUE, &encoded, &encoded_len,
+                                       ber_idML_KEM_768, ber_idML_KEM_768Len,
+                                       value, seed);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_ml_kem_private_key_with_seed_length_only: encoding failed with rv=0x%lx\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (encoded != NULL) {
+        fprintf(stderr, "[FAIL] test_encode_ml_kem_private_key_with_seed_length_only: encoded should be NULL in length_only mode\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    if (encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_ml_kem_private_key_with_seed_length_only: encoded_len should be non-zero\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_encode_ml_kem_private_key_with_seed_length_only\n");
+
+cleanup:
+    if (value) free(value);
+    if (seed) free(seed);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ber_decode_ML_KEM_PrivateKey with seed in encoded data */
+int test_decode_ml_kem_private_key_with_seed(void)
+{
+    CK_BYTE value_data[2400];
+    CK_BYTE seed_data[64];
+    CK_ATTRIBUTE *orig_value = NULL;
+    CK_ATTRIBUTE *orig_seed = NULL;
+    CK_ATTRIBUTE *dec_value = NULL;
+    CK_ATTRIBUTE *dec_seed = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    const struct pqc_oid *oid = NULL;
+    CK_RV rv;
+    int result = 0;
+
+    memset(value_data, 0x71, sizeof(value_data));
+    memset(seed_data, 0xF0, sizeof(seed_data));
+
+    orig_value = create_attribute(CKA_VALUE, value_data, sizeof(value_data));
+    orig_seed = create_attribute(CKA_VALUE, seed_data, sizeof(seed_data));
+
+    if (!orig_value || !orig_seed) {
+        fprintf(stderr, "[FAIL] test_decode_ml_kem_private_key_with_seed: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* First encode with seed */
+    rv = ber_encode_ML_KEM_PrivateKey(FALSE, &encoded, &encoded_len,
+                                       ber_idML_KEM_768, ber_idML_KEM_768Len,
+                                       orig_value, orig_seed);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ml_kem_private_key_with_seed: encoding failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Now decode */
+    rv = ber_decode_ML_KEM_PrivateKey(encoded, encoded_len, &dec_value, &dec_seed, &oid);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ml_kem_private_key_with_seed: decoding failed with rv=0x%lx\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (!dec_value || !dec_seed || !oid) {
+        fprintf(stderr, "[FAIL] test_decode_ml_kem_private_key_with_seed: decode produced NULL output\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify decoded value matches original */
+    if (dec_value->ulValueLen != sizeof(value_data) ||
+        memcmp(dec_value->pValue, value_data, sizeof(value_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_ml_kem_private_key_with_seed: value mismatch\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify decoded seed matches original */
+    if (dec_seed->ulValueLen != sizeof(seed_data) ||
+        memcmp(dec_seed->pValue, seed_data, sizeof(seed_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_ml_kem_private_key_with_seed: seed mismatch\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_decode_ml_kem_private_key_with_seed\n");
+
+cleanup:
+    if (orig_value) free(orig_value);
+    if (orig_seed) free(orig_seed);
+    if (dec_value) free(dec_value);
+    if (dec_seed) free(dec_seed);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ML-KEM private key with seed encode/decode roundtrip */
+int test_roundtrip_ml_kem_private_key_with_seed(void)
+{
+    CK_BYTE value_data[2400];
+    CK_BYTE seed_data[64];
+    CK_ATTRIBUTE *orig_value = NULL;
+    CK_ATTRIBUTE *orig_seed = NULL;
+    CK_ATTRIBUTE *dec_value = NULL;
+    CK_ATTRIBUTE *dec_seed = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    const struct pqc_oid *oid = NULL;
+    CK_RV rv;
+    int result = 0;
+
+    memset(value_data, 0x82, sizeof(value_data));
+    memset(seed_data, 0x23, sizeof(seed_data));
+
+    orig_value = create_attribute(CKA_VALUE, value_data, sizeof(value_data));
+    orig_seed = create_attribute(CKA_VALUE, seed_data, sizeof(seed_data));
+
+    if (!orig_value || !orig_seed) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_kem_private_key_with_seed: failed to create attributes\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Encode with seed */
+    rv = ber_encode_ML_KEM_PrivateKey(FALSE, &encoded, &encoded_len,
+                                       ber_idML_KEM_768, ber_idML_KEM_768Len,
+                                       orig_value, orig_seed);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_kem_private_key_with_seed: encode failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Decode */
+    rv = ber_decode_ML_KEM_PrivateKey(encoded, encoded_len, &dec_value, &dec_seed, &oid);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_kem_private_key_with_seed: decode failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify roundtrip for value */
+    if (dec_value->ulValueLen != sizeof(value_data) ||
+        memcmp(dec_value->pValue, value_data, sizeof(value_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_kem_private_key_with_seed: value mismatch\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify roundtrip for seed */
+    if (dec_seed->ulValueLen != sizeof(seed_data) ||
+        memcmp(dec_seed->pValue, seed_data, sizeof(seed_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_kem_private_key_with_seed: seed mismatch\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    if (result == 0)
+        printf("[PASS] test_roundtrip_ml_kem_private_key_with_seed\n");
+
+cleanup:
+    if (orig_value) free(orig_value);
+    if (orig_seed) free(orig_seed);
+    if (dec_value) free(dec_value);
+    if (dec_seed) free(dec_seed);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ber_encode_ML_KEM_PrivateKey with seed-only (no value) */
+int test_encode_ml_kem_private_key_seed_only(void)
+{
+    /* ML-KEM-768 seed for testing (64 bytes) */
+    CK_BYTE seed_data[64];
+    CK_ATTRIBUTE *seed = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    /* Initialize seed with test data */
+    memset(seed_data, 0xBC, sizeof(seed_data));
+
+    /* Create seed attribute */
+    seed = create_attribute(CKA_VALUE, seed_data, sizeof(seed_data));
+
+    if (!seed) {
+        fprintf(stderr, "[FAIL] test_encode_ml_kem_private_key_seed_only: failed to create seed attribute\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Encode with ML-KEM-768 OID, NULL value, and seed */
+    rv = ber_encode_ML_KEM_PrivateKey(FALSE, &encoded, &encoded_len,
+                                       ber_idML_KEM_768, ber_idML_KEM_768Len,
+                                       NULL, seed);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_ml_kem_private_key_seed_only: encoding failed with rv=0x%lx\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (!encoded || encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_ml_kem_private_key_seed_only: encoding produced no data\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_encode_ml_kem_private_key_seed_only\n");
+
+cleanup:
+    if (seed) free(seed);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ber_encode_ML_KEM_PrivateKey with seed-only in length_only mode */
+int test_encode_ml_kem_private_key_seed_only_length_only(void)
+{
+    CK_BYTE seed_data[64];
+    CK_ATTRIBUTE *seed = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    CK_RV rv;
+    int result = 0;
+
+    memset(seed_data, 0xDE, sizeof(seed_data));
+
+    seed = create_attribute(CKA_VALUE, seed_data, sizeof(seed_data));
+
+    if (!seed) {
+        fprintf(stderr, "[FAIL] test_encode_ml_kem_private_key_seed_only_length_only: failed to create seed attribute\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Encode with length_only = TRUE, NULL value, and seed */
+    rv = ber_encode_ML_KEM_PrivateKey(TRUE, &encoded, &encoded_len,
+                                       ber_idML_KEM_768, ber_idML_KEM_768Len,
+                                       NULL, seed);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_encode_ml_kem_private_key_seed_only_length_only: encoding failed with rv=0x%lx\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (encoded != NULL) {
+        fprintf(stderr, "[FAIL] test_encode_ml_kem_private_key_seed_only_length_only: encoded should be NULL in length_only mode\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    if (encoded_len == 0) {
+        fprintf(stderr, "[FAIL] test_encode_ml_kem_private_key_seed_only_length_only: encoded_len should be non-zero\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_encode_ml_kem_private_key_seed_only_length_only\n");
+
+cleanup:
+    if (seed) free(seed);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ber_decode_ML_KEM_PrivateKey with seed-only in encoded data */
+int test_decode_ml_kem_private_key_seed_only(void)
+{
+    CK_BYTE seed_data[64];
+    CK_ATTRIBUTE *orig_seed = NULL;
+    CK_ATTRIBUTE *dec_value = NULL;
+    CK_ATTRIBUTE *dec_seed = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    const struct pqc_oid *oid = NULL;
+    CK_RV rv;
+    int result = 0;
+
+    memset(seed_data, 0xF0, sizeof(seed_data));
+
+    orig_seed = create_attribute(CKA_VALUE, seed_data, sizeof(seed_data));
+
+    if (!orig_seed) {
+        fprintf(stderr, "[FAIL] test_decode_ml_kem_private_key_seed_only: failed to create seed attribute\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* First encode with NULL value and seed */
+    rv = ber_encode_ML_KEM_PrivateKey(FALSE, &encoded, &encoded_len,
+                                       ber_idML_KEM_768, ber_idML_KEM_768Len,
+                                       NULL, orig_seed);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ml_kem_private_key_seed_only: encoding failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Now decode */
+    rv = ber_decode_ML_KEM_PrivateKey(encoded, encoded_len, &dec_value, &dec_seed, &oid);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_decode_ml_kem_private_key_seed_only: decoding failed with rv=0x%lx\n", rv);
+        result = 1;
+        goto cleanup;
+    }
+
+    if (!dec_seed || !oid) {
+        fprintf(stderr, "[FAIL] test_decode_ml_kem_private_key_seed_only: decode produced NULL output\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify decoded seed matches original */
+    if (dec_seed->ulValueLen != sizeof(seed_data) ||
+        memcmp(dec_seed->pValue, seed_data, sizeof(seed_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_decode_ml_kem_private_key_seed_only: seed mismatch\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Value should be NULL for seed-only keys */
+    if (dec_value != NULL) {
+        fprintf(stderr, "[FAIL] test_decode_ml_kem_private_key_seed_only: value should be NULL for seed-only key\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    printf("[PASS] test_decode_ml_kem_private_key_seed_only\n");
+
+cleanup:
+    if (orig_seed) free(orig_seed);
+    if (dec_value) free(dec_value);
+    if (dec_seed) free(dec_seed);
+    if (encoded) free(encoded);
+    return result;
+}
+
+/* Test ML-KEM private key seed-only encode/decode roundtrip */
+int test_roundtrip_ml_kem_private_key_seed_only(void)
+{
+    CK_BYTE seed_data[64];
+    CK_ATTRIBUTE *orig_seed = NULL;
+    CK_ATTRIBUTE *dec_value = NULL;
+    CK_ATTRIBUTE *dec_seed = NULL;
+    CK_BYTE *encoded = NULL;
+    CK_ULONG encoded_len = 0;
+    const struct pqc_oid *oid = NULL;
+    CK_RV rv;
+    int result = 0;
+
+    memset(seed_data, 0x23, sizeof(seed_data));
+
+    orig_seed = create_attribute(CKA_VALUE, seed_data, sizeof(seed_data));
+
+    if (!orig_seed) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_kem_private_key_seed_only: failed to create seed attribute\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Encode with NULL value and seed */
+    rv = ber_encode_ML_KEM_PrivateKey(FALSE, &encoded, &encoded_len,
+                                       ber_idML_KEM_768, ber_idML_KEM_768Len,
+                                       NULL, orig_seed);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_kem_private_key_seed_only: encode failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Decode */
+    rv = ber_decode_ML_KEM_PrivateKey(encoded, encoded_len, &dec_value, &dec_seed, &oid);
+    if (rv != CKR_OK) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_kem_private_key_seed_only: decode failed\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify value is NULL */
+    if (dec_value != NULL) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_kem_private_key_seed_only: value should be NULL\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    /* Verify roundtrip for seed */
+    if (dec_seed->ulValueLen != sizeof(seed_data) ||
+        memcmp(dec_seed->pValue, seed_data, sizeof(seed_data)) != 0) {
+        fprintf(stderr, "[FAIL] test_roundtrip_ml_kem_private_key_seed_only: seed mismatch\n");
+        result = 1;
+        goto cleanup;
+    }
+
+    if (result == 0)
+        printf("[PASS] test_roundtrip_ml_kem_private_key_seed_only\n");
+
+cleanup:
+    if (orig_seed) free(orig_seed);
+    if (dec_value) free(dec_value);
+    if (dec_seed) free(dec_seed);
+    if (encoded) free(encoded);
+    return result;
+}

--- a/testcases/unit/asn1test_pqckeys.h
+++ b/testcases/unit/asn1test_pqckeys.h
@@ -1,0 +1,104 @@
+/*
+ * COPYRIGHT (c) International Business Machines Corp. 2026
+ *
+ * This program is provided under the terms of the Common Public License,
+ * version 1.0 (CPL-1.0). Any use, reproduction or distribution for this
+ * software constitutes recipient's acceptance of CPL-1.0 terms which can be
+ * found in the file LICENSE file or at
+ * https://opensource.org/licenses/cpl1.0.php
+ */
+
+#ifndef ASN1TEST_PQCKEYS_H
+#define ASN1TEST_PQCKEYS_H
+
+/* IBM ML-DSA Public Key Tests */
+int test_encode_ibm_ml_dsa_public_key_basic(void);
+int test_decode_ibm_ml_dsa_public_key_valid(void);
+int test_roundtrip_ibm_ml_dsa_public_key(void);
+
+/* IBM ML-DSA Private Key Tests */
+int test_encode_ibm_ml_dsa_private_key_basic(void);
+int test_encode_ibm_ml_dsa_private_key_length_only(void);
+int test_decode_ibm_ml_dsa_private_key_valid(void);
+int test_roundtrip_ibm_ml_dsa_private_key(void);
+
+/* IBM ML-KEM Public Key Tests */
+int test_encode_ibm_ml_kem_public_key_basic(void);
+int test_decode_ibm_ml_kem_public_key_valid(void);
+int test_roundtrip_ibm_ml_kem_public_key(void);
+
+/* IBM ML-KEM Private Key Tests */
+int test_encode_ibm_ml_kem_private_key_basic(void);
+int test_encode_ibm_ml_kem_private_key_length_only(void);
+int test_decode_ibm_ml_kem_private_key_valid(void);
+int test_roundtrip_ibm_ml_kem_private_key(void);
+
+/* IBM Dilithium Public Key Tests */
+int test_encode_ibm_dilithium_public_key_basic(void);
+int test_decode_ibm_dilithium_public_key_basic(void);
+int test_roundtrip_ibm_dilithium_public_key(void);
+
+/* IBM Dilithium Private Key Tests */
+int test_encode_ibm_dilithium_private_key_basic(void);
+int test_decode_ibm_dilithium_private_key_basic(void);
+int test_roundtrip_ibm_dilithium_private_key(void);
+int test_ibm_dilithium_private_key_null_optional(void);
+
+/* IBM Kyber Public Key Tests */
+int test_encode_ibm_kyber_public_key_basic(void);
+int test_decode_ibm_kyber_public_key_basic(void);
+int test_roundtrip_ibm_kyber_public_key(void);
+
+/* IBM Kyber Private Key Tests */
+int test_encode_ibm_kyber_private_key_basic(void);
+int test_decode_ibm_kyber_private_key_basic(void);
+int test_roundtrip_ibm_kyber_private_key(void);
+int test_ibm_kyber_private_key_null_optional(void);
+
+/* ML-DSA (NIST standardized) Public Key Tests */
+int test_encode_ml_dsa_public_key_basic(void);
+int test_decode_ml_dsa_public_key_valid(void);
+int test_roundtrip_ml_dsa_public_key(void);
+
+/* ML-DSA (NIST standardized) Private Key Tests */
+int test_encode_ml_dsa_private_key_basic(void);
+int test_encode_ml_dsa_private_key_length_only(void);
+int test_decode_ml_dsa_private_key_valid(void);
+int test_roundtrip_ml_dsa_private_key(void);
+
+/* ML-DSA (NIST standardized) Private Key Tests with Seed */
+int test_encode_ml_dsa_private_key_with_seed(void);
+int test_encode_ml_dsa_private_key_with_seed_length_only(void);
+int test_decode_ml_dsa_private_key_with_seed(void);
+int test_roundtrip_ml_dsa_private_key_with_seed(void);
+
+/* ML-DSA (NIST standardized) Private Key Tests with Seed-Only */
+int test_encode_ml_dsa_private_key_seed_only(void);
+int test_encode_ml_dsa_private_key_seed_only_length_only(void);
+int test_decode_ml_dsa_private_key_seed_only(void);
+int test_roundtrip_ml_dsa_private_key_seed_only(void);
+
+/* ML-KEM (NIST standardized) Public Key Tests */
+int test_encode_ml_kem_public_key_basic(void);
+int test_decode_ml_kem_public_key_valid(void);
+int test_roundtrip_ml_kem_public_key(void);
+
+/* ML-KEM (NIST standardized) Private Key Tests */
+int test_encode_ml_kem_private_key_basic(void);
+int test_encode_ml_kem_private_key_length_only(void);
+int test_decode_ml_kem_private_key_valid(void);
+int test_roundtrip_ml_kem_private_key(void);
+
+/* ML-KEM (NIST standardized) Private Key Tests with Seed */
+int test_encode_ml_kem_private_key_with_seed(void);
+int test_encode_ml_kem_private_key_with_seed_length_only(void);
+int test_decode_ml_kem_private_key_with_seed(void);
+int test_roundtrip_ml_kem_private_key_with_seed(void);
+
+/* ML-KEM (NIST standardized) Private Key Tests with Seed-Only */
+int test_encode_ml_kem_private_key_seed_only(void);
+int test_encode_ml_kem_private_key_seed_only_length_only(void);
+int test_decode_ml_kem_private_key_seed_only(void);
+int test_roundtrip_ml_kem_private_key_seed_only(void);
+
+#endif /* ASN1TEST_PQCKEYS_H */

--- a/testcases/unit/asn1test_stubs.c
+++ b/testcases/unit/asn1test_stubs.c
@@ -1,0 +1,311 @@
+/*
+ * COPYRIGHT (c) International Business Machines Corp. 2026
+ *
+ * This program is provided under the terms of the Common Public License,
+ * version 1.0 (CPL-1.0). Any use, reproduction or distribution for this
+ * software constitutes recipient's acceptance of CPL-1.0 terms which can be
+ * found in the file LICENSE file or at
+ * https://opensource.org/licenses/cpl1.0.php
+ */
+
+/*
+ * Stub implementations for asn1.c dependencies that are not needed
+ * for testing basic BER encoding/decoding functions.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include "pkcs11types.h"
+#include "defs.h"
+#include "pqc_defs.h"
+
+/* Helper function to create a CK_ATTRIBUTE with data */
+CK_ATTRIBUTE *create_attribute(CK_ATTRIBUTE_TYPE type, CK_BYTE *data, CK_ULONG data_len)
+{
+    CK_ATTRIBUTE *attr = (CK_ATTRIBUTE *)malloc(sizeof(CK_ATTRIBUTE) + data_len);
+    if (!attr)
+        return NULL;
+
+    attr->type = type;
+    attr->ulValueLen = data_len;
+
+    if (data_len > 0) {
+        attr->pValue = (CK_BYTE *)attr + sizeof(CK_ATTRIBUTE);
+        memcpy(attr->pValue, data, data_len);
+    } else {
+        attr->pValue = NULL;
+    }
+
+    return attr;
+}
+
+/* Real implementation of build_attribute - needed for RSA key encoding/decoding */
+CK_RV build_attribute(CK_ATTRIBUTE_TYPE type, CK_BYTE *data,
+                      CK_ULONG data_len, CK_ATTRIBUTE **attr)
+{
+    CK_ATTRIBUTE *a = NULL;
+
+    a = (CK_ATTRIBUTE *)malloc(sizeof(CK_ATTRIBUTE) + data_len);
+    if (!a)
+        return CKR_HOST_MEMORY;
+
+    a->type = type;
+    a->ulValueLen = data_len;
+
+    if (data_len > 0) {
+        a->pValue = (CK_BYTE *)a + sizeof(CK_ATTRIBUTE);
+        memcpy(a->pValue, data, data_len);
+    } else {
+        a->pValue = NULL;
+    }
+
+    *attr = a;
+    return CKR_OK;
+}
+
+/* Real RSA OID constants - needed for RSA key encoding/decoding */
+/* AlgorithmIdentifier for RSA: SEQUENCE { OID, NULL } */
+const CK_BYTE ber_AlgIdRSAEncryption[] = {
+    0x30, 0x0D,  /* SEQUENCE, length 13 */
+    0x06, 0x09,  /* OID, length 9 */
+    0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x01, 0x01,  /* rsaEncryption OID */
+    0x05, 0x00   /* NULL */
+};
+const CK_ULONG ber_AlgIdRSAEncryptionLen = sizeof(ber_AlgIdRSAEncryption);
+
+/* Just the OID part for comparison */
+const CK_BYTE ber_rsaEncryption[] = {
+    0x06, 0x09,  /* OID, length 9 */
+    0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x01, 0x01  /* rsaEncryption OID */
+};
+const CK_ULONG ber_rsaEncryptionLen = sizeof(ber_rsaEncryption);
+
+/* Real DSA OID constant - needed for DSA key encoding/decoding */
+const CK_BYTE ber_idDSA[] = {
+    0x06, 0x07,  /* OID, length 7 */
+    0x2A, 0x86, 0x48, 0xCE, 0x38, 0x04, 0x01  /* id-dsa OID: 1.2.840.10040.4.1 */
+};
+const CK_ULONG ber_idDSALen = sizeof(ber_idDSA);
+
+/* Real DH OID constant - needed for DH key encoding/decoding */
+const CK_BYTE ber_idDH[] = {
+    0x06, 0x07,  /* OID, length 7 */
+    0x2A, 0x86, 0x48, 0xCE, 0x3E, 0x02, 0x01  /* dhKeyAgreement OID: 1.2.840.10046.2.1 */
+};
+const CK_ULONG ber_idDHLen = sizeof(ber_idDH);
+
+/* Real EC OID constants - needed for EC key encoding/decoding */
+/* This is the base AlgorithmIdentifier for EC keys WITHOUT the curve parameter */
+const CK_BYTE der_AlgIdECBase[] = {
+    0x30, 0x09,  /* SEQUENCE, length 9 (will be adjusted by encode function to add curve OID length) */
+    0x06, 0x07,  /* OID, length 7 */
+    0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x02, 0x01  /* id-ecPublicKey OID: 1.2.840.10045.2.1 */
+    /* Curve OID parameter will be appended by the encode function */
+};
+const CK_ULONG der_AlgIdECBaseLen = 11;
+
+/* Just the EC algorithm OID for comparison */
+const CK_BYTE ber_idEC[] = {
+    0x06, 0x07,  /* OID, length 7 */
+    0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x02, 0x01  /* id-ecPublicKey OID: 1.2.840.10045.2.1 */
+};
+const CK_ULONG ber_idECLen = sizeof(ber_idEC);
+
+const CK_BYTE ber_NULL[] = {0x00};
+const CK_ULONG ber_NULLLen = 0;
+
+/* ML-DSA OID constants for testing */
+/* ML-DSA-44: 2.16.840.1.101.3.4.3.17 */
+const CK_BYTE ber_idML_DSA_44[] = {
+    0x06, 0x09,  /* OID, length 9 */
+    0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x03, 0x11
+};
+const CK_ULONG ber_idML_DSA_44Len = sizeof(ber_idML_DSA_44);
+
+/* ML-DSA-65: 2.16.840.1.101.3.4.3.18 */
+const CK_BYTE ber_idML_DSA_65[] = {
+    0x06, 0x09,  /* OID, length 9 */
+    0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x03, 0x12
+};
+const CK_ULONG ber_idML_DSA_65Len = sizeof(ber_idML_DSA_65);
+
+/* ML-DSA-87: 2.16.840.1.101.3.4.3.19 */
+const CK_BYTE ber_idML_DSA_87[] = {
+    0x06, 0x09,  /* OID, length 9 */
+    0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x03, 0x13
+};
+const CK_ULONG ber_idML_DSA_87Len = sizeof(ber_idML_DSA_87);
+
+/* ML-KEM OID constants for testing */
+/* ML-KEM-512: 2.16.840.1.101.3.4.4.1 */
+const CK_BYTE ber_idML_KEM_512[] = {
+    0x06, 0x09,  /* OID, length 9 */
+    0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x04, 0x01
+};
+const CK_ULONG ber_idML_KEM_512Len = sizeof(ber_idML_KEM_512);
+
+/* ML-KEM-768: 2.16.840.1.101.3.4.4.2 */
+const CK_BYTE ber_idML_KEM_768[] = {
+    0x06, 0x09,  /* OID, length 9 */
+    0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x04, 0x02
+};
+const CK_ULONG ber_idML_KEM_768Len = sizeof(ber_idML_KEM_768);
+
+/* ML-KEM-1024: 2.16.840.1.101.3.4.4.3 */
+const CK_BYTE ber_idML_KEM_1024[] = {
+    0x06, 0x09,  /* OID, length 9 */
+    0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x04, 0x03
+};
+const CK_ULONG ber_idML_KEM_1024Len = sizeof(ber_idML_KEM_1024);
+
+/* PQC OID arrays for ML-DSA and ML-KEM */
+const struct pqc_oid ml_dsa_oids[] = {
+    {
+        .oid = (const CK_BYTE[]){0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x03, 0x11},
+        .oid_len = 11,
+        .keyform = 44,
+        .len_info.ml_dsa = {
+            .rho_len = 32,
+            .seed_len = 32,
+            .tr_len = 64,
+            .s1_len = 384,
+            .s2_len = 384,
+            .t0_len = 1664,
+            .t1_len = 1280,
+            .priv_seed_len = 32
+        }
+    },
+    {
+        .oid = (const CK_BYTE[]){0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x03, 0x12},
+        .oid_len = 11,
+        .keyform = 65,
+        .len_info.ml_dsa = {
+            .rho_len = 32,
+            .seed_len = 32,
+            .tr_len = 64,
+            .s1_len = 640,
+            .s2_len = 768,
+            .t0_len = 2496,
+            .t1_len = 1920,
+            .priv_seed_len = 32
+        }
+    },
+    {
+        .oid = (const CK_BYTE[]){0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x03, 0x13},
+        .oid_len = 11,
+        .keyform = 87,
+        .len_info.ml_dsa = {
+            .rho_len = 32,
+            .seed_len = 32,
+            .tr_len = 64,
+            .s1_len = 672,
+            .s2_len = 768,
+            .t0_len = 3328,
+            .t1_len = 2560,
+            .priv_seed_len = 32
+        }
+    },
+    { .oid = NULL }
+};
+
+const struct pqc_oid ml_kem_oids[] = {
+    {
+        .oid = (const CK_BYTE[]){0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x04, 0x01},
+        .oid_len = 11,
+        .keyform = 512,
+        .len_info.ml_kem = {
+            .sk_len = 1632,
+            .pk_len = 800,
+            .fs_len = 64,
+            .priv_seed_len = 64,
+            .pubseed_len = 32
+        }
+    },
+    {
+        .oid = (const CK_BYTE[]){0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x04, 0x02},
+        .oid_len = 11,
+        .keyform = 768,
+        .len_info.ml_kem = {
+            .sk_len = 2400,
+            .pk_len = 1184,
+            .fs_len = 64,
+            .priv_seed_len = 64,
+            .pubseed_len = 32
+        }
+    },
+    {
+        .oid = (const CK_BYTE[]){0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x04, 0x03},
+        .oid_len = 11,
+        .keyform = 1024,
+        .len_info.ml_kem = {
+            .sk_len = 3168,
+            .pk_len = 1568,
+            .fs_len = 64,
+            .priv_seed_len = 64,
+            .pubseed_len = 32
+        }
+    },
+    { .oid = NULL }
+};
+
+/* IBM Dilithium OID constants for testing */
+const CK_BYTE ber_idDilithium_r2_65[] = {0x06, 0x0B, 0x2B, 0x06, 0x01, 0x04, 0x01, 0x02, 0x82, 0x0B, 0x01, 0x06, 0x05};
+const CK_ULONG ber_idDilithium_r2_65Len = sizeof(ber_idDilithium_r2_65);
+
+const struct pqc_oid dilithium_oids[] = {
+    {
+        .oid = ber_idDilithium_r2_65,
+        .oid_len = sizeof(ber_idDilithium_r2_65),
+        .keyform = CK_IBM_DILITHIUM_KEYFORM_ROUND2_65,
+        .policy_size = 256,
+        .policy_siglen = 3366,
+        .len_info.ml_dsa = {
+            .rho_len = 32,
+            .seed_len = 32,
+            .tr_len = 48,
+            .s1_len = 480,
+            .s2_len = 576,
+            .t0_len = 2688,
+            .t1_len = 1728
+        }
+    },
+    { .oid = NULL }
+};
+
+/* IBM Kyber OID constants for testing */
+const CK_BYTE ber_idKyber_r2_1024[] = {0x06, 0x0B, 0x2B, 0x06, 0x01, 0x04, 0x01, 0x02, 0x82, 0x0B, 0x05, 0x04, 0x04};
+const CK_ULONG ber_idKyber_r2_1024Len = sizeof(ber_idKyber_r2_1024);
+
+const struct pqc_oid kyber_oids[] = {
+    {
+        .oid = ber_idKyber_r2_1024,
+        .oid_len = sizeof(ber_idKyber_r2_1024),
+        .keyform = CK_IBM_KYBER_KEYFORM_ROUND2_1024,
+        .policy_size = 256,
+        .policy_siglen = 0,
+        .len_info.ml_kem = {
+            .sk_len = 3168,
+            .pk_len = 1568,
+            .fs_len = 64,
+            .pubseed_len = 32
+        }
+    },
+    { .oid = NULL }
+};
+
+/* Implementation of find_pqc_by_oid for ML-DSA and ML-KEM tests */
+const struct pqc_oid *find_pqc_by_oid(const struct pqc_oid *oids,
+                                      const CK_BYTE *oid, CK_ULONG oid_len)
+{
+    const struct pqc_oid *p;
+
+    if (oids == NULL || oid == NULL || oid_len == 0)
+        return NULL;
+
+    for (p = oids; p->oid != NULL; p++) {
+        if (p->oid_len == oid_len && memcmp(p->oid, oid, oid_len) == 0)
+            return p;
+    }
+
+    return NULL;
+}

--- a/testcases/unit/objectflattentest.c
+++ b/testcases/unit/objectflattentest.c
@@ -1,0 +1,988 @@
+/*
+ * COPYRIGHT (c) International Business Machines Corp. 2026
+ *
+ * This program is provided under the terms of the Common Public License,
+ * version 1.0 (CPL-1.0). Any use, reproduction or distribution for this
+ * software constitutes recipient's acceptance of CPL-1.0 terms which can be
+ * found in the file LICENSE file or at
+ * https://opensource.org/licenses/cpl1.0.php
+ */
+
+/*
+ * Unit and fuzzing tests for object_flatten and object_restore_withSize
+ * functions in object.c
+ *
+ * This test suite performs comprehensive testing including:
+ * - Unit tests for valid inputs
+ * - Unit tests for invalid/NULL inputs
+ * - Unit tests for boundary conditions
+ * - Fuzzing tests with random data
+ * - Fuzzing tests with corrupted data
+ * - Round-trip testing (flatten -> restore)
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <stdint.h>
+
+#include "pkcs11types.h"
+#include "defs.h"
+#include "host_defs.h"
+#include "unittest.h"
+
+#ifndef __BIG_ENDIAN__
+    #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+        #define __BIG_ENDIAN__
+    #endif
+#endif
+
+/* Function prototypes from object.c */
+CK_RV object_flatten(OBJECT *obj, CK_BYTE **data, CK_ULONG *len);
+CK_RV object_restore_withSize(struct policy *policy,
+                              CK_BYTE *data, OBJECT **new_obj,
+                              CK_BBOOL replace, CK_ULONG data_size,
+                              const char *fname);
+
+/* Template function prototypes */
+CK_RV template_add_attributes(TEMPLATE *tmpl, CK_ATTRIBUTE *pTemplate,
+                              CK_ULONG ulCount);
+CK_RV template_free(TEMPLATE *tmpl);
+CK_BBOOL template_attribute_find(TEMPLATE *tmpl,
+                                 CK_ATTRIBUTE_TYPE type, CK_ATTRIBUTE **attr);
+CK_BBOOL compare_attribute(CK_ATTRIBUTE_PTR a1, CK_ATTRIBUTE_PTR a2);
+void object_free(OBJECT *obj);
+CK_RV object_init_lock(OBJECT *obj);
+CK_RV object_init_ex_data_lock(OBJECT *obj);
+
+/* Test statistics */
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+static int crashes_prevented = 0;
+
+#define TEST_ASSERT(condition, msg) do { \
+    tests_run++; \
+    if (!(condition)) { \
+        printf("FAIL: %s (line %d): %s\n", __func__, __LINE__, msg); \
+        tests_failed++; \
+        return -1; \
+    } else { \
+        tests_passed++; \
+    } \
+} while(0)
+
+#define TEST_PASS_FUNC() do { \
+    printf("PASS: %s\n", __func__); \
+    return 0; \
+} while(0)
+
+/* Helper function to create a simple test object */
+static CK_RV create_test_object(OBJECT **obj, CK_OBJECT_CLASS class,
+                                const char *name)
+{
+    OBJECT *o = NULL;
+    TEMPLATE *tmpl = NULL;
+    CK_ATTRIBUTE attrs[4];
+    CK_BBOOL true_val = TRUE;
+    CK_BBOOL false_val = FALSE;
+    char *label = "A label for a nested attribute-array attribute";
+    CK_ATTRIBUTE unwrap_template[] = {
+            { CKA_SIGN, &true_val, sizeof(true_val) },
+            { CKA_VERIFY, &true_val, sizeof(true_val) },
+            { CKA_LABEL, label, strlen(label) },
+    };
+    CK_ATTRIBUTE wrap_template[] = {
+            { CKA_SIGN, &true_val, sizeof(true_val) },
+            { CKA_VERIFY, &true_val, sizeof(true_val) },
+            { CKA_LABEL, label, strlen(label) },
+            { CKA_UNWRAP_TEMPLATE, unwrap_template, sizeof(unwrap_template) },
+    };
+    CK_RV rc;
+
+    o = (OBJECT *)calloc(1, sizeof(OBJECT));
+    if (!o)
+        return CKR_HOST_MEMORY;
+
+    tmpl = (TEMPLATE *)calloc(1, sizeof(TEMPLATE));
+    if (!tmpl) {
+        free(o);
+        return CKR_HOST_MEMORY;
+    }
+
+    o->class = class;
+    if (name)
+        memcpy(o->name, name, 8);
+    else
+        memcpy(o->name, "testobj1", 8);
+
+    o->template = tmpl;
+
+    /* Add some basic attributes */
+    attrs[0].type = CKA_TOKEN;
+    attrs[0].pValue = &true_val;
+    attrs[0].ulValueLen = sizeof(CK_BBOOL);
+
+    attrs[1].type = CKA_PRIVATE;
+    attrs[1].pValue = &false_val;
+    attrs[1].ulValueLen = sizeof(CK_BBOOL);
+
+    attrs[2].type = CKA_CLASS;
+    attrs[2].pValue = &class;
+    attrs[2].ulValueLen = sizeof(CK_OBJECT_CLASS);
+
+    attrs[3].type = CKA_WRAP_TEMPLATE;
+    attrs[3].pValue = &wrap_template;
+    attrs[3].ulValueLen = sizeof(wrap_template);
+
+    rc = template_add_attributes(tmpl, attrs, 4);
+    if (rc != CKR_OK) {
+        free(tmpl);
+        free(o);
+        return rc;
+    }
+
+    rc = object_init_lock(o);
+    if (rc != CKR_OK) {
+        template_free(tmpl);
+        free(o);
+        return rc;
+    }
+
+    rc = object_init_ex_data_lock(o);
+    if (rc != CKR_OK) {
+        object_free(o);
+        return rc;
+    }
+
+    *obj = o;
+    return CKR_OK;
+}
+
+CK_BBOOL template_compare(TEMPLATE *t1, TEMPLATE *t2)
+{
+    DL_NODE *node;
+    CK_ATTRIBUTE *attr1 = NULL;
+    CK_ATTRIBUTE *attr2 = NULL;
+    CK_RV rc;
+
+    if (t1 == NULL || t2 == NULL)
+        return FALSE;
+
+    /* Check if all attributes of t1 are also on t2 */
+    node = t1->attribute_list;
+    while (node != NULL) {
+        attr1 = (CK_ATTRIBUTE *)node->data;
+
+        rc = template_attribute_find(t2, attr1->type, &attr2);
+        if (rc == FALSE)
+            return FALSE;
+
+        if (!compare_attribute(attr1, attr2))
+            return FALSE;
+
+        node = node->next;
+    }
+
+    /* Check if all attributes of t2 are also on t1 */
+    node = t2->attribute_list;
+    while (node != NULL) {
+        attr1 = (CK_ATTRIBUTE *)node->data;
+
+        rc = template_attribute_find(t1, attr1->type, &attr2);
+        if (rc == FALSE)
+            return FALSE;
+
+        if (!compare_attribute(attr1, attr2))
+            return FALSE;
+
+        node = node->next;
+    }
+
+    return TRUE;
+}
+
+/* ========== UNIT TESTS ========== */
+
+/* Test 1: object_flatten with NULL object */
+static int test_flatten_null_object(void)
+{
+    CK_BYTE *data = NULL;
+    CK_ULONG len = 0;
+    CK_RV rc;
+
+    rc = object_flatten(NULL, &data, &len);
+    TEST_ASSERT(rc == CKR_FUNCTION_FAILED,
+                "object_flatten should fail with NULL object");
+    TEST_ASSERT(data == NULL, "data should remain NULL");
+    TEST_ASSERT(len == 0, "len should remain 0");
+
+    TEST_PASS_FUNC();
+}
+
+/* Test 2: object_flatten with valid object */
+static int test_flatten_valid_object(void)
+{
+    OBJECT *obj = NULL;
+    CK_BYTE *data = NULL;
+    CK_ULONG len = 0;
+    CK_RV rc;
+
+    rc = create_test_object(&obj, CKO_DATA, "testobj1");
+    TEST_ASSERT(rc == CKR_OK, "Failed to create test object");
+
+    rc = object_flatten(obj, &data, &len);
+    TEST_ASSERT(rc == CKR_OK, "object_flatten should succeed");
+    TEST_ASSERT(data != NULL, "data should not be NULL");
+    TEST_ASSERT(len > 0, "len should be greater than 0");
+
+    /* Verify minimum size: class(4) + count(4) + name(8) */
+    TEST_ASSERT(len >= 16, "len should be at least 16 bytes");
+
+    /* Verify object class is stored correctly */
+    CK_OBJECT_CLASS_32 stored_class;
+    memcpy(&stored_class, data, sizeof(CK_OBJECT_CLASS_32));
+    TEST_ASSERT(stored_class == CKO_DATA, "stored class should match");
+
+    /* Verify object name is stored correctly */
+    TEST_ASSERT(memcmp(data + 8, "testobj1", 8) == 0,
+                "stored name should match");
+
+    free(data);
+    object_free(obj);
+
+    TEST_PASS_FUNC();
+}
+
+/* Test 3: object_restore_withSize with NULL data */
+static int test_restore_null_data(void)
+{
+    OBJECT *obj = NULL;
+    CK_RV rc;
+
+    rc = object_restore_withSize(NULL, NULL, &obj, FALSE, 100, NULL);
+    TEST_ASSERT(rc == CKR_FUNCTION_FAILED,
+                "object_restore_withSize should fail with NULL data");
+    TEST_ASSERT(obj == NULL, "obj should remain NULL");
+
+    TEST_PASS_FUNC();
+}
+
+/* Test 4: object_restore_withSize with NULL new_obj pointer */
+static int test_restore_null_obj_ptr(void)
+{
+    CK_BYTE data[100];
+    CK_RV rc;
+
+    memset(data, 0, sizeof(data));
+    rc = object_restore_withSize(NULL, data, NULL, FALSE, 100, NULL);
+    TEST_ASSERT(rc == CKR_FUNCTION_FAILED,
+                "object_restore_withSize should fail with NULL obj pointer");
+
+    TEST_PASS_FUNC();
+}
+
+/* Test 5: object_restore_withSize with insufficient data_size */
+static int test_restore_insufficient_size(void)
+{
+    CK_BYTE data[100];
+    OBJECT *obj = NULL;
+    CK_RV rc;
+
+    memset(data, 0, sizeof(data));
+
+    /* Test with size less than minimum (class + count + name = 16 bytes) */
+    rc = object_restore_withSize(NULL, data, &obj, FALSE, 15, NULL);
+    TEST_ASSERT(rc == CKR_FUNCTION_FAILED,
+                "object_restore_withSize should fail with size < 16");
+    TEST_ASSERT(obj == NULL, "obj should remain NULL");
+
+    TEST_PASS_FUNC();
+}
+
+/* Test 6: Round-trip test (flatten -> restore) */
+static int test_roundtrip_flatten_restore(void)
+{
+    OBJECT *obj1 = NULL, *obj2 = NULL;
+    CK_BYTE *data = NULL;
+    CK_ULONG len = 0;
+    CK_RV rc;
+
+    /* Create and flatten object */
+    rc = create_test_object(&obj1, CKO_SECRET_KEY, "roundtrp");
+    TEST_ASSERT(rc == CKR_OK, "Failed to create test object");
+
+    rc = object_flatten(obj1, &data, &len);
+    TEST_ASSERT(rc == CKR_OK, "object_flatten should succeed");
+    TEST_ASSERT(data != NULL && len > 0, "flatten should produce data");
+
+    /* Restore object */
+    rc = object_restore_withSize(NULL, data, &obj2, FALSE, len, NULL);
+    TEST_ASSERT(rc == CKR_OK, "object_restore_withSize should succeed");
+    TEST_ASSERT(obj2 != NULL, "restored object should not be NULL");
+
+    /* Verify restored object matches original */
+    TEST_ASSERT(obj2->class == obj1->class, "class should match");
+    TEST_ASSERT(memcmp(obj2->name, obj1->name, 8) == 0, "name should match");
+    TEST_ASSERT(template_compare(obj1->template, obj2->template), "template should match");
+
+    free(data);
+    object_free(obj1);
+    object_free(obj2);
+
+    TEST_PASS_FUNC();
+}
+
+/* Test 7: object_restore_withSize with filename validation */
+static int test_restore_with_filename(void)
+{
+    OBJECT *obj1 = NULL, *obj2 = NULL;
+    CK_BYTE *data = NULL;
+    CK_ULONG len = 0;
+    CK_RV rc;
+
+    /* Create and flatten object with specific name */
+    rc = create_test_object(&obj1, CKO_DATA, "filename");
+    TEST_ASSERT(rc == CKR_OK, "Failed to create test object");
+
+    rc = object_flatten(obj1, &data, &len);
+    TEST_ASSERT(rc == CKR_OK, "object_flatten should succeed");
+
+    /* Test with matching filename */
+    rc = object_restore_withSize(NULL, data, &obj2, FALSE, len,
+                                 "/path/to/filename");
+    TEST_ASSERT(rc == CKR_OK,
+                "object_restore_withSize should succeed with matching filename");
+    TEST_ASSERT(obj2 != NULL, "restored object should not be NULL");
+    object_free(obj2);
+    obj2 = NULL;
+
+    /* Test with mismatched filename */
+    rc = object_restore_withSize(NULL, data, &obj2, FALSE, len,
+                                 "/path/to/wrongnam");
+    TEST_ASSERT(rc == CKR_FUNCTION_FAILED,
+                "object_restore_withSize should fail with mismatched filename");
+    TEST_ASSERT(obj2 == NULL, "obj should remain NULL on mismatch");
+
+    /* Test with invalid filename format (too short) */
+    rc = object_restore_withSize(NULL, data, &obj2, FALSE, len,
+                                 "/path/to/short");
+    TEST_ASSERT(rc == CKR_FUNCTION_FAILED,
+                "object_restore_withSize should fail with short filename");
+
+    free(data);
+    object_free(obj1);
+
+    TEST_PASS_FUNC();
+}
+
+/* Test 8: object_restore_withSize with replace flag */
+static int test_restore_with_replace(void)
+{
+    OBJECT *obj1 = NULL, *obj2 = NULL;
+    CK_BYTE *data = NULL;
+    CK_ULONG len = 0;
+    CK_RV rc;
+
+    /* Create two objects */
+    rc = create_test_object(&obj1, CKO_DATA, "original");
+    TEST_ASSERT(rc == CKR_OK, "Failed to create first object");
+
+    rc = create_test_object(&obj2, CKO_SECRET_KEY, "replacem");
+    TEST_ASSERT(rc == CKR_OK, "Failed to create second object");
+
+    /* Flatten the replacement object */
+    rc = object_flatten(obj1, &data, &len);
+    TEST_ASSERT(rc == CKR_OK, "object_flatten should succeed");
+
+    /* Restore with replace flag */
+    rc = object_restore_withSize(NULL, data, &obj2, TRUE, len, NULL);
+    TEST_ASSERT(rc == CKR_OK,
+                "object_restore_withSize should succeed with replace=TRUE");
+
+    /* Verify template was replaced but object structure preserved */
+    TEST_ASSERT(obj2 != NULL, "obj2 should still exist");
+    /* Note: The replace operation updates the template, not the object itself */
+
+    free(data);
+    object_free(obj1);
+    object_free(obj2);
+
+    TEST_PASS_FUNC();
+}
+
+/* Test 9: Restore known object data  */
+static int test_restore_known_data(void)
+{
+    OBJECT *obj1 = NULL, *obj2 = NULL;
+    CK_BYTE *data = NULL;
+    CK_ULONG len = 0;
+    CK_RV rc;
+
+    CK_BYTE known_data[] = {
+#ifdef __BIG_ENDIAN__
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1f,
+            0x4f, 0x42, 0x70, 0x35, 0x79, 0x48, 0x5a, 0x59,
+            0x00, 0x00, 0x01, 0x29, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0xa2, 0x30, 0x81, 0x9f, 0x30,
+            0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7,
+            0x0d, 0x01, 0x01, 0x01, 0x05, 0x00, 0x03, 0x81,
+            0x8d, 0x00, 0x30, 0x81, 0x89, 0x02, 0x81, 0x81,
+            0x00, 0xa5, 0x6e, 0x4a, 0x0e, 0x70, 0x10, 0x17,
+            0x58, 0x9a, 0x51, 0x87, 0xdc, 0x7e, 0xa8, 0x41,
+            0xd1, 0x56, 0xf2, 0xec, 0x0e, 0x36, 0xad, 0x52,
+            0xa4, 0x4d, 0xfe, 0xb1, 0xe6, 0x1f, 0x7a, 0xd9,
+            0x91, 0xd8, 0xc5, 0x10, 0x56, 0xff, 0xed, 0xb1,
+            0x62, 0xb4, 0xc0, 0xf2, 0x83, 0xa1, 0x2a, 0x88,
+            0xa3, 0x94, 0xdf, 0xf5, 0x26, 0xab, 0x72, 0x91,
+            0xcb, 0xb3, 0x07, 0xce, 0xab, 0xfc, 0xe0, 0xb1,
+            0xdf, 0xd5, 0xcd, 0x95, 0x08, 0x09, 0x6d, 0x5b,
+            0x2b, 0x8b, 0x6d, 0xf5, 0xd6, 0x71, 0xef, 0x63,
+            0x77, 0xc0, 0x92, 0x1c, 0xb2, 0x3c, 0x27, 0x0a,
+            0x70, 0xe2, 0x59, 0x8e, 0x6f, 0xf8, 0x9d, 0x19,
+            0xf1, 0x05, 0xac, 0xc2, 0xd3, 0xf0, 0xcb, 0x35,
+            0xf2, 0x92, 0x80, 0xe1, 0x38, 0x6b, 0x6f, 0x64,
+            0xc4, 0xef, 0x22, 0xe1, 0xe1, 0xf2, 0x0d, 0x0c,
+            0xe8, 0xcf, 0xfb, 0x22, 0x49, 0xbd, 0x9a, 0x21,
+            0x37, 0x02, 0x03, 0x01, 0x00, 0x01, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x04, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00,
+            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x01, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+            0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x1d, 0x41, 0x6e, 0x6f, 0x74,
+            0x68, 0x65, 0x72, 0x20, 0x52, 0x53, 0x41, 0x20,
+            0x70, 0x75, 0x62, 0x6c, 0x69, 0x63, 0x20, 0x6b,
+            0x65, 0x79, 0x20, 0x6f, 0x62, 0x6a, 0x65, 0x63,
+            0x74, 0x00, 0x00, 0x01, 0x20, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x80, 0xa5, 0x6e, 0x4a,
+            0x0e, 0x70, 0x10, 0x17, 0x58, 0x9a, 0x51, 0x87,
+            0xdc, 0x7e, 0xa8, 0x41, 0xd1, 0x56, 0xf2, 0xec,
+            0x0e, 0x36, 0xad, 0x52, 0xa4, 0x4d, 0xfe, 0xb1,
+            0xe6, 0x1f, 0x7a, 0xd9, 0x91, 0xd8, 0xc5, 0x10,
+            0x56, 0xff, 0xed, 0xb1, 0x62, 0xb4, 0xc0, 0xf2,
+            0x83, 0xa1, 0x2a, 0x88, 0xa3, 0x94, 0xdf, 0xf5,
+            0x26, 0xab, 0x72, 0x91, 0xcb, 0xb3, 0x07, 0xce,
+            0xab, 0xfc, 0xe0, 0xb1, 0xdf, 0xd5, 0xcd, 0x95,
+            0x08, 0x09, 0x6d, 0x5b, 0x2b, 0x8b, 0x6d, 0xf5,
+            0xd6, 0x71, 0xef, 0x63, 0x77, 0xc0, 0x92, 0x1c,
+            0xb2, 0x3c, 0x27, 0x0a, 0x70, 0xe2, 0x59, 0x8e,
+            0x6f, 0xf8, 0x9d, 0x19, 0xf1, 0x05, 0xac, 0xc2,
+            0xd3, 0xf0, 0xcb, 0x35, 0xf2, 0x92, 0x80, 0xe1,
+            0x38, 0x6b, 0x6f, 0x64, 0xc4, 0xef, 0x22, 0xe1,
+            0xe1, 0xf2, 0x0d, 0x0c, 0xe8, 0xcf, 0xfb, 0x22,
+            0x49, 0xbd, 0x9a, 0x21, 0x37, 0x00, 0x00, 0x01,
+            0x22, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x03, 0x01, 0x00, 0x01, 0x40, 0x00, 0x02, 0x11,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x3e,
+            0x00, 0x00, 0x01, 0x04, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01,
+            0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x01, 0x01, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x18, 0x41, 0x6e,
+            0x20, 0x52, 0x53, 0x41, 0x20, 0x70, 0x75, 0x62,
+            0x6c, 0x69, 0x63, 0x20, 0x6b, 0x65, 0x79, 0x20,
+            0x6f, 0x62, 0x6a, 0x65, 0x63, 0x74, 0x00, 0x00,
+            0x01, 0x21, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x04, 0x00, 0x00, 0x04, 0x00, 0x40, 0x00,
+            0x06, 0x2a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x06, 0x33, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
+            0x00, 0x00, 0x86, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x06,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+            0x01, 0x00, 0x00, 0x01, 0x0b, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00,
+            0x01, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x04, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01,
+            0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x80, 0x01, 0x00, 0x0d,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+            0x01, 0x80, 0x01, 0x00, 0x0c, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x40, 0x00,
+            0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x01, 0x66, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x08, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00,
+            0x01, 0x63, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x0c, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+            0x00, 0x00, 0x01, 0x11, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x10,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x01, 0x02, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x72,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+            0x01, 0x00, 0x00, 0x01, 0x71, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00,
+            0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x40, 0x65, 0x61, 0x61, 0x66, 0x63, 0x39,
+            0x30, 0x64, 0x35, 0x34, 0x64, 0x65, 0x33, 0x31,
+            0x34, 0x38, 0x39, 0x64, 0x30, 0x39, 0x65, 0x33,
+            0x66, 0x39, 0x34, 0x62, 0x39, 0x35, 0x66, 0x30,
+            0x39, 0x62, 0x63, 0x35, 0x66, 0x31, 0x35, 0x61,
+            0x62, 0x35, 0x65, 0x61, 0x30, 0x63, 0x65, 0x38,
+            0x36, 0x32, 0x35, 0x64, 0x35, 0x63, 0x33, 0x39,
+            0x37, 0x65, 0x32, 0x37, 0x37, 0x33, 0x64, 0x63,
+            0x64, 0x33, 0x00, 0x00, 0x01, 0x70, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01
+#else
+            0x00, 0x00, 0x00, 0x00, 0x1f, 0x00, 0x00, 0x00,
+            0x4f, 0x42, 0x70, 0x35, 0x79, 0x48, 0x5a, 0x59,
+            0x29, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0xa2, 0x00, 0x00, 0x00, 0x30, 0x81, 0x9f, 0x30,
+            0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7,
+            0x0d, 0x01, 0x01, 0x01, 0x05, 0x00, 0x03, 0x81,
+            0x8d, 0x00, 0x30, 0x81, 0x89, 0x02, 0x81, 0x81,
+            0x00, 0xa5, 0x6e, 0x4a, 0x0e, 0x70, 0x10, 0x17,
+            0x58, 0x9a, 0x51, 0x87, 0xdc, 0x7e, 0xa8, 0x41,
+            0xd1, 0x56, 0xf2, 0xec, 0x0e, 0x36, 0xad, 0x52,
+            0xa4, 0x4d, 0xfe, 0xb1, 0xe6, 0x1f, 0x7a, 0xd9,
+            0x91, 0xd8, 0xc5, 0x10, 0x56, 0xff, 0xed, 0xb1,
+            0x62, 0xb4, 0xc0, 0xf2, 0x83, 0xa1, 0x2a, 0x88,
+            0xa3, 0x94, 0xdf, 0xf5, 0x26, 0xab, 0x72, 0x91,
+            0xcb, 0xb3, 0x07, 0xce, 0xab, 0xfc, 0xe0, 0xb1,
+            0xdf, 0xd5, 0xcd, 0x95, 0x08, 0x09, 0x6d, 0x5b,
+            0x2b, 0x8b, 0x6d, 0xf5, 0xd6, 0x71, 0xef, 0x63,
+            0x77, 0xc0, 0x92, 0x1c, 0xb2, 0x3c, 0x27, 0x0a,
+            0x70, 0xe2, 0x59, 0x8e, 0x6f, 0xf8, 0x9d, 0x19,
+            0xf1, 0x05, 0xac, 0xc2, 0xd3, 0xf0, 0xcb, 0x35,
+            0xf2, 0x92, 0x80, 0xe1, 0x38, 0x6b, 0x6f, 0x64,
+            0xc4, 0xef, 0x22, 0xe1, 0xe1, 0xf2, 0x0d, 0x0c,
+            0xe8, 0xcf, 0xfb, 0x22, 0x49, 0xbd, 0x9a, 0x21,
+            0x37, 0x02, 0x03, 0x01, 0x00, 0x01, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00,
+            0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x01,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+            0x00, 0x00, 0x01, 0x02, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+            0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x1d, 0x00, 0x00, 0x00, 0x41, 0x6e, 0x6f, 0x74,
+            0x68, 0x65, 0x72, 0x20, 0x52, 0x53, 0x41, 0x20,
+            0x70, 0x75, 0x62, 0x6c, 0x69, 0x63, 0x20, 0x6b,
+            0x65, 0x79, 0x20, 0x6f, 0x62, 0x6a, 0x65, 0x63,
+            0x74, 0x20, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x80, 0x00, 0x00, 0x00, 0xa5, 0x6e, 0x4a,
+            0x0e, 0x70, 0x10, 0x17, 0x58, 0x9a, 0x51, 0x87,
+            0xdc, 0x7e, 0xa8, 0x41, 0xd1, 0x56, 0xf2, 0xec,
+            0x0e, 0x36, 0xad, 0x52, 0xa4, 0x4d, 0xfe, 0xb1,
+            0xe6, 0x1f, 0x7a, 0xd9, 0x91, 0xd8, 0xc5, 0x10,
+            0x56, 0xff, 0xed, 0xb1, 0x62, 0xb4, 0xc0, 0xf2,
+            0x83, 0xa1, 0x2a, 0x88, 0xa3, 0x94, 0xdf, 0xf5,
+            0x26, 0xab, 0x72, 0x91, 0xcb, 0xb3, 0x07, 0xce,
+            0xab, 0xfc, 0xe0, 0xb1, 0xdf, 0xd5, 0xcd, 0x95,
+            0x08, 0x09, 0x6d, 0x5b, 0x2b, 0x8b, 0x6d, 0xf5,
+            0xd6, 0x71, 0xef, 0x63, 0x77, 0xc0, 0x92, 0x1c,
+            0xb2, 0x3c, 0x27, 0x0a, 0x70, 0xe2, 0x59, 0x8e,
+            0x6f, 0xf8, 0x9d, 0x19, 0xf1, 0x05, 0xac, 0xc2,
+            0xd3, 0xf0, 0xcb, 0x35, 0xf2, 0x92, 0x80, 0xe1,
+            0x38, 0x6b, 0x6f, 0x64, 0xc4, 0xef, 0x22, 0xe1,
+            0xe1, 0xf2, 0x0d, 0x0c, 0xe8, 0xcf, 0xfb, 0x22,
+            0x49, 0xbd, 0x9a, 0x21, 0x37, 0x22, 0x01, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00,
+            0x00, 0x01, 0x00, 0x01, 0x11, 0x02, 0x00, 0x40,
+            0x00, 0x00, 0x00, 0x00, 0x3e, 0x00, 0x00, 0x00,
+            0x04, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x01, 0x00, 0x00, 0x00, 0x01, 0x06, 0x01, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
+            0x00, 0x01, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x18, 0x00, 0x00, 0x00, 0x41, 0x6e,
+            0x20, 0x52, 0x53, 0x41, 0x20, 0x70, 0x75, 0x62,
+            0x6c, 0x69, 0x63, 0x20, 0x6b, 0x65, 0x79, 0x20,
+            0x6f, 0x62, 0x6a, 0x65, 0x63, 0x74, 0x21, 0x01,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00,
+            0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x2a, 0x06,
+            0x00, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x33, 0x06, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x86,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+            0x00, 0x00, 0x00, 0x00, 0x06, 0x01, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+            0x01, 0x0b, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x0a, 0x01,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+            0x00, 0x00, 0x01, 0x04, 0x01, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+            0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x0d, 0x00, 0x01, 0x80,
+            0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+            0x01, 0x0c, 0x00, 0x01, 0x80, 0x00, 0x00, 0x00,
+            0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x06,
+            0x00, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x66, 0x01, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x63, 0x01,
+            0x00, 0x60, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+            0x00, 0x00, 0x00, 0x0c, 0x01, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+            0x11, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x10, 0x01, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x02, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x72, 0x01, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+            0x01, 0x71, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x04, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00,
+            0x00, 0x00, 0x65, 0x61, 0x61, 0x66, 0x63, 0x39,
+            0x30, 0x64, 0x35, 0x34, 0x64, 0x65, 0x33, 0x31,
+            0x34, 0x38, 0x39, 0x64, 0x30, 0x39, 0x65, 0x33,
+            0x66, 0x39, 0x34, 0x62, 0x39, 0x35, 0x66, 0x30,
+            0x39, 0x62, 0x63, 0x35, 0x66, 0x31, 0x35, 0x61,
+            0x62, 0x35, 0x65, 0x61, 0x30, 0x63, 0x65, 0x38,
+            0x36, 0x32, 0x35, 0x64, 0x35, 0x63, 0x33, 0x39,
+            0x37, 0x65, 0x32, 0x37, 0x37, 0x33, 0x64, 0x63,
+            0x64, 0x33, 0x70, 0x01, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01
+#endif
+    };
+
+    /* Restore object from known data */
+    rc = object_restore_withSize(NULL, known_data, &obj1, FALSE, sizeof(known_data), NULL);
+    TEST_ASSERT(rc == CKR_OK, "object_restore_withSize should succeed");
+    TEST_ASSERT(obj1 != NULL, "restored object should not be NULL");
+
+    /* Flatten object */
+    rc = object_flatten(obj1, &data, &len);
+    TEST_ASSERT(rc == CKR_OK, "object_flatten should succeed");
+    TEST_ASSERT(data != NULL && len > 0, "flatten should produce data");
+    TEST_ASSERT(len == sizeof(known_data), "flatten should produce the same number of bytes");
+
+    /*
+     * The flattened data may not be exactly the same as the known data because
+     * the order of the attributes is not retained when restoring an object.
+     * Restore the flattened data into a new object and compare the templates
+     * of the objects.
+     */
+    rc = object_restore_withSize(NULL, data, &obj2, FALSE, len, NULL);
+    TEST_ASSERT(rc == CKR_OK, "object_restore_withSize should succeed");
+    TEST_ASSERT(obj2 != NULL, "restored object should not be NULL");
+
+    /* Verify restored object matches original */
+    TEST_ASSERT(obj2->class == obj1->class, "class should match");
+    TEST_ASSERT(memcmp(obj2->name, obj1->name, 8) == 0, "name should match");
+    TEST_ASSERT(template_compare(obj1->template, obj2->template), "template should match");
+
+    free(data);
+    object_free(obj1);
+    object_free(obj2);
+
+    TEST_PASS_FUNC();
+}
+
+/* ========== FUZZING TESTS ========== */
+
+/* Helper function to generate random data */
+static void generate_random_data(CK_BYTE *data, CK_ULONG len)
+{
+    for (CK_ULONG i = 0; i < len; i++) {
+        data[i] = (CK_BYTE)(rand() % 256);
+    }
+}
+
+/* Fuzz Test 1: Random data of various sizes */
+static int fuzz_test_random_data(void)
+{
+    CK_BYTE data[1024];
+    OBJECT *obj = NULL;
+    CK_RV rc;
+    int iterations = 1000;
+    int safe_failures = 0;
+
+    printf("Running fuzz test with %d iterations of random data...\n",
+           iterations);
+
+    for (int i = 0; i < iterations; i++) {
+        CK_ULONG size = (rand() % 1000) + 1;
+        generate_random_data(data, size);
+
+        obj = NULL;
+        rc = object_restore_withSize(NULL, data, &obj, FALSE, size, NULL);
+
+        /* We expect most random data to fail gracefully */
+        if (rc != CKR_OK) {
+            safe_failures++;
+            TEST_ASSERT(obj == NULL, "obj should be NULL on failure");
+        } else {
+            /* If it somehow succeeded, clean up */
+            if (obj != NULL)
+                object_free(obj);
+        }
+    }
+
+    crashes_prevented += safe_failures;
+    printf("  Safe failures: %d/%d (prevented crashes)\n",
+           safe_failures, iterations);
+
+    TEST_PASS_FUNC();
+}
+
+/* Fuzz Test 2: Boundary size values */
+static int fuzz_test_boundary_sizes(void)
+{
+    CK_BYTE data[1024];
+    OBJECT *obj = NULL;
+    CK_RV rc;
+    CK_ULONG test_sizes[] = {0, 1, 15, 16, 17, 255, 256, 1023, 1024};
+    int num_tests = sizeof(test_sizes) / sizeof(test_sizes[0]);
+    int safe_failures = 0;
+
+    printf("Running fuzz test with boundary size values...\n");
+
+    for (int i = 0; i < num_tests; i++) {
+        CK_ULONG size = test_sizes[i];
+        memset(data, 0xAA, sizeof(data));
+
+        obj = NULL;
+        rc = object_restore_withSize(NULL, data, &obj, FALSE, size, NULL);
+
+        if (rc != CKR_OK) {
+            safe_failures++;
+            TEST_ASSERT(obj == NULL, "obj should be NULL on failure");
+        } else {
+            if (obj != NULL)
+                object_free(obj);
+        }
+    }
+
+    crashes_prevented += safe_failures;
+    printf("  Safe failures: %d/%d (prevented crashes)\n",
+           safe_failures, num_tests);
+
+    TEST_PASS_FUNC();
+}
+
+/* Fuzz Test 3: Corrupted valid data */
+static int fuzz_test_corrupted_data(void)
+{
+    OBJECT *obj1 = NULL, *obj2 = NULL;
+    CK_BYTE *data = NULL;
+    CK_ULONG len = 0;
+    CK_RV rc;
+    int iterations = 10000;
+    int safe_failures = 0;
+
+    printf("Running fuzz test with corrupted valid data...\n");
+
+    /* Create a valid object and flatten it */
+    rc = create_test_object(&obj1, CKO_DATA, "corrupt1");
+    TEST_ASSERT(rc == CKR_OK, "Failed to create test object");
+
+    rc = object_flatten(obj1, &data, &len);
+    TEST_ASSERT(rc == CKR_OK, "object_flatten should succeed");
+
+    /* Corrupt the data in various ways */
+    for (int i = 0; i < iterations; i++) {
+        CK_BYTE *corrupted = (CK_BYTE *)malloc(len);
+        TEST_ASSERT(corrupted != NULL, "malloc failed");
+
+        memcpy(corrupted, data, len);
+
+        /* Randomly corrupt 1-5 bytes */
+        int num_corruptions = (rand() % 5) + 1;
+        for (int j = 0; j < num_corruptions; j++) {
+            CK_ULONG pos = rand() % len;
+            corrupted[pos] = (CK_BYTE)(rand() % 256);
+        }
+
+        obj2 = NULL;
+        rc = object_restore_withSize(NULL, corrupted, &obj2, FALSE, len, NULL);
+
+        if (rc != CKR_OK) {
+            safe_failures++;
+            TEST_ASSERT(obj2 == NULL, "obj should be NULL on failure");
+        } else {
+            if (obj2 != NULL)
+                object_free(obj2);
+        }
+
+        free(corrupted);
+    }
+
+    crashes_prevented += safe_failures;
+    printf("  Safe failures: %d/%d (prevented crashes)\n",
+           safe_failures, iterations);
+
+    free(data);
+    object_free(obj1);
+
+    TEST_PASS_FUNC();
+}
+
+/* Fuzz Test 4: Extreme count values */
+static int fuzz_test_extreme_counts(void)
+{
+    CK_BYTE data[1024];
+    OBJECT *obj = NULL;
+    CK_RV rc;
+    CK_ULONG_32 extreme_counts[] = {
+        0, 1, 0xFFFFFFFF, 0x7FFFFFFF, 0x80000000,
+        1000000, 0xFFFFFFFE
+    };
+    int num_tests = sizeof(extreme_counts) / sizeof(extreme_counts[0]);
+    int safe_failures = 0;
+
+    printf("Running fuzz test with extreme count values...\n");
+
+    for (int i = 0; i < num_tests; i++) {
+        memset(data, 0, sizeof(data));
+
+        /* Set up minimal valid structure with extreme count */
+        CK_OBJECT_CLASS_32 class32 = CKO_DATA;
+        memcpy(data, &class32, sizeof(CK_OBJECT_CLASS_32));
+        memcpy(data + 4, &extreme_counts[i], sizeof(CK_ULONG_32));
+        memcpy(data + 8, "extreme1", 8);
+
+        obj = NULL;
+        rc = object_restore_withSize(NULL, data, &obj, FALSE, 1024, NULL);
+
+        if (rc != CKR_OK) {
+            safe_failures++;
+            TEST_ASSERT(obj == NULL, "obj should be NULL on failure");
+        } else {
+            if (obj != NULL)
+                object_free(obj);
+        }
+    }
+
+    crashes_prevented += safe_failures;
+    printf("  Safe failures: %d/%d (prevented crashes)\n",
+           safe_failures, num_tests);
+
+    TEST_PASS_FUNC();
+}
+
+/* Fuzz Test 5: Size mismatches */
+static int fuzz_test_size_mismatches(void)
+{
+    OBJECT *obj1 = NULL, *obj2 = NULL;
+    CK_BYTE *data = NULL;
+    CK_ULONG len = 0;
+    CK_RV rc;
+    int safe_failures = 0;
+
+    printf("Running fuzz test with size mismatches...\n");
+
+    /* Create a valid object and flatten it */
+    rc = create_test_object(&obj1, CKO_DATA, "sizemism");
+    TEST_ASSERT(rc == CKR_OK, "Failed to create test object");
+
+    rc = object_flatten(obj1, &data, &len);
+    TEST_ASSERT(rc == CKR_OK, "object_flatten should succeed");
+
+    /* Test with various incorrect sizes */
+    CK_ULONG test_sizes[] = {
+        len - 1, len + 1, len / 2, len * 2,
+        16, len - 10, len + 100
+    };
+    int num_tests = sizeof(test_sizes) / sizeof(test_sizes[0]);
+
+    for (int i = 0; i < num_tests; i++) {
+        obj2 = NULL;
+        rc = object_restore_withSize(NULL, data, &obj2, FALSE,
+                                     test_sizes[i], NULL);
+
+        if (rc != CKR_OK) {
+            safe_failures++;
+            TEST_ASSERT(obj2 == NULL, "obj should be NULL on failure");
+        } else {
+            if (obj2 != NULL)
+                object_free(obj2);
+        }
+    }
+
+    crashes_prevented += safe_failures;
+    printf("  Safe failures: %d/%d (prevented crashes)\n",
+           safe_failures, num_tests);
+
+    free(data);
+    object_free(obj1);
+
+    TEST_PASS_FUNC();
+}
+
+/* ========== MAIN TEST RUNNER ========== */
+
+int main(int argc, char **argv)
+{
+    int rc = 0;
+
+    (void)argc;  /* Suppress unused parameter warning */
+    (void)argv;  /* Suppress unused parameter warning */
+
+    /* Initialize random seed for fuzzing tests */
+    srand((unsigned int)time(NULL));
+
+    printf("\n");
+    printf("========================================\n");
+    printf("Object Flatten/Restore Test Suite\n");
+    printf("========================================\n\n");
+
+    printf("=== UNIT TESTS ===\n");
+
+    if (test_flatten_null_object() != 0)
+        rc = 1;
+
+    if (test_flatten_valid_object() != 0)
+        rc = 1;
+
+    if (test_restore_null_data() != 0)
+        rc = 1;
+
+    if (test_restore_null_obj_ptr() != 0)
+        rc = 1;
+
+    if (test_restore_insufficient_size() != 0)
+        rc = 1;
+
+    if (test_roundtrip_flatten_restore() != 0)
+        rc = 1;
+
+    if (test_restore_with_filename() != 0)
+        rc = 1;
+
+    if (test_restore_with_replace() != 0)
+        rc = 1;
+
+    if (test_restore_known_data() != 0)
+        rc = 1;
+
+    printf("\n=== FUZZING TESTS ===\n");
+
+    if (fuzz_test_random_data() != 0)
+        rc = 1;
+
+    if (fuzz_test_boundary_sizes() != 0)
+        rc = 1;
+
+    if (fuzz_test_corrupted_data() != 0)
+        rc = 1;
+
+    if (fuzz_test_extreme_counts() != 0)
+        rc = 1;
+
+    if (fuzz_test_size_mismatches() != 0)
+        rc = 1;
+
+    printf("\n========================================\n");
+    printf("Test Summary:\n");
+    printf("  Total tests run: %d\n", tests_run);
+    printf("  Passed: %d\n", tests_passed);
+    printf("  Failed: %d\n", tests_failed);
+    printf("  Crashes prevented: %d\n", crashes_prevented);
+    printf("========================================\n\n");
+
+    if (rc == 0)
+        printf("All tests PASSED!\n");
+    else
+        printf("Some tests FAILED!\n");
+
+    return (rc == 0) ? TEST_PASS : TEST_FAIL;
+}

--- a/testcases/unit/objecttest_stubs.c
+++ b/testcases/unit/objecttest_stubs.c
@@ -1,0 +1,72 @@
+/*
+ * COPYRIGHT (c) International Business Machines Corp. 2026
+ *
+ * This program is provided under the terms of the Common Public License,
+ * version 1.0 (CPL-1.0). Any use, reproduction or distribution for this
+ * software constitutes recipient's acceptance of CPL-1.0 terms which can be
+ * found in the file LICENSE file or at
+ * https://opensource.org/licenses/cpl1.0.php
+ */
+
+/*
+ * Stub implementations for objectflattentest
+ * These stubs provide minimal implementations of functions that are
+ * referenced by object.c, template.c, and attributes.c but not needed
+ * for testing object_flatten and object_restore_withSize.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "pkcs11types.h"
+#include "defs.h"
+#include "host_defs.h"
+#include "h_extern.h"
+
+/* Global stubs */
+token_spec_t token_specific = { 0 };
+
+/* Stub implementations */
+CK_RV build_attribute(CK_ATTRIBUTE_TYPE type, CK_BYTE *value,
+                      CK_ULONG value_len, CK_ATTRIBUTE **attrib)
+{
+    CK_ATTRIBUTE *attr;
+
+    attr = (CK_ATTRIBUTE *)malloc(sizeof(CK_ATTRIBUTE));
+    if (!attr)
+        return CKR_HOST_MEMORY;
+
+    attr->type = type;
+    attr->ulValueLen = value_len;
+
+    if (value_len > 0 && value != NULL) {
+        attr->pValue = malloc(value_len);
+        if (!attr->pValue) {
+            free(attr);
+            return CKR_HOST_MEMORY;
+        }
+        memcpy(attr->pValue, value, value_len);
+    } else {
+        attr->pValue = NULL;
+    }
+
+    *attrib = attr;
+    return CKR_OK;
+}
+
+CK_RV policy_get_attr_from_template(void *data,
+                                    CK_ATTRIBUTE_TYPE type,
+                                    CK_ATTRIBUTE **attr)
+{
+    (void)data;
+    (void)type;
+    (void)attr;
+    return CKR_ATTRIBUTE_TYPE_INVALID;
+}
+
+CK_BBOOL session_mgr_user_session_exists(STDLL_TokData_t *tokdata)
+{
+    (void)tokdata;
+    return FALSE;
+}

--- a/testcases/unit/unit.mk
+++ b/testcases/unit/unit.mk
@@ -1,12 +1,12 @@
 check_PROGRAMS = testcases/unit/policytest testcases/unit/hashmaptest	\
 	testcases/unit/mechtabletest testcases/unit/configdump		\
 	testcases/unit/buffertest testcases/unit/uritest		\
-	testcases/unit/pintest
+	testcases/unit/pintest testcases/unit/asn1test
 
 TESTS = testcases/unit/policytest testcases/unit/hashmaptest		\
 	testcases/unit/mechtabletest testcases/unit/configdump		\
 	testcases/unit/buffertest testcases/unit/uritest		\
-	testcases/unit/pintest.sh
+	testcases/unit/pintest.sh testcases/unit/asn1test
 
 EXTRA_DIST += testcases/unit/pintest.sh
 noinst_HEADERS += testcases/unit/unittest.h
@@ -84,3 +84,14 @@ testcases_unit_pintest_SOURCES=testcases/unit/pintest.c		\
 testcases_unit_pintest_CFLAGS=-I${top_srcdir}/usr/lib/common \
 	-I${top_srcdir}/usr/include
 testcases_unit_pintest_LDFLAGS=-lcrypto
+
+testcases_unit_asn1test_SOURCES=testcases/unit/asn1test.c	\
+	testcases/unit/asn1test_keys.c				\
+	testcases/unit/asn1test_pqckeys.c			\
+	usr/lib/common/asn1.c usr/lib/common/trace.c		\
+	testcases/unit/asn1test_stubs.c
+
+testcases_unit_asn1test_CFLAGS=-I${top_srcdir}/usr/lib/common	\
+	-I${top_srcdir}/usr/include -DSTDLL_NAME=\"asn1test\"
+
+testcases_unit_asn1test_LDFLAGS=-llber

--- a/testcases/unit/unit.mk
+++ b/testcases/unit/unit.mk
@@ -1,12 +1,14 @@
 check_PROGRAMS = testcases/unit/policytest testcases/unit/hashmaptest	\
 	testcases/unit/mechtabletest testcases/unit/configdump		\
 	testcases/unit/buffertest testcases/unit/uritest		\
-	testcases/unit/pintest testcases/unit/asn1test
+	testcases/unit/pintest testcases/unit/asn1test			\
+	testcases/unit/asn1fuzztest
 
 TESTS = testcases/unit/policytest testcases/unit/hashmaptest		\
 	testcases/unit/mechtabletest testcases/unit/configdump		\
 	testcases/unit/buffertest testcases/unit/uritest		\
-	testcases/unit/pintest.sh testcases/unit/asn1test
+	testcases/unit/pintest.sh testcases/unit/asn1test		\
+	testcases/unit/asn1fuzztest
 
 EXTRA_DIST += testcases/unit/pintest.sh
 noinst_HEADERS += testcases/unit/unittest.h
@@ -95,3 +97,12 @@ testcases_unit_asn1test_CFLAGS=-I${top_srcdir}/usr/lib/common	\
 	-I${top_srcdir}/usr/include -DSTDLL_NAME=\"asn1test\"
 
 testcases_unit_asn1test_LDFLAGS=-llber
+
+testcases_unit_asn1fuzztest_SOURCES=testcases/unit/asn1fuzztest.c	\
+	usr/lib/common/asn1.c usr/lib/common/trace.c			\
+	testcases/unit/asn1test_stubs.c
+
+testcases_unit_asn1fuzztest_CFLAGS=-I${top_srcdir}/usr/lib/common	\
+	-I${top_srcdir}/usr/include -DSTDLL_NAME=\"asn1fuzztest\"
+
+testcases_unit_asn1fuzztest_LDFLAGS=-llber

--- a/testcases/unit/unit.mk
+++ b/testcases/unit/unit.mk
@@ -2,13 +2,13 @@ check_PROGRAMS = testcases/unit/policytest testcases/unit/hashmaptest	\
 	testcases/unit/mechtabletest testcases/unit/configdump		\
 	testcases/unit/buffertest testcases/unit/uritest		\
 	testcases/unit/pintest testcases/unit/asn1test			\
-	testcases/unit/asn1fuzztest
+	testcases/unit/asn1fuzztest testcases/unit/objectflattentest
 
 TESTS = testcases/unit/policytest testcases/unit/hashmaptest		\
 	testcases/unit/mechtabletest testcases/unit/configdump		\
 	testcases/unit/buffertest testcases/unit/uritest		\
 	testcases/unit/pintest.sh testcases/unit/asn1test		\
-	testcases/unit/asn1fuzztest
+	testcases/unit/asn1fuzztest testcases/unit/objectflattentest
 
 EXTRA_DIST += testcases/unit/pintest.sh
 noinst_HEADERS += testcases/unit/unittest.h
@@ -106,3 +106,15 @@ testcases_unit_asn1fuzztest_CFLAGS=-I${top_srcdir}/usr/lib/common	\
 	-I${top_srcdir}/usr/include -DSTDLL_NAME=\"asn1fuzztest\"
 
 testcases_unit_asn1fuzztest_LDFLAGS=-llber
+
+testcases_unit_objectflattentest_SOURCES=testcases/unit/objectflattentest.c	\
+	testcases/unit/objecttest_stubs.c				\
+	usr/lib/common/object.c usr/lib/common/p11util.c		\
+	usr/lib/common/trace.c usr/lib/common/template.c		\
+	usr/lib/common/attributes.c usr/lib/common/dlist.c
+
+testcases_unit_objectflattentest_CFLAGS=-I${top_srcdir}/usr/lib/common	\
+	-I${top_srcdir}/usr/include -I${top_srcdir}/usr/lib/api	\
+	-DSTDLL_NAME=\"objectflattentest\" -DOCK_UNIT_TESTS
+
+testcases_unit_objectflattentest_LDFLAGS=-lpthread -lcrypto

--- a/usr/lib/common/object.c
+++ b/usr/lib/common/object.c
@@ -38,6 +38,8 @@
 #include "trace.h"
 #include "../api/policy.h"
 
+#ifndef OCK_UNIT_TESTS
+
 // object_create()
 //
 // Args:   void *  attributes : (INPUT)  pointer to data block containing
@@ -273,6 +275,7 @@ error:
     return rc;
 }
 
+#endif
 
 // object_flatten() - this is still used when saving token objects
 //
@@ -348,6 +351,8 @@ void object_free(OBJECT * obj)
         free(obj);
     }
 }
+
+#ifndef OCK_UNIT_TESTS
 
 //call_object_free()
 //This function is added to silence the compiler during implicit void (*)(void*)
@@ -710,6 +715,8 @@ error:
     return rc;
 }
 
+#endif
+
 CK_RV object_restore_withSize(struct policy *policy,
                               CK_BYTE * data, OBJECT ** new_obj,
                               CK_BBOOL replace, CK_ULONG data_size,
@@ -824,7 +831,7 @@ error:
     return rc;
 }
 
-
+#ifndef OCK_UNIT_TESTS
 //
 //
 CK_RV object_create_skel(STDLL_TokData_t * tokdata,
@@ -933,6 +940,8 @@ done:
 
     return rc;
 }
+
+#endif
 
 CK_RV object_init_lock(OBJECT *obj)
 {

--- a/usr/lib/common/template.c
+++ b/usr/lib/common/template.c
@@ -45,6 +45,8 @@
 
 static CK_ULONG attribute_get_compressed_size(CK_ATTRIBUTE_PTR attr);
 
+#ifndef OCK_UNIT_TESTS
+
 /* Random 32 byte string is unique with overwhelming probability. */
 #define UNIQUE_ID_LEN 32
 
@@ -61,6 +63,8 @@ static CK_RV get_unique_id_str(char unique_id_str[2 * UNIQUE_ID_LEN + 1])
 
     return CKR_OK;
 }
+
+#endif
 
 /* template_add_attributes()
  *
@@ -129,6 +133,7 @@ CK_RV template_add_attributes(TEMPLATE *tmpl, CK_ATTRIBUTE *pTemplate,
     return CKR_OK;
 }
 
+#ifndef OCK_UNIT_TESTS
 
 /* template_add_default_attributes()
  * Add default attributes to '*tmpl'.
@@ -282,6 +287,7 @@ CK_RV template_add_default_attributes(STDLL_TokData_t *tokdata,
     }
 }
 
+#endif
 
 /* template_attribute_find()
  *
@@ -430,6 +436,7 @@ void template_attribute_find_multiple(TEMPLATE *tmpl,
     }
 }
 
+#ifndef OCK_UNIT_TESTS
 
 /* template_check_required_attributes() */
 CK_RV template_check_required_attributes(TEMPLATE *tmpl, CK_ULONG class,
@@ -713,6 +720,7 @@ CK_RV template_copy(TEMPLATE *dest, TEMPLATE *src)
     return CKR_OK;
 }
 
+#endif
 
 static CK_BBOOL flatten_ulong_attribute_as_ulong32(CK_ATTRIBUTE_TYPE type)
 {
@@ -1446,6 +1454,8 @@ CK_ULONG template_get_compressed_size(TEMPLATE *tmpl)
     return size;
 }
 
+#ifndef OCK_UNIT_TESTS
+
 /* template_is_okay_to_reveal_attribute()
  *
  * determines whether the specified CK_ATTRIBUTE_TYPE is allowed to
@@ -1725,6 +1735,8 @@ error:
     return rc;
 }
 
+#endif
+
 /* template_remove_attribute()
  *
  * removes an attribute (if existing) from the template.
@@ -1827,6 +1839,8 @@ CK_RV template_build_update_attribute(TEMPLATE *tmpl,
 
     return CKR_OK;
 }
+
+#ifndef OCK_UNIT_TESTS
 
 /* template_validate_attribute()
  *
@@ -2120,4 +2134,5 @@ void dump_template(TEMPLATE *tmpl)
         node = node->next;
     }
 }
+#endif
 #endif


### PR DESCRIPTION
The tests have been mostly generated by IBM Bob and validated manually for correctness.