### PR TITLE
Fix typos and errors in README.md and p11sak man page

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ directory and do the following:
 
    If you're planning to install the package into your home directory or to a
    location other than `/usr/local` then add the flag `--prefix=PATH` to
-   `configure`. Fox example, if your home directory is `/home/luser` you can
+   `configure`. For example, if your home directory is `/home/luser` you can
    configure the package to install itself there by invoking:
 
    ```bash
@@ -120,7 +120,7 @@ directory and do the following:
    invocation. For instance,
 
    ```bash
-   $ CPPFLAGS="-L/path/lib" LDFLAGS="-I/path/include" ./configure
+   $ CPPFLAGS="-I/path/include" LDFLAGS="-L/path/lib" ./configure
    ```
 
    See `./configure --help` for info on various options. The default behavior is
@@ -131,12 +131,12 @@ directory and do the following:
    option, provided the appropriate libraries are available and the token is
    supported on the platform you are compiling.
 
-   While running, `configure` prints some messages telling which features is it
+   While running, `configure` prints some messages telling which features it is
    checking for.
 
-   **Note**: On AIX, if you wish to run `make distcheck`, the environment variable
-   `DISTCHECK_CONFIGURE_FLAGS` to include the appropriate values for
-   `CFLAGS` and `CXXFLAGS`
+   **Note**: On AIX, if you wish to run `make distcheck`, set the environment
+   variable `DISTCHECK_CONFIGURE_FLAGS` to include the appropriate values for
+   `CFLAGS` and `CXXFLAGS`.
 
 3. Compile the package by typing:
 
@@ -282,7 +282,7 @@ directories:
    By prepending your home directory to the rest of the PATH you can override
    systemwide installed software with your own custom installation.
 
-For more installation information, please check [INSTALL](INSTALL).
+   For more installation information, please check [INSTALL](INSTALL).
 
 ## CONFIGURATION
 

--- a/man/man1/p11sak.1.in
+++ b/man/man1/p11sak.1.in
@@ -245,7 +245,7 @@ Use the
 .B 128|192|256
 command and
 .I KEYTYPE
-argument to generate a AES key (\fBCKK_AES\fP) with 128-, 192-, or 256-bit
+argument to generate an AES key (\fBCKK_AES\fP) with 128-, 192-, or 256-bit
 length, respectively. The
 .BR \-\-label | \-L
 .I LABEL
@@ -290,7 +290,7 @@ Use the
 .B 128|256
 command and
 .I KEYTYPE
-argument to generate a AES\-XTS key (\fBCKK_AES_XTS\fP) with 128- or 256-bit
+argument to generate an AES\-XTS key (\fBCKK_AES_XTS\fP) with 128- or 256-bit
 length, respectively. The
 .BR \-\-label | \-L
 .I LABEL
@@ -587,7 +587,7 @@ command and
 .I KEYTYPE
 argument to generate an EC\-Edwards key (\fBCKK_EC_EDWARDS\fP), where
 .I CURVE
-specifies the edwards curve used to create the EC-Edwards key. The following
+specifies the Edwards curve used to create the EC\-Edwards key. The following
 arguments can be used for respective curves:
 .BR ed25519 |\: ed448 .
 .PP
@@ -645,7 +645,7 @@ command and
 .I KEYTYPE
 argument to generate an EC\-Montgomery key (\fBCKK_EC_MONTGOMERY\fP), where
 .I CURVE
-specifies the montgomery curve used to create the EC\-Montgomery key. The
+specifies the Montgomery curve used to create the EC\-Montgomery key. The
 following arguments can be used for respective curves:
 .BR curve25519 |\: curve448 .
 .PP
@@ -1285,7 +1285,7 @@ prompt, use the
 option.
 .PP
 .
-.SS "Coyping symmetric and asymmetric keys"
+.SS "Copying symmetric and asymmetric keys"
 .
 .B p11sak
 .BR copy\-key | copy | cp
@@ -2447,7 +2447,7 @@ the prompt, use the
 option.
 .PP
 .
-.SS "Coyping certificates"
+.SS "Copying certificates"
 .
 .B p11sak
 .BR copy\-cert | copyc | cpc
@@ -2855,12 +2855,12 @@ Specifies the public exponent for an RSA key. If not specified, the default is
 .
 .SS "PRIV\-BITS"
 .
-Specifies the size of the private key in bits for an DH key.
+Specifies the size of the private key in bits for a DH key.
 .PP
 .
 .SS "GROUP"
 .
-Specifies the Diffie\-Hellman FFC group name for an DH key. Possible values are
+Specifies the Diffie\-Hellman FFC group name for a DH key. Possible values are
 .BR ffdhe2048 |\: ffdhe3072 |\: ffdhe4096 |\: ffdhe6144 |\: ffdhe8192 |\: \
 modp1536 |\: modp2048 |\: modp3072 |\: modp4096 |\: modp6144 |\: modp8192 .
 .PP
@@ -3386,9 +3386,8 @@ matching the specified \fIKEYTYPE\fP, label, and ID filter (if specified).
 For the
 .B wrap\-key
 command and the
-command, and the
 .B unwrap\-key
-command, also supress the prompt for a confirmation to use a key as KEK.
+command, also suppress the prompt for a confirmation to use a key as KEK.
 .RE
 .PP
 .
@@ -3710,7 +3709,7 @@ the default IV as per AESKW\-PKCS7 specification is used.
 .TP 8
 .BR \-\-hash\-alg\~\fIHASH\-ALG\fP
 The message digest algorithm used to calculate the digest of the OAEP encoding
-parameter. The default is to use the samealgorithm as specified with option
+parameter. The default is to use the same algorithm as specified with option
 .BR \-\-mgf\-alg ,
 or SHA256 if neither is specified. Possible algorithms are:
 .BR SHA\-1 |\: SHA224 |\: SHA256 |\: SHA384 |\: SHA512 |\: SHA3\-224 |\: \
@@ -3751,7 +3750,7 @@ key sizes are:
 .TP 8
 .BR \-\-hash\-alg\~\fIHASH\-ALG\fP
 The message digest algorithm used to calculate the digest of the OAEP encoding
-parameter. The default is to use the samealgorithm as specified with option
+parameter. The default is to use the same algorithm as specified with option
 .BR \-\-mgf\-alg ,
 or SHA256 if neither is specified. Possible algorithms are:
 .BR SHA\-1 |\: SHA224 |\: SHA256 |\: SHA384 |\: SHA512 |\: SHA3\-224 |\: \


### PR DESCRIPTION
README.md:
  - Fix "Fox example" typo (should be "For example")
  - Swap CPPFLAGS/LDFLAGS values in configure example (-I for CPPFLAGS, -L for LDFLAGS)
  - Fix word order "which features is it" to "which features it is"
  - Add missing verb "set" in DISTCHECK_CONFIGURE_FLAGS note and add closing period
  - Restore indentation of "For more installation information" line

man/man1/p11sak.1.in:
  - Fix "a AES" and "a AES-XTS" to "an AES" and "an AES-XTS"
  - Capitalize proper nouns "edwards" and "montgomery" in curve descriptions
  - Fix "Coyping" typo to "Copying" in two section headings
  - Remove stray "command, and the" and fix "supress" to "suppress" in --force|-f option description
  - Fix missing space in "samealgorithm" (two occurrences)