### PR TITLE
MAKEFILE: Fix ci-installcheck

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -280,7 +280,7 @@ installcheck-local: all check
 	if test ! -z ${PKCS11_TEST_USER}; then				\
 		chmod 777 ${srcdir}/testcases &&			\
 		cd ${srcdir}/testcases &&                               \
-		su ${PKCS11_TEST_USER} -s /bin/bash -c "PKCS11_SO_PIN=$(PKCS11_SO_PIN) PKCS11_USER_PIN=$(PKCS11_USER_PIN) PKCSLIB=$(PKCSLIB) /bin/bash ./ock_tests.sh || true"; \
+		su -s /bin/bash -c "PKCS11_SO_PIN=$(PKCS11_SO_PIN) PKCS11_USER_PIN=$(PKCS11_USER_PIN) PKCSLIB=$(PKCSLIB) /bin/bash ./ock_tests.sh || true" ${PKCS11_TEST_USER}; \
 	else								\
 		cd ${srcdir}/testcases && 				\
 		PKCS11_SO_PIN=$(PKCS11_SO_PIN) PKCS11_USER_PIN=$(PKCS11_USER_PIN) PKCSLIB=$(PKCSLIB) ./ock_tests.sh || true; \


### PR DESCRIPTION
Use 'su ...' without '-s' option. For whatever reason the '-s' option to specify the shell to use causes the testcases to not run at all.

It runs '/bin/bash ./ock_tests.sh' anyway, so the shell also being '/bin/bash' or whatever is irrelevant.