### PR TITLE
MAN: Fix man page variable substitution

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -834,32 +834,9 @@ AC_LANG_POP([C++])
 
 AC_CONFIG_MACRO_DIRS([m4])
 
-AM_COND_IF([ENABLE_PKCSHSM_MK_CHANGE],
-           [AC_CONFIG_FILES([man/man1/pkcshsm_mk_change.1])])
-AM_COND_IF([ENABLE_PKCSSTATS],
-           [AC_CONFIG_FILES([man/man1/pkcsstats.1])])
-AM_COND_IF([ENABLE_P11SAK],
-           [AC_CONFIG_FILES([man/man1/p11sak.1])])
-AM_COND_IF([ENABLE_P11KMIP],
-           [AC_CONFIG_FILES([man/man1/p11kmip.1])])
-AM_COND_IF([ENABLE_PKCSEP11_MIGRATE],
-           [AC_CONFIG_FILES([man/man1/pkcsep11_migrate.1])])
-AM_COND_IF([ENABLE_PKCSEP11_SESSION],
-           [AC_CONFIG_FILES([man/man1/pkcsep11_session.1])])
-AM_COND_IF([ENABLE_PKCSTOK_MIGRATE],
-           [AC_CONFIG_FILES([man/man1/pkcstok_migrate.1])])
-
 AC_CONFIG_FILES([Makefile				\
 		 misc/opencryptoki.pc			\
-		 usr/lib/api/shrd_mem.c			\
-		 man/man1/pkcsconf.1			\
-		 man/man5/opencryptoki.conf.5		\
-		 man/man5/p11sak_defined_attrs.conf.5	\
-		 man/man5/strength.conf.5		\
-		 man/man5/policy.conf.5			\
-		 man/man5/p11kmip.conf.5        \
-		 man/man7/opencryptoki.7		\
-		 man/man8/pkcsslotd.8])
+		 usr/lib/api/shrd_mem.c])
 
 AC_OUTPUT
 

--- a/man/man.mk
+++ b/man/man.mk
@@ -1,3 +1,11 @@
+MAN_SUBST = $(AM_V_GEN)@SED@ \
+	-e s!\@sysconfdir\@!"$(sysconfdir)"!g \
+	-e s!\@localstatedir\@!"$(localstatedir)"!g \
+	-e s!\@sbindir\@!"$(sbindir)"!g \
+	-e s!\@pkcs_group\@!"$(pkcs_group)"!g \
+	-e s!\@pkcsslotd_user\@!"$(pkcsslotd_user)"!g \
+	-e s!\@PACKAGE_VERSION\@!"$(PACKAGE_VERSION)"!g
+
 include man/man1/man1.mk
 include man/man5/man5.mk
 include man/man7/man7.mk

--- a/man/man1/man1.mk
+++ b/man/man1/man1.mk
@@ -2,12 +2,6 @@ man1_MANS += man/man1/pkcsconf.1
 
 if ENABLE_ICSFTOK
 man1_MANS += man/man1/pkcsicsf.1
-
-man/man1/pkcsicsf.1: man/man1/pkcsicsf.1.in
-	$(AM_V_GEN)@SED@ -e s!\@sysconfdir\@!"$(sysconfdir)"!g		\
-			 -e s!\@localstatedir\@!"$(localstatedir)"!g 	\
-			 < $< > $@-t &&					\
-	$(am__mv) $@-t $@
 endif
 
 if ENABLE_PKCSHSM_MK_CHANGE
@@ -33,12 +27,6 @@ endif
 if ENABLE_CCATOK
 if ENABLE_PKCSCCA
 man1_MANS += man/man1/pkcscca.1
-
-man/man1/pkcscca.1: man/man1/pkcscca.1.in
-	$(AM_V_GEN)@SED@ -e s!\@sysconfdir\@!"$(sysconfdir)"!g		\
-			 -e s!\@localstatedir\@!"$(localstatedir)"!g	\
-			 < $< > $@-t &&					\
-	$(am__mv) $@-t $@
 endif
 endif
 
@@ -52,14 +40,21 @@ endif
 
 if ENABLE_PKCSTOK_ADMIN
 man1_MANS += man/man1/pkcstok_admin.1
-
-man/man1/pkcstok_admin.1: man/man1/pkcstok_admin.1.in
-	$(AM_V_GEN)@SED@ -e s!\@sysconfdir\@!"$(sysconfdir)"!g		\
-			 -e s!\@pkcs_group\@!"$(pkcs_group)"!g		\
-			 -e s!\@localstatedir\@!"$(localstatedir)"!g 	\
-			 < $< > $@-t &&					\
-	$(am__mv) $@-t $@
 endif
 
-EXTRA_DIST += man/man1/pkcstok_admin.1.in man/man1/pkcsicsf.1.in man/man1/pkcscca.1.in
+man/man1/%.1: man/man1/%.1.in
+	@$(MKDIR_P) man/man1
+	$(MAN_SUBST) < $< > $@-t && $(am__mv) $@-t $@
+
+EXTRA_DIST += man/man1/pkcsconf.1.in \
+	      man/man1/pkcsicsf.1.in \
+	      man/man1/pkcshsm_mk_change.1.in \
+	      man/man1/pkcsstats.1.in \
+	      man/man1/pkcstok_migrate.1.in \
+	      man/man1/pkcsep11_migrate.1.in \
+	      man/man1/pkcsep11_session.1.in \
+	      man/man1/pkcscca.1.in \
+	      man/man1/p11sak.1.in \
+	      man/man1/p11kmip.1.in \
+	      man/man1/pkcstok_admin.1.in
 CLEANFILES += man/man1/*.1

--- a/man/man5/man5.mk
+++ b/man/man5/man5.mk
@@ -7,3 +7,14 @@ endif
 if ENABLE_P11KMIP
 man5_MANS += man/man5/p11kmip.conf.5
 endif
+
+man/man5/%.5: man/man5/%.5.in
+	@$(MKDIR_P) man/man5
+	$(MAN_SUBST) < $< > $@-t && $(am__mv) $@-t $@
+
+EXTRA_DIST += man/man5/opencryptoki.conf.5.in \
+	      man/man5/strength.conf.5.in \
+	      man/man5/policy.conf.5.in \
+	      man/man5/p11sak_defined_attrs.conf.5.in \
+	      man/man5/p11kmip.conf.5.in
+CLEANFILES += man/man5/*.5

--- a/man/man7/man7.mk
+++ b/man/man7/man7.mk
@@ -1,1 +1,8 @@
 man7_MANS += man/man7/opencryptoki.7
+
+man/man7/%.7: man/man7/%.7.in
+	@$(MKDIR_P) man/man7
+	$(MAN_SUBST) < $< > $@-t && $(am__mv) $@-t $@
+
+EXTRA_DIST += man/man7/opencryptoki.7.in
+CLEANFILES += man/man7/*.7

--- a/man/man8/man8.mk
+++ b/man/man8/man8.mk
@@ -1,1 +1,8 @@
 man8_MANS += man/man8/pkcsslotd.8
+
+man/man8/%.8: man/man8/%.8.in
+	@$(MKDIR_P) man/man8
+	$(MAN_SUBST) < $< > $@-t && $(am__mv) $@-t $@
+
+EXTRA_DIST += man/man8/pkcsslotd.8.in
+CLEANFILES += man/man8/*.8


### PR DESCRIPTION
Not all variables ('@...@' placeholders) in man pages were correctly substituted by AC_CONFIG_FILES or the existing SED rules.

Introduce a common substitution rule for man pages and process all man pages with it.