### PR TITLE
CCA: Only support CKM_ML_DSA_KEY_PAIR_GEN with CCA 8.4 or later

### DIFF
--- a/usr/lib/cca_stdll/cca_specific.c
+++ b/usr/lib/cca_stdll/cca_specific.c
@@ -7680,6 +7680,7 @@ static CK_BBOOL token_specific_filter_mechanism(STDLL_TokData_t *tokdata,
         break;
     case CKM_IBM_ML_DSA_KEY_PAIR_GEN:
     case CKM_IBM_ML_DSA:
+    case CKM_ML_DSA_KEY_PAIR_GEN:
     case CKM_ML_DSA:
     case CKM_HASH_ML_DSA:
     case CKM_HASH_ML_DSA_SHA512:


### PR DESCRIPTION
Only report the CKM_ML_DSA_KEY_PAIR_GEN mechanism to be supported when the required CCA version (i.e. 8.4) is available.

Fixes: bbf50cdfd7072d225c94c61fed11dd2b51dd74f9