### PR TITLE
Update CKM_PUB_KEY_FROM_PRIV_KEY handling after PKCS#11 spec update

### DIFF
--- a/usr/lib/common/key_mgr.c
+++ b/usr/lib/common/key_mgr.c
@@ -1922,7 +1922,7 @@ CK_RV key_mgr_derive_key(STDLL_TokData_t *tokdata,
     OBJECT *base_key_obj = NULL;
     CK_ATTRIBUTE *new_attrs = NULL;
     CK_ULONG new_attr_count = 0;
-    CK_BBOOL flag;
+    CK_BBOOL flag = CK_FALSE;
     CK_ATTRIBUTE_TYPE key_usage_attr, apply_tmpl_attr;
     CK_ULONG mode;
     int policy_check;
@@ -2044,14 +2044,20 @@ CK_RV key_mgr_derive_key(STDLL_TokData_t *tokdata,
     /* is base key allowed to do the desired operation? */
     rc = template_attribute_get_bool(base_key_obj->template, key_usage_attr,
                                      &flag);
-    if (rc != CKR_OK) {
+    if (rc != CKR_OK && mech->mechanism != CKM_PUB_KEY_FROM_PRIV_KEY) {
         TRACE_ERROR("Could not find %s for the base key.\n",
                     p11_get_cka(key_usage_attr));
         rc = CKR_KEY_FUNCTION_NOT_PERMITTED;
         goto done;
     }
 
-    if (flag != TRUE) {
+    /*
+     * Special handling for CKM_PUB_KEY_FROM_PRIV_KEY:
+     * As per updated PKCS#11 spec: Although this is technically a derivation
+     * mechanism, it can always be used with any CKO_PRIVATE_KEY object
+     * regardless of its CKA_DERIVE attribute value.
+     */
+    if (flag != TRUE && mech->mechanism != CKM_PUB_KEY_FROM_PRIV_KEY) {
         TRACE_ERROR("%s is set to FALSE.\n", p11_get_cka(key_usage_attr));
         rc = CKR_KEY_FUNCTION_NOT_PERMITTED;
         goto done;

--- a/usr/sbin/p11sak/p11sak.c
+++ b/usr/sbin/p11sak/p11sak.c
@@ -10633,15 +10633,9 @@ static CK_RV p11sak_key_extract_pubkey(const struct p11tool_objtype *keytype,
     CK_RV rc;
     CK_MECHANISM pub_from_priv_mech = { CKM_PUB_KEY_FROM_PRIV_KEY, NULL, 0 };
     CK_BBOOL pub_from_priv_supported;
-    CK_BBOOL derive_val = CK_FALSE;
-    CK_ATTRIBUTE derive = { CKA_DERIVE, &derive_val, sizeof(derive_val) };
 
     pub_from_priv_supported =
             (p11tool_check_pub_from_priv_mech_supported(opt_slot) == CKR_OK);
-
-    rc = p11tool_get_attribute(key, &derive);
-    if (rc != CKR_OK || derive_val == CK_FALSE)
-        pub_from_priv_supported = CK_FALSE;
 
     if (opt_new_attr != NULL) {
         rc = p11tool_parse_boolean_attrs(keytype, p11sak_bool_attrs,


### PR DESCRIPTION
PKCS#11 spec update https://github.com/oasis-tcs/pkcs11/commit/1f2af1234e8b891ff9a91b46261372ce401c132f clarified the behavior of CKM_PUB_KEY_FROM_PRIV_KEY in regards of the CKA_DERIVE attribute:

>    Although this is technically a derivation mechanism, it can always be used with any CKO_PRIVATE_KEY object regardless of its CKA_DERIVE attribute value.

Update the key_mgr_derive_key() function and p11sak command 'extract-pubkey' accordingly.