### PR TITLE
P11SAK: Fix a typo in an error message

### DIFF
--- a/usr/sbin/p11sak/p11sak_keywrap.c
+++ b/usr/sbin/p11sak/p11sak_keywrap.c
@@ -1221,7 +1221,7 @@ static CK_RV p11sak_select_kek(CK_OBJECT_CLASS kek_class, CK_KEY_TYPE kek_type,
 
     if (opt_kek_label == NULL && opt_kek_id == NULL) {
         warnx("At least one of the following options must be specified:");
-        warnx("'-K'/'--kek-label',  r '-k'/'--kek-id'");
+        warnx("'-K'/'--kek-label', or '-k'/'--kek-id'");
         return CKR_ARGUMENTS_BAD;
     }
 


### PR DESCRIPTION
Fixes: 4a9a7b47298dfda7cd912f63cb427eace9eca2fe