### PR TITLE
Fixes for the kmipclient library

### DIFF
--- a/usr/sbin/p11kmip/kmipclient/https.c
+++ b/usr/sbin/p11kmip/kmipclient/https.c
@@ -782,7 +782,8 @@ int kmip_connection_https_perform(struct kmip_connection *conn,
 	switch (conn->config.encoding) {
 	case KMIP_ENCODING_TTLV:
 		rc = kmip_decode_ttlv(write_cb.ttlv.resp_mem_bio, NULL,
-				      response, debug);
+				      response, KMIP_DECODE_MAX_NESTING_LEVEL,
+				      debug);
 		if (rc != 0) {
 			kmip_debug(debug, "kmip_decode_ttlv failed");
 			goto out;
@@ -798,7 +799,7 @@ int kmip_connection_https_perform(struct kmip_connection *conn,
 		}
 
 		rc = kmip_decode_json(write_cb.json.resp_obj, NULL, response,
-				      debug);
+				      KMIP_DECODE_MAX_NESTING_LEVEL, debug);
 		if (rc != 0) {
 			kmip_debug(debug, "kmip_decode_json failed");
 			goto out;
@@ -817,7 +818,8 @@ int kmip_connection_https_perform(struct kmip_connection *conn,
 
 		rc = kmip_decode_xml(xmlDocGetRootElement(
 						write_cb.xml.ctx->myDoc),
-				     NULL, response, debug);
+				     NULL, response,
+				     KMIP_DECODE_MAX_NESTING_LEVEL, debug);
 		if (rc != 0) {
 			kmip_debug(debug, "kmip_decode_xml failed");
 			goto out;

--- a/usr/sbin/p11kmip/kmipclient/json.c
+++ b/usr/sbin/p11kmip/kmipclient/json.c
@@ -30,12 +30,16 @@
  * @param parent            the parent node or NULL if no parent exists.
  * @param node              On return: the decoded node. The newly allocated
  *                          node has a reference count of 1.
+ * @param max_nesting_level the maximum nesting levels of structures within the
+ *                          KMIP node. If the nesting level is reached, E2BIG
+ *                          is returned.
  * @param debug             if true, debug messages are printed
  *
  * @returns 0 in case of success, or a negative errno value
  */
 int kmip_decode_json(const json_object *obj, struct kmip_node *parent,
-		     struct kmip_node **node, bool debug)
+		     struct kmip_node **node, size_t max_nesting_level,
+		     bool debug)
 {
 	json_object *tag_obj, *type_obj, *value_obj, *name_obj;
 	enum kmip_tag tag, v1_attr_tag = 0;
@@ -44,6 +48,9 @@ int kmip_decode_json(const json_object *obj, struct kmip_node *parent,
 	const char *str;
 	int rc, num, i;
 	int64_t int64;
+
+	if (max_nesting_level == 0)
+		return -E2BIG;
 
 	if (obj == NULL || node == NULL)
 		return -EINVAL;
@@ -141,7 +148,7 @@ int kmip_decode_json(const json_object *obj, struct kmip_node *parent,
 			for (i = 0; i < num; i++) {
 				rc = kmip_decode_json(
 					json_object_array_get_idx(value_obj, i),
-					n, &e, debug);
+					n, &e, max_nesting_level - 1, debug);
 				if (rc != 0) {
 					kmip_debug(debug, "Failed to parse "
 						   "array element %d", i);

--- a/usr/sbin/p11kmip/kmipclient/json.c
+++ b/usr/sbin/p11kmip/kmipclient/json.c
@@ -92,7 +92,7 @@ int kmip_decode_json(const json_object *obj, struct kmip_node *parent,
 			rc = -EBADMSG;
 			goto out;
 		}
-		n->name = strdup(json_object_get_string(tag_obj));
+		n->name = strdup(json_object_get_string(name_obj));
 	}
 
 	type_obj = json_object_object_get(obj, KMIP_JSON_TYPE);

--- a/usr/sbin/p11kmip/kmipclient/json.c
+++ b/usr/sbin/p11kmip/kmipclient/json.c
@@ -624,6 +624,10 @@ int kmip_encode_json(const struct kmip_node *node, json_object **obj,
 
 	case KMIP_TYPE_DATE_TIME:
 		tm = gmtime((time_t *)&node->date_time_value);
+		if (tm == NULL) {
+			rc = -EINVAL;
+			goto out;
+		}
 		strftime(outstr, sizeof(outstr), KMIP_ISO8601_TIMESTAMP_UTC,
 			 tm);
 		memb_obj = json_object_new_string(outstr);

--- a/usr/sbin/p11kmip/kmipclient/key.c
+++ b/usr/sbin/p11kmip/kmipclient/key.c
@@ -426,8 +426,14 @@ int kmip_get_key_value(const struct kmip_node *node,
 	/* Must be a KMIP v1.x attribute then */
 	kmip_node_free(attr);
 
-	if (num_attrs != NULL)
-		*num_attrs = kmip_node_get_structure_element_count(node) - 1;
+	if (num_attrs != NULL) {
+		*num_attrs = kmip_node_get_structure_element_count(node);
+		if (*num_attrs == 0) {
+			rc = -EBADMSG;
+			goto error;
+		}
+		(*num_attrs)--;
+	}
 
 	if (v2_attr == NULL)
 		return 0;

--- a/usr/sbin/p11kmip/kmipclient/kmip.c
+++ b/usr/sbin/p11kmip/kmipclient/kmip.c
@@ -257,7 +257,7 @@ int kmip_node_add_structure_elements(struct kmip_node *node,
  *
  * @param node              the KMIP node
  *
- * @returns the number of elements, or -1 if  the node is not of type structure
+ * @returns the number of elements, or 0 if  the node is not of type structure
  */
 unsigned int kmip_node_get_structure_element_count(const struct kmip_node *node)
 {
@@ -265,10 +265,10 @@ unsigned int kmip_node_get_structure_element_count(const struct kmip_node *node)
 	unsigned int i;
 
 	if (node == NULL)
-		return -1;
+		return 0;
 
 	if (node->type != KMIP_TYPE_STRUCTURE)
-		return -1;
+		return 0;
 
 	element = node->structure_value;
 	for (i = 0; element != NULL; i++)
@@ -318,7 +318,7 @@ struct kmip_node *kmip_node_get_structure_element_by_index(
  * @param node              the KMIP node
  * @param tag               the tag to find
  *
- * @returns the number of elements, or -1 if  the node is not of type structure
+ * @returns the number of elements, or 0 if  the node is not of type structure
  */
 unsigned int kmip_node_get_structure_element_by_tag_count(
 					const struct kmip_node *node,
@@ -328,10 +328,10 @@ unsigned int kmip_node_get_structure_element_by_tag_count(
 	unsigned int i;
 
 	if (node == NULL)
-		return -1;
+		return 0;
 
 	if (node->type != KMIP_TYPE_STRUCTURE)
-		return -1;
+		return 0;
 
 	element = node->structure_value;
 	for (i = 0; element != NULL; element = element->next) {

--- a/usr/sbin/p11kmip/kmipclient/kmip.c
+++ b/usr/sbin/p11kmip/kmipclient/kmip.c
@@ -1513,7 +1513,7 @@ retry:
 		}
 
 		if (i == 0 && server_cert_pem != NULL) {
-			fp = fopen(server_cert_pem, "w");
+			fp = fopen_nofollow(server_cert_pem, "w");
 			if (fp == NULL) {
 				rc = -errno;
 				kmip_debug(debug, "Failed to open %s for write",
@@ -1531,7 +1531,7 @@ retry:
 			fp = NULL;
 
 			if (server_pubkey_pem != NULL) {
-				fp = fopen(server_pubkey_pem, "w");
+				fp = fopen_nofollow(server_pubkey_pem, "w");
 				if (fp == NULL) {
 					rc = -errno;
 					kmip_debug(debug, "Failed to open %s "
@@ -1557,7 +1557,7 @@ retry:
 
 		if (i > 0 && cert_chain_pem != NULL) {
 			if (fp == NULL)
-				fp = fopen(cert_chain_pem, "w");
+				fp = fopen_nofollow(cert_chain_pem, "w");
 			if (fp == NULL) {
 				rc = -errno;
 				kmip_debug(debug, "Failed to open %s for write",

--- a/usr/sbin/p11kmip/kmipclient/kmip.c
+++ b/usr/sbin/p11kmip/kmipclient/kmip.c
@@ -896,7 +896,7 @@ struct kmip_node *kmip_node_clone(const struct kmip_node *node)
 	case KMIP_TYPE_TEXT_STRING:
 		if (node->text_value != NULL) {
 			clone->text_value = strdup(node->text_value);
-			if (node->text_value == NULL)
+			if (clone->text_value == NULL)
 				goto error;
 			clone->length = strlen(clone->text_value);
 		}

--- a/usr/sbin/p11kmip/kmipclient/kmip.h
+++ b/usr/sbin/p11kmip/kmipclient/kmip.h
@@ -125,23 +125,27 @@ int kmip_connection_https_perform(struct kmip_connection *connection,
 void kmip_connection_https_term(struct kmip_connection *connection);
 #endif
 
-/* KIMP decoding and encoding internal functions */
+/* KIMP decoding and encoding internal functions and definitions */
+#define KMIP_DECODE_MAX_NESTING_LEVEL	32
+
 int kmip_decode_ttlv(BIO *bio, size_t *size, struct kmip_node **node,
-		     bool debug);
+		     size_t max_nesting_level, bool debug);
 int kmip_encode_ttlv(struct kmip_node *node, BIO *bio, size_t *size,
 		     bool debug);
 
 #ifdef HAVE_LIBCURL
 #ifdef HAVE_LIBJSONC
 int kmip_decode_json(const json_object *obj, struct kmip_node *parent,
-		     struct kmip_node **node, bool debug);
+		     struct kmip_node **node, size_t max_nesting_level,
+		     bool debug);
 int kmip_encode_json(const struct kmip_node *node, json_object **obj,
 		     bool debug);
 #endif
 
 #ifdef HAVE_LIBXML2
 int kmip_decode_xml(const xmlNode *xml, struct kmip_node *parent,
-		    struct kmip_node **node, bool debug);
+		    struct kmip_node **node, size_t max_nesting_level,
+		    bool debug);
 int kmip_encode_xml(const struct kmip_node *node, xmlNode **xml, bool debug);
 #endif
 #endif

--- a/usr/sbin/p11kmip/kmipclient/response.c
+++ b/usr/sbin/p11kmip/kmipclient/response.c
@@ -686,14 +686,20 @@ int kmip_get_get_attribute_list_response_payload(const struct kmip_node *node,
 
 	if (kmip_node_get_tag(node) != KMIP_TAG_RESPONSE_PAYLOAD)
 		return -EBADMSG;
+	if (kmip_node_get_type(node) != KMIP_TYPE_STRUCTURE)
+		return -EBADMSG;
 
 	if (unique_id != NULL)
 		*unique_id = kmip_node_get_structure_element_by_tag(node,
 						KMIP_TAG_UNIQUE_IDENTIFIER, 0);
 
-	if (num_attr_refs != NULL)
+	if (num_attr_refs != NULL) {
 		*num_attr_refs =
-			kmip_node_get_structure_element_count(node) - 1;
+			kmip_node_get_structure_element_count(node);
+		if (*num_attr_refs == 0)
+			return -EBADMSG;
+		(*num_attr_refs)--;
+	}
 
 	if (attr_ref == NULL)
 		return 0;
@@ -766,6 +772,8 @@ int kmip_get_get_attributes_response_payload(const struct kmip_node *node,
 
 	if (kmip_node_get_tag(node) != KMIP_TAG_RESPONSE_PAYLOAD)
 		return -EBADMSG;
+	if (kmip_node_get_type(node) != KMIP_TYPE_STRUCTURE)
+		return -EBADMSG;
 
 	if (unique_id != NULL)
 		*unique_id = kmip_node_get_structure_element_by_tag(node,
@@ -798,8 +806,12 @@ int kmip_get_get_attributes_response_payload(const struct kmip_node *node,
 	/* Must be a KMIP v1.x attribute then */
 	kmip_node_free(attr);
 
-	if (num_attrs != NULL)
-		*num_attrs = kmip_node_get_structure_element_count(node) - 1;
+	if (num_attrs != NULL) {
+		*num_attrs = kmip_node_get_structure_element_count(node);
+		if (*num_attrs == 0)
+			return -EBADMSG;
+		(*num_attrs)--;
+	}
 
 	if (v2_attr == NULL)
 		return 0;

--- a/usr/sbin/p11kmip/kmipclient/tls.c
+++ b/usr/sbin/p11kmip/kmipclient/tls.c
@@ -494,7 +494,8 @@ int kmip_connection_tls_perform(struct kmip_connection *conn,
 	kmip_debug(debug, "%lu bytes sent", size);
 
 	/* receive the response */
-	rc = kmip_decode_ttlv(conn->plain_tls.bio, NULL, response, debug);
+	rc = kmip_decode_ttlv(conn->plain_tls.bio, NULL, response,
+			      KMIP_DECODE_MAX_NESTING_LEVEL, debug);
 	if (rc != 0 || *response == NULL) {
 		kmip_debug(debug, "kmip_decode_ttlv failed");
 		goto out;

--- a/usr/sbin/p11kmip/kmipclient/ttlv.c
+++ b/usr/sbin/p11kmip/kmipclient/ttlv.c
@@ -28,12 +28,15 @@
  *                          as many bytes as needed.
  * @param node              On return: the decoded node. The newly allocated
  *                          node has a reference count of 1.
+ * @param max_nesting_level the maximum nesting levels of structures within the
+ *                          KMIP node. If the nesting level is reached, E2BIG
+ *                          is returned.
  * @param debug             if true, debug messages are printed
  *
  * @returns 0 in case of success, or a negative errno value
  */
 int kmip_decode_ttlv(BIO *bio, size_t *size, struct kmip_node **node,
-		     bool debug)
+		     size_t max_nesting_level, bool debug)
 {
 	unsigned char padding[KMIP_TTLV_BLOCK_LENGTH];
 	unsigned char ttlv[KMIP_TTLV_HEADER_LENGTH];
@@ -43,6 +46,9 @@ int kmip_decode_ttlv(BIO *bio, size_t *size, struct kmip_node **node,
 	uint32_t int32;
 	uint64_t int64;
 	int rc;
+
+	if (max_nesting_level == 0)
+		return -E2BIG;
 
 	if (bio == NULL || node == NULL)
 		return -EINVAL;
@@ -167,7 +173,8 @@ int kmip_decode_ttlv(BIO *bio, size_t *size, struct kmip_node **node,
 	switch (n->type) {
 	case KMIP_TYPE_STRUCTURE:
 		while (value_len > 0) {
-			rc = kmip_decode_ttlv(bio, &value_len, &e, debug);
+			rc = kmip_decode_ttlv(bio, &value_len, &e,
+					      max_nesting_level - 1, debug);
 			if (rc != 0) {
 				kmip_debug(debug, "kmip_decode_ttlv failed: "
 					   "rc: %d", rc);

--- a/usr/sbin/p11kmip/kmipclient/ttlv.c
+++ b/usr/sbin/p11kmip/kmipclient/ttlv.c
@@ -166,8 +166,15 @@ int kmip_decode_ttlv(BIO *bio, size_t *size, struct kmip_node **node,
 			rc = -EIO;
 			goto out;
 		}
-		if (size != NULL)
+
+		if (size != NULL) {
+			if (*size < pad_len) {
+				rc = -EMSGSIZE;
+				goto out;
+			}
+
 			*size -= pad_len;
+		}
 	}
 
 	switch (n->type) {

--- a/usr/sbin/p11kmip/kmipclient/ttlv.c
+++ b/usr/sbin/p11kmip/kmipclient/ttlv.c
@@ -104,6 +104,11 @@ int kmip_decode_ttlv(BIO *bio, size_t *size, struct kmip_node **node,
 	case KMIP_TYPE_TEXT_STRING:
 	case KMIP_TYPE_BYTE_STRING:
 		value_len = n->length;
+		if (value_len > INT_MAX) {
+			rc = -EMSGSIZE;
+			goto out;
+		}
+
 		value = calloc(1, value_len + 1);
 		if (value == NULL) {
 			kmip_debug(debug, "calloc failed");

--- a/usr/sbin/p11kmip/kmipclient/ttlv.c
+++ b/usr/sbin/p11kmip/kmipclient/ttlv.c
@@ -79,18 +79,18 @@ int kmip_decode_ttlv(BIO *bio, size_t *size, struct kmip_node **node,
 	n->ref_count = 1;
 
 	/* Tag: 3-byte binary unsigned integer, transmitted big endian */
-	n->tag |= (uint32_t)(ttlv[0] << 16);
-	n->tag |= (uint32_t)(ttlv[1] << 8);
-	n->tag |= (uint32_t)(ttlv[2]);
+	n->tag |= (uint32_t)ttlv[0] << 16;
+	n->tag |= (uint32_t)ttlv[1] << 8;
+	n->tag |= (uint32_t)ttlv[2];
 
 	/* Type: 1 byte containing a coded value that indicates the data type */
 	n->type = ttlv[3];
 
 	/* Length: 32-bit binary integer, transmitted big-endian */
-	n->length |= (uint32_t)(ttlv[4] << 24);
-	n->length |= (uint32_t)(ttlv[5] << 16);
-	n->length |= (uint32_t)(ttlv[6] << 8);
-	n->length |= (uint32_t)(ttlv[7]);
+	n->length |= (uint32_t)ttlv[4] << 24;
+	n->length |= (uint32_t)ttlv[5] << 16;
+	n->length |= (uint32_t)ttlv[6] << 8;
+	n->length |= (uint32_t)ttlv[7];
 
 	kmip_debug(debug, "tag: 0x%x type: 0x%x, length: %u", n->tag, n->type,
 		   n->length);

--- a/usr/sbin/p11kmip/kmipclient/ttlv.c
+++ b/usr/sbin/p11kmip/kmipclient/ttlv.c
@@ -282,7 +282,7 @@ out:
 static int kmip_node_get_length(struct kmip_node *node, size_t *length)
 {
 	struct kmip_node *element;
-	size_t len;
+	size_t len, prev_len;
 	int rc;
 
 	if (node == NULL || length == NULL)
@@ -297,10 +297,13 @@ static int kmip_node_get_length(struct kmip_node *node, size_t *length)
 			if (rc != 0)
 				return rc;
 
+			prev_len = *length;
 			*length += KMIP_TTLV_HEADER_LENGTH + len;
 			if ((len % KMIP_TTLV_BLOCK_LENGTH) != 0)
 				*length += KMIP_TTLV_BLOCK_LENGTH -
 						(len % KMIP_TTLV_BLOCK_LENGTH);
+			if (*length < prev_len)
+				return -EOVERFLOW;
 
 			element = element->next;
 		}

--- a/usr/sbin/p11kmip/kmipclient/utils.c
+++ b/usr/sbin/p11kmip/kmipclient/utils.c
@@ -74,6 +74,8 @@ int kmip_parse_decimal_uint(const char *str, uint64_t *val)
 
 	if (str == NULL)
 		return -EINVAL;
+	if (str[0] == '-')
+		return -EBADMSG;
 
 	errno = 0;
 	v = strtoull(str, &endptr, 10);

--- a/usr/sbin/p11kmip/kmipclient/utils.c
+++ b/usr/sbin/p11kmip/kmipclient/utils.c
@@ -166,12 +166,15 @@ int kmip_parse_hex(const char *str, bool has_prefix, unsigned char **val,
  * Format a hex string from the byte array specified in val. The caller must
  * free the returned str.
  */
-int kmip_format_hex(const unsigned char *val, uint32_t length, bool prefix,
+int kmip_format_hex(const unsigned char *val, size_t length, bool prefix,
 		    char **str)
 {
-	uint32_t str_len, i;
+	size_t str_len, i;
 	char tmp[4];
 	char *ret;
+
+	if (length > (SIZE_MAX - ((prefix ? 2 : 0) + 1)) / 2)
+		return -EINVAL;
 
 	str_len = length * 2 + (prefix ? 2 : 0) + 1;
 	ret = calloc(1, str_len);

--- a/usr/sbin/p11kmip/kmipclient/utils.c
+++ b/usr/sbin/p11kmip/kmipclient/utils.c
@@ -225,14 +225,18 @@ int kmip_parse_bignum(const char *str, bool has_prefix, BIGNUM **bn)
 int kmip_format_bignum(const BIGNUM *bn, bool prefix, char **str)
 {
 	unsigned char *buf;
-	uint32_t len;
+	uint32_t len, prev_len;
 	int rc;
 
 	len = kmip_encode_bignum_length(bn);
 	/* BIG INTEGERS must be a multiple of 8 bytes long */
-	if ((len % KMIP_BIG_INTEGER_BLOCK_LENGTH) != 0)
+	if ((len % KMIP_BIG_INTEGER_BLOCK_LENGTH) != 0) {
+		prev_len = len;
 		len += KMIP_BIG_INTEGER_BLOCK_LENGTH -
 				(len % KMIP_BIG_INTEGER_BLOCK_LENGTH);
+		if (len < prev_len)
+			return -EOVERFLOW;
+	}
 
 	buf = malloc(len);
 	if (buf == NULL)
@@ -409,10 +413,10 @@ int kmip_parse_mask(enum kmip_tag tag, const char *str, char separator,
 	return rc;
 }
 
-static int kmip_append_string(char **str, int *str_len, char separator,
+static int kmip_append_string(char **str, size_t *str_len, char separator,
 			      const char *append)
 {
-	int new_len;
+	size_t new_len;
 	char *tmp;
 
 	if (str == NULL || str_len == NULL)
@@ -428,6 +432,9 @@ static int kmip_append_string(char **str, int *str_len, char separator,
 		new_len++;
 	if (append != NULL)
 		new_len += strlen(append);
+
+	if (new_len < *str_len)
+		return -EOVERFLOW;
 
 	tmp = realloc(*str, new_len);
 	if (tmp == NULL)
@@ -453,8 +460,9 @@ int kmip_format_mask(enum kmip_tag tag, int32_t value, char separator,
 		     char **str)
 {
 	const struct kmip_enum *info;
-	int rc = 0, i, s_len = 0;
 	char *s = NULL, *tmp;
+	size_t s_len = 0;
+	int rc = 0, i;
 
 	info = kmip_enum_info_by_tag(tag);
 	if (info == NULL || value == 0)

--- a/usr/sbin/p11kmip/kmipclient/utils.c
+++ b/usr/sbin/p11kmip/kmipclient/utils.c
@@ -11,9 +11,11 @@
 #define _DEFAULT_SOURCE
 
 #include <errno.h>
+#include <fcntl.h>
 #include <stdarg.h>
 #include <string.h>
 #include <strings.h>
+#include <unistd.h>
 #include <sys/time.h>
 
 #include "utils.h"
@@ -728,3 +730,34 @@ enum kmip_tag kmip_find_v1_attribute_name_tag(struct kmip_node *parent)
 	return 0;
 }
 
+#if 0 /* Use fopen_nofollow from platform.h */
+FILE *fopen_nofollow(const char *path, const char *mode)
+{
+	int flags = O_NOFOLLOW;
+	int fd;
+	FILE *fp;
+
+	/* Determine flags based on mode */
+	if (mode[0] == 'r')
+		flags |= (mode[1] == '+') ? O_RDWR : O_RDONLY;
+	else if (mode[0] == 'w')
+		flags |= O_CREAT | O_TRUNC |
+				((mode[1] == '+') ? O_RDWR : O_WRONLY);
+	else if (mode[0] == 'a')
+		flags |= O_CREAT | O_APPEND |
+				((mode[1] == '+') ? O_RDWR : O_WRONLY);
+	else
+		return NULL;
+
+	fd = open(path, flags, 0600);
+	if (fd < 0)
+		return NULL;
+
+	fp = fdopen(fd, mode);
+	if (fp == NULL) {
+		close(fd);
+		return NULL;
+	}
+	return fp;
+}
+#endif

--- a/usr/sbin/p11kmip/kmipclient/utils.h
+++ b/usr/sbin/p11kmip/kmipclient/utils.h
@@ -39,7 +39,7 @@ int kmip_parse_decimal_uint(const char *str, uint64_t *val);
 int kmip_parse_hex_int(const char *str, int64_t *val);
 int kmip_parse_hex(const char *str, bool has_prefix, unsigned char **val,
 		   uint32_t *length);
-int kmip_format_hex(const unsigned char *val, uint32_t length, bool prefix,
+int kmip_format_hex(const unsigned char *val, size_t length, bool prefix,
 		    char **str);
 
 int kmip_parse_bignum(const char *str, bool has_prefix, BIGNUM **bn);

--- a/usr/sbin/p11kmip/kmipclient/utils.h
+++ b/usr/sbin/p11kmip/kmipclient/utils.h
@@ -59,4 +59,8 @@ void kmip_node_dump(struct kmip_node *node, bool debug);
 
 enum kmip_tag kmip_find_v1_attribute_name_tag(struct kmip_node *parent);
 
+#if 0 /* Use fopen_nofollow from platform.h */
+FILE *fopen_nofollow(const char *path, const char *mode);
+#endif
+
 #endif

--- a/usr/sbin/p11kmip/kmipclient/xml.c
+++ b/usr/sbin/p11kmip/kmipclient/xml.c
@@ -463,6 +463,10 @@ int kmip_encode_xml(const struct kmip_node *node, xmlNode **xml, bool debug)
 
 	case KMIP_TYPE_DATE_TIME:
 		tm = gmtime((time_t *)&node->date_time_value);
+		if (tm == NULL) {
+			rc = -EINVAL;
+			goto out;
+		}
 		strftime(tmp_str, sizeof(tmp_str), KMIP_ISO8601_TIMESTAMP_UTC,
 			 tm);
 		attr = xmlSetProp(ret_xml, (xmlChar *)KMIP_XML_VALUE,

--- a/usr/sbin/p11kmip/kmipclient/xml.c
+++ b/usr/sbin/p11kmip/kmipclient/xml.c
@@ -31,12 +31,16 @@
  * @param parent            the parent node or NULL if no parent exists.
  * @param node              On return: the decoded node.The newly allocated
  *                          node has a reference count of 1.
+ * @param max_nesting_level the maximum nesting levels of structures within the
+ *                          KMIP node. If the nesting level is reached, E2BIG
+ *                          is returned.
  * @param debug             if true, debug messages are printed
  *
  * @returns 0 in case of success, or a negative errno value
  */
 int kmip_decode_xml(const xmlNode *xml, struct kmip_node *parent,
-		    struct kmip_node **node, bool debug)
+		    struct kmip_node **node, size_t max_nesting_level,
+		    bool debug)
 {
 	char *tag_attr = NULL, *name_attr = NULL, *type_attr = NULL;
 	enum kmip_tag tag, v1_attr_tag = 0;
@@ -46,6 +50,9 @@ int kmip_decode_xml(const xmlNode *xml, struct kmip_node *parent,
 	xmlNode *child;
 	int64_t int64;
 	int rc = 0, i;
+
+	if (max_nesting_level == 0)
+		return -E2BIG;
 
 	if (xml == NULL || node == NULL)
 		return -EINVAL;
@@ -125,7 +132,8 @@ int kmip_decode_xml(const xmlNode *xml, struct kmip_node *parent,
 			if (child->type != XML_ELEMENT_NODE)
 				continue;
 
-			rc = kmip_decode_xml(child, n, &e, debug);
+			rc = kmip_decode_xml(child, n, &e,
+					     max_nesting_level - 1, debug);
 			if (rc != 0) {
 				kmip_debug(debug, "Failed to parse child "
 					   "element %d", i);


### PR DESCRIPTION
Replicate the fixes for the kmipclient library also provided in the s390-tools project (https://github.com/ibm-s390-linux/s390-tools) to Opencryptoki.'s p11kmip tool. The code is intentionally kept almost the same as in s390-tools, except for a few #ifdefs to account for the different environment.